### PR TITLE
Solidify connector-hub critical path

### DIFF
--- a/.claude/agents/lib/mermaid_augment.js
+++ b/.claude/agents/lib/mermaid_augment.js
@@ -1,0 +1,399 @@
+import { formatErDiagram, formatGraph, } from "./mermaid_format.js";
+// ── Per-connector transformers ────────────────────────────────────────
+//
+// Each function takes the raw envelope (parsed JSON object, the same shape
+// the connector CLI prints to stdout) and returns a MermaidBlock or
+// undefined. When a connector's action set changes, update the matching
+// transformer here; this is the single site for wiki-side decoration.
+function mermaidForAws(result) {
+    if (result["status"] !== "success")
+        return undefined;
+    const action = result["action"];
+    const data = result["data"];
+    if (data === undefined)
+        return undefined;
+    if (action === "list_functions") {
+        const fns = data["functions"] ?? [];
+        if (fns.length === 0)
+            return undefined;
+        const region = data["region"] || "region";
+        const nodes = [
+            { id: `region_${region}`, label: `Region: ${region}`, shape: "rounded" },
+            ...fns.map((f) => ({
+                id: `fn_${f.name}`,
+                label: `${f.name} (${f.runtime || "unknown"})`,
+            })),
+        ];
+        const edges = fns.map((f) => ({
+            from: `region_${region}`,
+            to: `fn_${f.name}`,
+        }));
+        return formatGraph("TB", `AWS Lambda Functions — ${region}`, nodes, edges);
+    }
+    if (action === "describe_db") {
+        const region = data["region"] || "region";
+        const id = data["db_identifier"] || "db";
+        const engine = data["engine"] || "";
+        const cls = data["instance_class"] || "";
+        const label = engine || cls ? `${id} (${engine}${cls ? `, ${cls}` : ""})` : id;
+        const nodes = [
+            { id: `region_${region}`, label: `Region: ${region}`, shape: "rounded" },
+            { id: `db_${id}`, label, shape: "stadium" },
+        ];
+        const edges = [{ from: `region_${region}`, to: `db_${id}` }];
+        return formatGraph("TB", `AWS RDS — ${id}`, nodes, edges);
+    }
+    if (action === "list_buckets") {
+        const buckets = data["buckets"] ?? [];
+        if (buckets.length === 0)
+            return undefined;
+        const nodes = [
+            { id: "account", label: "AWS Account", shape: "rounded" },
+            ...buckets.map((b) => ({ id: `bucket_${b.name}`, label: b.name })),
+        ];
+        const edges = buckets.map((b) => ({
+            from: "account",
+            to: `bucket_${b.name}`,
+        }));
+        return formatGraph("TB", "AWS S3 Buckets", nodes, edges);
+    }
+    return undefined;
+}
+function mermaidForGcp(result) {
+    if (result["status"] !== "success")
+        return undefined;
+    const action = result["action"];
+    const data = result["data"];
+    if (data === undefined)
+        return undefined;
+    if (action === "list_services") {
+        const services = data["services"] ?? [];
+        if (services.length === 0)
+            return undefined;
+        const project = data["project_id"] || "project";
+        const nodes = [
+            { id: `proj_${project}`, label: `Project: ${project}`, shape: "rounded" },
+            ...services.map((s, i) => ({ id: `svc_${i}`, label: s.title || s.name })),
+        ];
+        const edges = services.map((_, i) => ({
+            from: `proj_${project}`,
+            to: `svc_${i}`,
+        }));
+        return formatGraph("TB", `GCP Services — ${project}`, nodes, edges);
+    }
+    if (action === "describe_db") {
+        const project = data["project_id"] || "project";
+        const instance = data["instance_id"] || "instance";
+        const engine = data["engine"] || "";
+        const version = data["version"] || "";
+        const label = engine || version ? `${instance} (${engine}${version ? ` ${version}` : ""})` : instance;
+        const nodes = [
+            { id: `proj_${project}`, label: `Project: ${project}`, shape: "rounded" },
+            { id: `db_${instance}`, label, shape: "stadium" },
+        ];
+        const edges = [{ from: `proj_${project}`, to: `db_${instance}` }];
+        return formatGraph("TB", `GCP Cloud SQL — ${instance}`, nodes, edges);
+    }
+    if (action === "list_topics") {
+        const topics = data["topics"] ?? [];
+        if (topics.length === 0)
+            return undefined;
+        const project = data["project_id"] || "project";
+        const nodes = [
+            { id: `proj_${project}`, label: `Project: ${project}`, shape: "rounded" },
+            ...topics.map((t, i) => ({ id: `topic_${i}`, label: t })),
+        ];
+        const edges = topics.map((_, i) => ({
+            from: `proj_${project}`,
+            to: `topic_${i}`,
+        }));
+        return formatGraph("TB", `GCP Pub/Sub Topics — ${project}`, nodes, edges);
+    }
+    return undefined;
+}
+function mermaidForJira(result) {
+    if (result["status"] !== "success")
+        return undefined;
+    if (result["action"] !== "jql_search")
+        return undefined;
+    const data = result["data"];
+    if (data === undefined)
+        return undefined;
+    const issues = data["issues"] ?? [];
+    if (issues.length === 0)
+        return undefined;
+    const byStatus = new Map();
+    for (const issue of issues) {
+        const status = (issue["status"] ?? "unknown") || "unknown";
+        let bucket = byStatus.get(status);
+        if (bucket === undefined) {
+            bucket = [];
+            byStatus.set(status, bucket);
+        }
+        bucket.push(issue);
+    }
+    const nodes = [];
+    const edges = [];
+    nodes.push({ id: "root", label: "Issues", shape: "rounded" });
+    let si = 0;
+    let ii = 0;
+    const PER_DIAGRAM_CAP = 40;
+    let drawn = 0;
+    for (const [status, bucket] of byStatus) {
+        if (drawn >= PER_DIAGRAM_CAP)
+            break;
+        const sid = `s${si++}`;
+        nodes.push({ id: sid, label: status });
+        edges.push({ from: "root", to: sid });
+        for (const issue of bucket) {
+            if (drawn >= PER_DIAGRAM_CAP)
+                break;
+            const key = issue["key"] ?? `I${ii}`;
+            const summary = (issue["summary"] ?? "").slice(0, 40);
+            const label = summary ? `${key}: ${summary}` : key;
+            const id = `i${ii++}`;
+            nodes.push({ id, label });
+            edges.push({ from: sid, to: id });
+            drawn++;
+        }
+    }
+    return formatGraph("TB", "Issue Status Tree", nodes, edges);
+}
+function mermaidForConfluence(result) {
+    if (result["status"] !== "success")
+        return undefined;
+    const action = result["action"];
+    const data = result["data"];
+    if (data === undefined)
+        return undefined;
+    if (action === "cql_search") {
+        const pages = data["pages"] ?? [];
+        if (pages.length === 0)
+            return undefined;
+        const spaceKeys = new Set(pages
+            .map((p) => p["space_key"] ?? "")
+            .filter((k) => k.length > 0));
+        const nodes = [];
+        const edges = [];
+        const capped = pages.slice(0, 30);
+        if (spaceKeys.size <= 1) {
+            const root = [...spaceKeys][0] ?? "Results";
+            nodes.push({ id: "space", label: root, shape: "rounded" });
+            for (const [i, p] of capped.entries()) {
+                const title = (p["title"] ?? `page ${i}`).slice(0, 60);
+                nodes.push({ id: `p${i}`, label: title });
+                edges.push({ from: "space", to: `p${i}` });
+            }
+        }
+        else {
+            const spaceIdx = new Map();
+            let si = 0;
+            for (const k of spaceKeys) {
+                const id = `s${si++}`;
+                spaceIdx.set(k, id);
+                nodes.push({ id, label: k, shape: "rounded" });
+            }
+            for (const [i, p] of capped.entries()) {
+                const key = p["space_key"] ?? "";
+                const parent = spaceIdx.get(key);
+                if (parent === undefined)
+                    continue;
+                const title = (p["title"] ?? `page ${i}`).slice(0, 60);
+                nodes.push({ id: `p${i}`, label: title });
+                edges.push({ from: parent, to: `p${i}` });
+            }
+        }
+        return formatGraph("TB", "Page Hierarchy", nodes, edges);
+    }
+    if (action === "get_page") {
+        const spaceKey = data["space_key"] ?? "";
+        const title = (data["title"] ?? "page").slice(0, 60);
+        if (title.length === 0)
+            return undefined;
+        const nodes = [];
+        const edges = [];
+        if (spaceKey.length > 0) {
+            nodes.push({ id: "space", label: spaceKey, shape: "rounded" });
+            nodes.push({ id: "page", label: title });
+            edges.push({ from: "space", to: "page" });
+        }
+        else {
+            nodes.push({ id: "page", label: title });
+        }
+        return formatGraph("TB", "Page Hierarchy", nodes, edges);
+    }
+    return undefined;
+}
+function mermaidForNotion(result) {
+    if (result["status"] !== "success")
+        return undefined;
+    const action = result["action"];
+    const data = result["data"];
+    if (data === undefined)
+        return undefined;
+    if (action === "search") {
+        const results = data["results"] ?? [];
+        if (results.length === 0)
+            return undefined;
+        const capped = results.slice(0, 30);
+        const nodes = [
+            { id: "root", label: "Search Results", shape: "rounded" },
+        ];
+        const edges = [];
+        for (const [i, r] of capped.entries()) {
+            const id = (r["id"] ?? `r${i}`).slice(0, 8);
+            const objType = (r["object_type"] ?? "page").slice(0, 20);
+            nodes.push({ id: `r${i}`, label: `${objType} ${id}` });
+            edges.push({ from: "root", to: `r${i}` });
+        }
+        return formatGraph("TB", "Notion Search Hierarchy", nodes, edges);
+    }
+    if (action === "query_database") {
+        const databaseId = data["database_id"] ?? "database";
+        const results = data["results"] ?? [];
+        if (results.length === 0)
+            return undefined;
+        const capped = results.slice(0, 30);
+        const dbLabel = databaseId.length > 8 ? databaseId.slice(0, 8) + "…" : databaseId;
+        const nodes = [
+            { id: "db", label: `DB ${dbLabel}`, shape: "rounded" },
+        ];
+        const edges = [];
+        for (const [i, r] of capped.entries()) {
+            const title = (r["title"] ?? `row ${i}`).slice(0, 60);
+            nodes.push({ id: `p${i}`, label: title });
+            edges.push({ from: "db", to: `p${i}` });
+        }
+        return formatGraph("TB", "Notion Page Tree", nodes, edges);
+    }
+    return undefined;
+}
+function parsePackageJsonDeps(content) {
+    try {
+        const parsed = JSON.parse(content);
+        const deps = [
+            ...Object.keys(parsed.dependencies ?? {}),
+            ...Object.keys(parsed.devDependencies ?? {}),
+        ];
+        return [...new Set(deps)];
+    }
+    catch {
+        return [];
+    }
+}
+function parseRequirementsTxt(content) {
+    const deps = [];
+    const seen = new Set();
+    for (const rawLine of content.split(/\r?\n/)) {
+        const line = rawLine.trim();
+        if (line === "" || line.startsWith("#"))
+            continue;
+        const m = line.match(/^([A-Za-z0-9_.\-]+)/);
+        if (!m)
+            continue;
+        const name = m[1];
+        if (seen.has(name))
+            continue;
+        seen.add(name);
+        deps.push(name);
+    }
+    return deps;
+}
+function mermaidForGithub(result) {
+    if (result["status"] !== "success")
+        return undefined;
+    if (result["action"] !== "get_file")
+        return undefined;
+    const data = result["data"];
+    if (data === undefined)
+        return undefined;
+    const filePath = (data["path"] ?? "").toLowerCase();
+    const content = data["content"] ?? "";
+    if (content === "")
+        return undefined;
+    let deps = [];
+    if (filePath.endsWith("package.json")) {
+        deps = parsePackageJsonDeps(content);
+    }
+    else if (filePath.endsWith("requirements.txt")) {
+        deps = parseRequirementsTxt(content);
+    }
+    if (deps.length === 0)
+        return undefined;
+    const capped = deps.slice(0, 40);
+    const rootLabel = data["path"] || "repo";
+    const nodes = [
+        { id: "root", label: rootLabel, shape: "rounded" },
+        ...capped.map((d, i) => ({ id: `dep_${i}`, label: d })),
+    ];
+    const edges = capped.map((_, i) => ({
+        from: "root",
+        to: `dep_${i}`,
+    }));
+    return formatGraph("LR", "Dependency Graph", nodes, edges);
+}
+function mermaidForDb(result) {
+    // db-agent uses `status: "ok"` instead of `success`, and emits the
+    // schema action's `tables` array at top level rather than nested in `data`.
+    if (result["status"] !== "ok")
+        return undefined;
+    const tables = result["tables"];
+    if (!Array.isArray(tables) || tables.length === 0)
+        return undefined;
+    const wrapped = tables;
+    const ermTables = wrapped.map((t) => {
+        const cols = t.columns.map((c) => {
+            const col = {
+                name: c.name,
+                type: c.data_type || "string",
+            };
+            if (c.is_primary_key)
+                col.key = "PK";
+            return col;
+        });
+        return { name: t.name, columns: cols };
+    });
+    return formatErDiagram("Database Schema", ermTables, []);
+}
+const TRANSFORMERS = {
+    aws: mermaidForAws,
+    gcp: mermaidForGcp,
+    jira: mermaidForJira,
+    confluence: mermaidForConfluence,
+    notion: mermaidForNotion,
+    github: mermaidForGithub,
+    db: mermaidForDb,
+};
+// ── Public API ────────────────────────────────────────────────────────
+/**
+ * Apply a wiki Mermaid block on top of a `DispatchResult.envelope` when the
+ * connector + action + payload qualify. Returns a fresh `DispatchResult` with
+ * the augmented envelope. Returns the input unchanged for:
+ *  - error results (no envelope to augment),
+ *  - non-object envelopes,
+ *  - unknown connector short names (no transformer registered),
+ *  - actions that don't produce diagram-worthy data.
+ *
+ * Never throws — mirrors wrappers' permissive contract.
+ */
+export function applyMermaid(result) {
+    if (result.error !== undefined)
+        return result;
+    const envelope = result.envelope;
+    if (envelope === null || typeof envelope !== "object")
+        return result;
+    const transformer = TRANSFORMERS[result.connector];
+    if (transformer === undefined)
+        return result;
+    const env = envelope;
+    const mermaid = transformer(env);
+    if (mermaid === undefined)
+        return result;
+    return {
+        ...result,
+        envelope: { ...env, mermaid },
+    };
+}
+/** Connector short names this module knows how to augment. Used by tests
+ *  and any caller that wants to filter to structural-action connectors. */
+export const SUPPORTED_CONNECTORS = new Set(Object.keys(TRANSFORMERS));

--- a/.claude/agents/lib/mermaid_augment.ts
+++ b/.claude/agents/lib/mermaid_augment.ts
@@ -1,0 +1,448 @@
+/**
+ * mermaid_augment.ts — wiki-side Mermaid augmentation for raw connector envelopes.
+ *
+ * Used by the wiki ingest pipeline (SKILL.md step 7). After
+ * `@narai/connector-hub`'s `gather()` dispatches connector CLIs in parallel
+ * and returns raw `DispatchResult` entries, this module applies the
+ * wiki-specific Mermaid diagram block (`mermaid: { type, title, code }`) on
+ * top of structural-action envelopes.
+ *
+ * Single decoration site for all 7 builtin connectors (aws, gcp, jira,
+ * confluence, notion, github, db). The legacy `wiki-<svc>-agent/scripts/*_wrapper.ts`
+ * scripts that previously held this logic were decommissioned — they only duplicated
+ * what the hub does (CLI dispatch) plus what this module does (Mermaid).
+ *
+ * Public API:
+ *   applyMermaid(result: DispatchResult): DispatchResult
+ *     - Returns a *new* `DispatchResult` whose `envelope` has been augmented
+ *       with a `mermaid` block when the connector + action + payload qualify.
+ *     - When the envelope cannot be augmented (error result, non-structural
+ *       action, empty data, unknown connector), the input is returned as-is.
+ *     - Never throws; permissive on malformed data.
+ */
+import type { DispatchResult } from "@narai/connector-hub";
+
+import {
+  formatErDiagram,
+  formatGraph,
+  type ErColumn,
+  type ErTable,
+  type GraphEdge,
+  type GraphNode,
+  type MermaidBlock,
+} from "./mermaid_format.js";
+
+// ── Per-connector transformers ────────────────────────────────────────
+//
+// Each function takes the raw envelope (parsed JSON object, the same shape
+// the connector CLI prints to stdout) and returns a MermaidBlock or
+// undefined. When a connector's action set changes, update the matching
+// transformer here; this is the single site for wiki-side decoration.
+
+function mermaidForAws(result: Record<string, unknown>): MermaidBlock | undefined {
+  if (result["status"] !== "success") return undefined;
+  const action = result["action"];
+  const data = result["data"] as Record<string, unknown> | undefined;
+  if (data === undefined) return undefined;
+
+  if (action === "list_functions") {
+    const fns =
+      (data["functions"] as Array<{ name: string; runtime: string }> | undefined) ?? [];
+    if (fns.length === 0) return undefined;
+    const region = (data["region"] as string) || "region";
+    const nodes: GraphNode[] = [
+      { id: `region_${region}`, label: `Region: ${region}`, shape: "rounded" },
+      ...fns.map((f) => ({
+        id: `fn_${f.name}`,
+        label: `${f.name} (${f.runtime || "unknown"})`,
+      })),
+    ];
+    const edges: GraphEdge[] = fns.map((f) => ({
+      from: `region_${region}`,
+      to: `fn_${f.name}`,
+    }));
+    return formatGraph("TB", `AWS Lambda Functions — ${region}`, nodes, edges);
+  }
+
+  if (action === "describe_db") {
+    const region = (data["region"] as string) || "region";
+    const id = (data["db_identifier"] as string) || "db";
+    const engine = (data["engine"] as string) || "";
+    const cls = (data["instance_class"] as string) || "";
+    const label = engine || cls ? `${id} (${engine}${cls ? `, ${cls}` : ""})` : id;
+    const nodes: GraphNode[] = [
+      { id: `region_${region}`, label: `Region: ${region}`, shape: "rounded" },
+      { id: `db_${id}`, label, shape: "stadium" },
+    ];
+    const edges: GraphEdge[] = [{ from: `region_${region}`, to: `db_${id}` }];
+    return formatGraph("TB", `AWS RDS — ${id}`, nodes, edges);
+  }
+
+  if (action === "list_buckets") {
+    const buckets = (data["buckets"] as Array<{ name: string }> | undefined) ?? [];
+    if (buckets.length === 0) return undefined;
+    const nodes: GraphNode[] = [
+      { id: "account", label: "AWS Account", shape: "rounded" },
+      ...buckets.map((b) => ({ id: `bucket_${b.name}`, label: b.name })),
+    ];
+    const edges: GraphEdge[] = buckets.map((b) => ({
+      from: "account",
+      to: `bucket_${b.name}`,
+    }));
+    return formatGraph("TB", "AWS S3 Buckets", nodes, edges);
+  }
+
+  return undefined;
+}
+
+function mermaidForGcp(result: Record<string, unknown>): MermaidBlock | undefined {
+  if (result["status"] !== "success") return undefined;
+  const action = result["action"];
+  const data = result["data"] as Record<string, unknown> | undefined;
+  if (data === undefined) return undefined;
+
+  if (action === "list_services") {
+    const services =
+      (data["services"] as Array<{ name: string; title: string }> | undefined) ?? [];
+    if (services.length === 0) return undefined;
+    const project = (data["project_id"] as string) || "project";
+    const nodes: GraphNode[] = [
+      { id: `proj_${project}`, label: `Project: ${project}`, shape: "rounded" },
+      ...services.map((s, i) => ({ id: `svc_${i}`, label: s.title || s.name })),
+    ];
+    const edges: GraphEdge[] = services.map((_, i) => ({
+      from: `proj_${project}`,
+      to: `svc_${i}`,
+    }));
+    return formatGraph("TB", `GCP Services — ${project}`, nodes, edges);
+  }
+
+  if (action === "describe_db") {
+    const project = (data["project_id"] as string) || "project";
+    const instance = (data["instance_id"] as string) || "instance";
+    const engine = (data["engine"] as string) || "";
+    const version = (data["version"] as string) || "";
+    const label = engine || version ? `${instance} (${engine}${version ? ` ${version}` : ""})` : instance;
+    const nodes: GraphNode[] = [
+      { id: `proj_${project}`, label: `Project: ${project}`, shape: "rounded" },
+      { id: `db_${instance}`, label, shape: "stadium" },
+    ];
+    const edges: GraphEdge[] = [{ from: `proj_${project}`, to: `db_${instance}` }];
+    return formatGraph("TB", `GCP Cloud SQL — ${instance}`, nodes, edges);
+  }
+
+  if (action === "list_topics") {
+    const topics = (data["topics"] as string[] | undefined) ?? [];
+    if (topics.length === 0) return undefined;
+    const project = (data["project_id"] as string) || "project";
+    const nodes: GraphNode[] = [
+      { id: `proj_${project}`, label: `Project: ${project}`, shape: "rounded" },
+      ...topics.map((t, i) => ({ id: `topic_${i}`, label: t })),
+    ];
+    const edges: GraphEdge[] = topics.map((_, i) => ({
+      from: `proj_${project}`,
+      to: `topic_${i}`,
+    }));
+    return formatGraph("TB", `GCP Pub/Sub Topics — ${project}`, nodes, edges);
+  }
+
+  return undefined;
+}
+
+function mermaidForJira(result: Record<string, unknown>): MermaidBlock | undefined {
+  if (result["status"] !== "success") return undefined;
+  if (result["action"] !== "jql_search") return undefined;
+  const data = result["data"] as Record<string, unknown> | undefined;
+  if (data === undefined) return undefined;
+  const issues =
+    (data["issues"] as Array<Record<string, unknown>> | undefined) ?? [];
+  if (issues.length === 0) return undefined;
+
+  const byStatus = new Map<string, Array<Record<string, unknown>>>();
+  for (const issue of issues) {
+    const status = ((issue["status"] as string | undefined) ?? "unknown") || "unknown";
+    let bucket = byStatus.get(status);
+    if (bucket === undefined) {
+      bucket = [];
+      byStatus.set(status, bucket);
+    }
+    bucket.push(issue);
+  }
+
+  const nodes: GraphNode[] = [];
+  const edges: GraphEdge[] = [];
+  nodes.push({ id: "root", label: "Issues", shape: "rounded" });
+  let si = 0;
+  let ii = 0;
+  const PER_DIAGRAM_CAP = 40;
+  let drawn = 0;
+  for (const [status, bucket] of byStatus) {
+    if (drawn >= PER_DIAGRAM_CAP) break;
+    const sid = `s${si++}`;
+    nodes.push({ id: sid, label: status });
+    edges.push({ from: "root", to: sid });
+    for (const issue of bucket) {
+      if (drawn >= PER_DIAGRAM_CAP) break;
+      const key = (issue["key"] as string | undefined) ?? `I${ii}`;
+      const summary = ((issue["summary"] as string | undefined) ?? "").slice(0, 40);
+      const label = summary ? `${key}: ${summary}` : key;
+      const id = `i${ii++}`;
+      nodes.push({ id, label });
+      edges.push({ from: sid, to: id });
+      drawn++;
+    }
+  }
+  return formatGraph("TB", "Issue Status Tree", nodes, edges);
+}
+
+function mermaidForConfluence(result: Record<string, unknown>): MermaidBlock | undefined {
+  if (result["status"] !== "success") return undefined;
+  const action = result["action"];
+  const data = result["data"] as Record<string, unknown> | undefined;
+  if (data === undefined) return undefined;
+
+  if (action === "cql_search") {
+    const pages = (data["pages"] as Array<Record<string, unknown>> | undefined) ?? [];
+    if (pages.length === 0) return undefined;
+    const spaceKeys = new Set(
+      pages
+        .map((p) => (p["space_key"] as string | undefined) ?? "")
+        .filter((k) => k.length > 0),
+    );
+    const nodes: GraphNode[] = [];
+    const edges: GraphEdge[] = [];
+    const capped = pages.slice(0, 30);
+    if (spaceKeys.size <= 1) {
+      const root = [...spaceKeys][0] ?? "Results";
+      nodes.push({ id: "space", label: root, shape: "rounded" });
+      for (const [i, p] of capped.entries()) {
+        const title = ((p["title"] as string | undefined) ?? `page ${i}`).slice(0, 60);
+        nodes.push({ id: `p${i}`, label: title });
+        edges.push({ from: "space", to: `p${i}` });
+      }
+    } else {
+      const spaceIdx = new Map<string, string>();
+      let si = 0;
+      for (const k of spaceKeys) {
+        const id = `s${si++}`;
+        spaceIdx.set(k, id);
+        nodes.push({ id, label: k, shape: "rounded" });
+      }
+      for (const [i, p] of capped.entries()) {
+        const key = (p["space_key"] as string | undefined) ?? "";
+        const parent = spaceIdx.get(key);
+        if (parent === undefined) continue;
+        const title = ((p["title"] as string | undefined) ?? `page ${i}`).slice(0, 60);
+        nodes.push({ id: `p${i}`, label: title });
+        edges.push({ from: parent, to: `p${i}` });
+      }
+    }
+    return formatGraph("TB", "Page Hierarchy", nodes, edges);
+  }
+
+  if (action === "get_page") {
+    const spaceKey = (data["space_key"] as string | undefined) ?? "";
+    const title = ((data["title"] as string | undefined) ?? "page").slice(0, 60);
+    if (title.length === 0) return undefined;
+    const nodes: GraphNode[] = [];
+    const edges: GraphEdge[] = [];
+    if (spaceKey.length > 0) {
+      nodes.push({ id: "space", label: spaceKey, shape: "rounded" });
+      nodes.push({ id: "page", label: title });
+      edges.push({ from: "space", to: "page" });
+    } else {
+      nodes.push({ id: "page", label: title });
+    }
+    return formatGraph("TB", "Page Hierarchy", nodes, edges);
+  }
+
+  return undefined;
+}
+
+function mermaidForNotion(result: Record<string, unknown>): MermaidBlock | undefined {
+  if (result["status"] !== "success") return undefined;
+  const action = result["action"];
+  const data = result["data"] as Record<string, unknown> | undefined;
+  if (data === undefined) return undefined;
+
+  if (action === "search") {
+    const results = (data["results"] as Array<Record<string, unknown>> | undefined) ?? [];
+    if (results.length === 0) return undefined;
+    const capped = results.slice(0, 30);
+    const nodes: GraphNode[] = [
+      { id: "root", label: "Search Results", shape: "rounded" },
+    ];
+    const edges: GraphEdge[] = [];
+    for (const [i, r] of capped.entries()) {
+      const id = ((r["id"] as string | undefined) ?? `r${i}`).slice(0, 8);
+      const objType = ((r["object_type"] as string | undefined) ?? "page").slice(0, 20);
+      nodes.push({ id: `r${i}`, label: `${objType} ${id}` });
+      edges.push({ from: "root", to: `r${i}` });
+    }
+    return formatGraph("TB", "Notion Search Hierarchy", nodes, edges);
+  }
+
+  if (action === "query_database") {
+    const databaseId = (data["database_id"] as string | undefined) ?? "database";
+    const results = (data["results"] as Array<Record<string, unknown>> | undefined) ?? [];
+    if (results.length === 0) return undefined;
+    const capped = results.slice(0, 30);
+    const dbLabel = databaseId.length > 8 ? databaseId.slice(0, 8) + "…" : databaseId;
+    const nodes: GraphNode[] = [
+      { id: "db", label: `DB ${dbLabel}`, shape: "rounded" },
+    ];
+    const edges: GraphEdge[] = [];
+    for (const [i, r] of capped.entries()) {
+      const title = ((r["title"] as string | undefined) ?? `row ${i}`).slice(0, 60);
+      nodes.push({ id: `p${i}`, label: title });
+      edges.push({ from: "db", to: `p${i}` });
+    }
+    return formatGraph("TB", "Notion Page Tree", nodes, edges);
+  }
+
+  return undefined;
+}
+
+function parsePackageJsonDeps(content: string): string[] {
+  try {
+    const parsed = JSON.parse(content) as {
+      dependencies?: Record<string, unknown>;
+      devDependencies?: Record<string, unknown>;
+    };
+    const deps = [
+      ...Object.keys(parsed.dependencies ?? {}),
+      ...Object.keys(parsed.devDependencies ?? {}),
+    ];
+    return [...new Set(deps)];
+  } catch {
+    return [];
+  }
+}
+
+function parseRequirementsTxt(content: string): string[] {
+  const deps: string[] = [];
+  const seen = new Set<string>();
+  for (const rawLine of content.split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (line === "" || line.startsWith("#")) continue;
+    const m = line.match(/^([A-Za-z0-9_.\-]+)/);
+    if (!m) continue;
+    const name = m[1]!;
+    if (seen.has(name)) continue;
+    seen.add(name);
+    deps.push(name);
+  }
+  return deps;
+}
+
+function mermaidForGithub(result: Record<string, unknown>): MermaidBlock | undefined {
+  if (result["status"] !== "success") return undefined;
+  if (result["action"] !== "get_file") return undefined;
+  const data = result["data"] as Record<string, unknown> | undefined;
+  if (data === undefined) return undefined;
+
+  const filePath = ((data["path"] as string) ?? "").toLowerCase();
+  const content = (data["content"] as string) ?? "";
+  if (content === "") return undefined;
+
+  let deps: string[] = [];
+  if (filePath.endsWith("package.json")) {
+    deps = parsePackageJsonDeps(content);
+  } else if (filePath.endsWith("requirements.txt")) {
+    deps = parseRequirementsTxt(content);
+  }
+
+  if (deps.length === 0) return undefined;
+  const capped = deps.slice(0, 40);
+  const rootLabel = (data["path"] as string) || "repo";
+  const nodes: GraphNode[] = [
+    { id: "root", label: rootLabel, shape: "rounded" },
+    ...capped.map((d, i) => ({ id: `dep_${i}`, label: d })),
+  ];
+  const edges: GraphEdge[] = capped.map((_, i) => ({
+    from: "root",
+    to: `dep_${i}`,
+  }));
+  return formatGraph("LR", "Dependency Graph", nodes, edges);
+}
+
+interface DbWrapperTable {
+  name: string;
+  columns: Array<{
+    name: string;
+    data_type?: string;
+    is_primary_key?: boolean;
+  }>;
+}
+
+function mermaidForDb(result: Record<string, unknown>): MermaidBlock | undefined {
+  // db-agent uses `status: "ok"` instead of `success`, and emits the
+  // schema action's `tables` array at top level rather than nested in `data`.
+  if (result["status"] !== "ok") return undefined;
+  const tables = result["tables"];
+  if (!Array.isArray(tables) || tables.length === 0) return undefined;
+  const wrapped = tables as DbWrapperTable[];
+  const ermTables: ErTable[] = wrapped.map((t) => {
+    const cols: ErColumn[] = t.columns.map((c) => {
+      const col: ErColumn = {
+        name: c.name,
+        type: c.data_type || "string",
+      };
+      if (c.is_primary_key) col.key = "PK";
+      return col;
+    });
+    return { name: t.name, columns: cols };
+  });
+  return formatErDiagram("Database Schema", ermTables, []);
+}
+
+// ── Dispatch table ────────────────────────────────────────────────────
+
+type Transformer = (envelope: Record<string, unknown>) => MermaidBlock | undefined;
+
+const TRANSFORMERS: Record<string, Transformer> = {
+  aws: mermaidForAws,
+  gcp: mermaidForGcp,
+  jira: mermaidForJira,
+  confluence: mermaidForConfluence,
+  notion: mermaidForNotion,
+  github: mermaidForGithub,
+  db: mermaidForDb,
+};
+
+// ── Public API ────────────────────────────────────────────────────────
+
+/**
+ * Apply a wiki Mermaid block on top of a `DispatchResult.envelope` when the
+ * connector + action + payload qualify. Returns a fresh `DispatchResult` with
+ * the augmented envelope. Returns the input unchanged for:
+ *  - error results (no envelope to augment),
+ *  - non-object envelopes,
+ *  - unknown connector short names (no transformer registered),
+ *  - actions that don't produce diagram-worthy data.
+ *
+ * Never throws — mirrors wrappers' permissive contract.
+ */
+export function applyMermaid(result: DispatchResult): DispatchResult {
+  if (result.error !== undefined) return result;
+  const envelope = result.envelope;
+  if (envelope === null || typeof envelope !== "object") return result;
+
+  const transformer = TRANSFORMERS[result.connector];
+  if (transformer === undefined) return result;
+
+  const env = envelope as Record<string, unknown>;
+  const mermaid = transformer(env);
+  if (mermaid === undefined) return result;
+
+  return {
+    ...result,
+    envelope: { ...env, mermaid },
+  };
+}
+
+/** Connector short names this module knows how to augment. Used by tests
+ *  and any caller that wants to filter to structural-action connectors. */
+export const SUPPORTED_CONNECTORS: ReadonlySet<string> = new Set(
+  Object.keys(TRANSFORMERS),
+);

--- a/.claude/agents/lib/tests/gather_integration.test.ts
+++ b/.claude/agents/lib/tests/gather_integration.test.ts
@@ -1,0 +1,292 @@
+/**
+ * Tests the seam between @narai/connector-hub's `gather()` and the wiki-side
+ * `applyMermaid()` decoration. Step 7 of /wiki-ingest depends on this contract:
+ *
+ *   const { results } = await gather({ prompt, consumer: "doc-wiki" });
+ *   const augmented = results.map(applyMermaid);
+ *
+ * This test fixtures the `gather()` output for all 7 builtin connectors plus
+ * the failure modes the hub emits (error, non-structural action, malformed
+ * envelope) and asserts that `applyMermaid` produces the shape `mermaid_inject.js`
+ * (step 9) consumes — i.e. either an envelope with a `mermaid: { type, title, code }`
+ * field, or a passthrough.
+ *
+ * Direct unit coverage of each transformer lives in `mermaid_augment.test.ts`.
+ * This file covers the orchestration: `results.map(applyMermaid)` over a
+ * realistic mixed batch.
+ */
+import { describe, expect, it } from "vitest";
+import type { DispatchResult } from "@narai/connector-hub";
+
+import { applyMermaid, SUPPORTED_CONNECTORS } from "../mermaid_augment.js";
+
+// ── Fixtures: a realistic gather() output ────────────────────────────
+
+/**
+ * One DispatchResult per builtin connector, plus three failure shapes.
+ * Models the hub's actual return shape (per @narai/connector-hub README):
+ *   { step, connector, action, params, envelope?, error? }
+ */
+function fakeGatherOutput(): DispatchResult[] {
+  return [
+    // 1. AWS — list_functions (structural, should get mermaid)
+    {
+      step: 0,
+      connector: "aws",
+      action: "list_functions",
+      params: { region: "us-east-1" },
+      envelope: {
+        status: "success",
+        action: "list_functions",
+        data: {
+          region: "us-east-1",
+          functions: [
+            { name: "ingest-handler", runtime: "nodejs20.x" },
+            { name: "transform-handler", runtime: "nodejs20.x" },
+          ],
+        },
+      },
+    },
+    // 2. GCP — list_services (structural, should get mermaid)
+    {
+      step: 1,
+      connector: "gcp",
+      action: "list_services",
+      params: { project_id: "my-proj" },
+      envelope: {
+        status: "success",
+        action: "list_services",
+        data: {
+          project_id: "my-proj",
+          services: [
+            { name: "api-gateway", title: "API Gateway" },
+            { name: "worker-pool", title: "Worker Pool" },
+          ],
+        },
+      },
+    },
+    // 3. Jira — jql_search (structural, should get mermaid)
+    {
+      step: 2,
+      connector: "jira",
+      action: "jql_search",
+      params: { jql: "project = AUTH" },
+      envelope: {
+        status: "success",
+        action: "jql_search",
+        data: {
+          issues: [
+            { key: "AUTH-1", status: "Done", summary: "Login flow" },
+            { key: "AUTH-2", status: "In Progress", summary: "MFA" },
+          ],
+        },
+      },
+    },
+    // 4. Confluence — cql_search (structural, should get mermaid)
+    {
+      step: 3,
+      connector: "confluence",
+      action: "cql_search",
+      params: { cql: "space = ARCH" },
+      envelope: {
+        status: "success",
+        action: "cql_search",
+        data: {
+          pages: [
+            { space_key: "ARCH", title: "Architecture overview" },
+            { space_key: "ARCH", title: "Auth design" },
+          ],
+        },
+      },
+    },
+    // 5. Notion — search (structural, should get mermaid)
+    {
+      step: 4,
+      connector: "notion",
+      action: "search",
+      params: { query: "auth" },
+      envelope: {
+        status: "success",
+        action: "search",
+        data: {
+          results: [
+            { id: "page-1", object_type: "page" },
+            { id: "page-2", object_type: "page" },
+          ],
+        },
+      },
+    },
+    // 6. GitHub — get_file (structural for package.json, should get mermaid)
+    {
+      step: 5,
+      connector: "github",
+      action: "get_file",
+      params: { owner: "acme", repo: "svc", path: "package.json" },
+      envelope: {
+        status: "success",
+        action: "get_file",
+        data: {
+          path: "package.json",
+          content: JSON.stringify({
+            name: "svc",
+            dependencies: { express: "^4.0.0", pg: "^8.0.0" },
+          }),
+        },
+      },
+    },
+    // 7. DB — schema (erDiagram path; db-agent envelope uses status:"ok" + top-level tables)
+    {
+      step: 6,
+      connector: "db",
+      action: "schema",
+      params: { env: "dev" },
+      envelope: {
+        status: "ok",
+        tables: [
+          {
+            name: "users",
+            columns: [
+              { name: "id", data_type: "uuid", is_primary_key: true },
+              { name: "email", data_type: "varchar" },
+            ],
+          },
+          {
+            name: "sessions",
+            columns: [
+              { name: "id", data_type: "uuid", is_primary_key: true },
+              { name: "user_id", data_type: "uuid" },
+            ],
+          },
+        ],
+      },
+    },
+    // Failure shapes the hub can emit:
+
+    // 8. Error result (planner failure / spawn failure / non-JSON stdout)
+    {
+      step: 7,
+      connector: "github",
+      action: "search_code",
+      params: { q: "broken-token" },
+      error: { code: "AUTH_ERROR", message: "Invalid GitHub token" },
+    },
+    // 9. Non-structural action (success but applyMermaid should skip)
+    {
+      step: 8,
+      connector: "github",
+      action: "search_code",
+      params: { q: "TODO" },
+      envelope: {
+        status: "success",
+        action: "search_code",
+        data: { results: [{ path: "src/x.ts" }] },
+      },
+    },
+    // 10. Unknown connector (custom from wiki.config.yaml; applyMermaid passthrough)
+    {
+      step: 9,
+      connector: "linear",
+      action: "list_issues",
+      params: {},
+      envelope: { status: "success", action: "list_issues", data: { issues: [] } },
+    },
+  ];
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────
+
+describe("gather() → applyMermaid() seam", () => {
+  it("covers all 7 builtin connectors in the SUPPORTED_CONNECTORS set", () => {
+    const fixture = fakeGatherOutput();
+    const builtinHits = fixture
+      .map((r) => r.connector)
+      .filter((c) => SUPPORTED_CONNECTORS.has(c));
+    // Each of the 7 builtin connectors appears at least once in the fixture
+    expect(new Set(builtinHits)).toEqual(
+      new Set(["aws", "gcp", "jira", "confluence", "notion", "github", "db"]),
+    );
+  });
+
+  it("attaches mermaid to all 7 structural connector results", () => {
+    const fixture = fakeGatherOutput();
+    const augmented = fixture.map(applyMermaid);
+
+    // The first 7 are structural-action successes — each must have mermaid
+    for (const i of [0, 1, 2, 3, 4, 5, 6]) {
+      const env = augmented[i]!.envelope as Record<string, unknown>;
+      const mermaid = env["mermaid"] as { type?: string; title?: string; code?: string } | undefined;
+      expect(mermaid, `step ${i} (${augmented[i]!.connector}) should have mermaid`).toBeDefined();
+      expect(typeof mermaid!.type).toBe("string");
+      expect(typeof mermaid!.title).toBe("string");
+      expect(typeof mermaid!.code).toBe("string");
+      expect(mermaid!.code!.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("uses erDiagram for db, graph LR for github get_file, graph TB for the rest", () => {
+    const augmented = fakeGatherOutput().map(applyMermaid);
+
+    const typeOf = (idx: number): string | undefined => {
+      const env = augmented[idx]!.envelope as Record<string, unknown>;
+      const mermaid = env["mermaid"] as { type?: string } | undefined;
+      return mermaid?.type;
+    };
+
+    expect(typeOf(0)).toBe("graph TB"); // aws
+    expect(typeOf(1)).toBe("graph TB"); // gcp
+    expect(typeOf(2)).toBe("graph TB"); // jira
+    expect(typeOf(3)).toBe("graph TB"); // confluence
+    expect(typeOf(4)).toBe("graph TB"); // notion
+    expect(typeOf(5)).toBe("graph LR"); // github get_file
+    expect(typeOf(6)).toBe("erDiagram"); // db schema
+  });
+
+  it("passes error results through unchanged", () => {
+    const fixture = fakeGatherOutput();
+    const augmented = fixture.map(applyMermaid);
+
+    const errorResult = augmented[7]!;
+    expect(errorResult).toBe(fixture[7]); // identity — input returned as-is
+    expect(errorResult.error).toEqual({ code: "AUTH_ERROR", message: "Invalid GitHub token" });
+    expect(errorResult.envelope).toBeUndefined();
+  });
+
+  it("leaves non-structural successful envelopes untouched", () => {
+    const fixture = fakeGatherOutput();
+    const augmented = fixture.map(applyMermaid);
+
+    // GitHub search_code is not a structural action — applyMermaid skips it
+    const nonStructural = augmented[8]!;
+    const env = nonStructural.envelope as Record<string, unknown>;
+    expect(env["mermaid"]).toBeUndefined();
+  });
+
+  it("passes unknown-connector envelopes through (custom registry agents)", () => {
+    const fixture = fakeGatherOutput();
+    const augmented = fixture.map(applyMermaid);
+
+    const custom = augmented[9]!;
+    expect(custom.connector).toBe("linear");
+    const env = custom.envelope as Record<string, unknown>;
+    expect(env["mermaid"]).toBeUndefined();
+  });
+
+  it("preserves step / connector / action / params on every entry", () => {
+    const fixture = fakeGatherOutput();
+    const augmented = fixture.map(applyMermaid);
+
+    for (let i = 0; i < fixture.length; i++) {
+      expect(augmented[i]!.step).toBe(fixture[i]!.step);
+      expect(augmented[i]!.connector).toBe(fixture[i]!.connector);
+      expect(augmented[i]!.action).toBe(fixture[i]!.action);
+      expect(augmented[i]!.params).toEqual(fixture[i]!.params);
+    }
+  });
+
+  it("does not mutate the input array or its entries", () => {
+    const fixture = fakeGatherOutput();
+    const beforeJson = JSON.stringify(fixture);
+    fixture.map(applyMermaid);
+    expect(JSON.stringify(fixture)).toBe(beforeJson);
+  });
+});

--- a/.claude/agents/lib/tests/mermaid_augment.test.ts
+++ b/.claude/agents/lib/tests/mermaid_augment.test.ts
@@ -1,0 +1,270 @@
+/**
+ * Tests for mermaid_augment.ts — apply Mermaid blocks to raw connector envelopes
+ * returned by `@narai/connector-hub`'s `gather()`.
+ *
+ * Each describe block covers one connector short name. We assert:
+ *  - happy path: a structural envelope gets a `mermaid: { type, title, code }`
+ *    field attached that matches the wrapper's diagram type.
+ *  - skip path: empty data (or a non-structural action) leaves the envelope
+ *    unchanged.
+ */
+import { describe, expect, it } from "vitest";
+import type { DispatchResult } from "@narai/connector-hub";
+
+import {
+  SUPPORTED_CONNECTORS,
+  applyMermaid,
+} from "../mermaid_augment.js";
+
+function makeResult(connector: string, envelope: unknown, action = "x"): DispatchResult {
+  return {
+    step: 0,
+    connector,
+    action,
+    params: {},
+    envelope,
+  };
+}
+
+describe("applyMermaid — passthrough cases", () => {
+  it("returns input unchanged when result has an error", () => {
+    const input: DispatchResult = {
+      step: 0,
+      connector: "aws",
+      action: "list_functions",
+      params: {},
+      error: { code: "X", message: "y" },
+    };
+    expect(applyMermaid(input)).toBe(input);
+  });
+
+  it("returns input unchanged for an unknown connector", () => {
+    const input = makeResult("unknown-svc", {
+      status: "success",
+      action: "list_functions",
+      data: { functions: [] },
+    });
+    expect(applyMermaid(input)).toBe(input);
+  });
+
+  it("returns input unchanged for a non-object envelope", () => {
+    const input = makeResult("aws", "raw-string");
+    expect(applyMermaid(input)).toBe(input);
+  });
+
+  it("returns input unchanged when transformer rejects (status != success)", () => {
+    const input = makeResult("aws", {
+      status: "error",
+      action: "list_functions",
+      data: { functions: [{ name: "f", runtime: "nodejs20.x" }] },
+    });
+    expect(applyMermaid(input)).toBe(input);
+  });
+});
+
+describe("applyMermaid — aws", () => {
+  it("attaches a graph TB diagram for list_functions", () => {
+    const out = applyMermaid(
+      makeResult("aws", {
+        status: "success",
+        action: "list_functions",
+        data: {
+          region: "us-east-1",
+          functions: [{ name: "fn1", runtime: "nodejs20.x" }],
+        },
+      }),
+    );
+    const env = out.envelope as Record<string, unknown>;
+    expect(env["mermaid"]).toMatchObject({
+      type: "graph TB",
+      title: "AWS Lambda Functions — us-east-1",
+    });
+  });
+
+  it("skips when functions list is empty", () => {
+    const input = makeResult("aws", {
+      status: "success",
+      action: "list_functions",
+      data: { region: "us-east-1", functions: [] },
+    });
+    expect(applyMermaid(input)).toBe(input);
+  });
+});
+
+describe("applyMermaid — gcp", () => {
+  it("attaches a graph TB diagram for list_services", () => {
+    const out = applyMermaid(
+      makeResult("gcp", {
+        status: "success",
+        action: "list_services",
+        data: {
+          project_id: "p1",
+          services: [{ name: "svc1.googleapis.com", title: "Service One" }],
+        },
+      }),
+    );
+    const env = out.envelope as Record<string, unknown>;
+    expect(env["mermaid"]).toMatchObject({
+      type: "graph TB",
+      title: "GCP Services — p1",
+    });
+  });
+});
+
+describe("applyMermaid — jira", () => {
+  it("groups issues by status under a root node", () => {
+    const out = applyMermaid(
+      makeResult("jira", {
+        status: "success",
+        action: "jql_search",
+        data: {
+          issues: [
+            { key: "AUTH-1", status: "Open", summary: "Login broken" },
+            { key: "AUTH-2", status: "Done", summary: "Add 2FA" },
+          ],
+        },
+      }),
+    );
+    const env = out.envelope as Record<string, unknown>;
+    expect(env["mermaid"]).toMatchObject({
+      type: "graph TB",
+      title: "Issue Status Tree",
+    });
+    const code = (env["mermaid"] as Record<string, unknown>)["code"] as string;
+    expect(code).toContain("AUTH-1");
+    expect(code).toContain("Open");
+  });
+
+  it("skips when issues list is empty", () => {
+    const input = makeResult("jira", {
+      status: "success",
+      action: "jql_search",
+      data: { issues: [] },
+    });
+    expect(applyMermaid(input)).toBe(input);
+  });
+});
+
+describe("applyMermaid — confluence", () => {
+  it("attaches a page-hierarchy diagram for cql_search", () => {
+    const out = applyMermaid(
+      makeResult("confluence", {
+        status: "success",
+        action: "cql_search",
+        data: {
+          pages: [
+            { title: "Page 1", space_key: "DEV" },
+            { title: "Page 2", space_key: "DEV" },
+          ],
+        },
+      }),
+    );
+    const env = out.envelope as Record<string, unknown>;
+    expect(env["mermaid"]).toMatchObject({
+      type: "graph TB",
+      title: "Page Hierarchy",
+    });
+  });
+});
+
+describe("applyMermaid — notion", () => {
+  it("attaches a search-hierarchy diagram for search", () => {
+    const out = applyMermaid(
+      makeResult("notion", {
+        status: "success",
+        action: "search",
+        data: {
+          results: [{ id: "abcd1234", object_type: "page" }],
+        },
+      }),
+    );
+    const env = out.envelope as Record<string, unknown>;
+    expect(env["mermaid"]).toMatchObject({
+      type: "graph TB",
+      title: "Notion Search Hierarchy",
+    });
+  });
+});
+
+describe("applyMermaid — github", () => {
+  it("attaches a dependency graph for package.json content", () => {
+    const out = applyMermaid(
+      makeResult("github", {
+        status: "success",
+        action: "get_file",
+        data: {
+          path: "package.json",
+          content: JSON.stringify({
+            dependencies: { vitest: "^3" },
+            devDependencies: { typescript: "^5" },
+          }),
+        },
+      }),
+    );
+    const env = out.envelope as Record<string, unknown>;
+    expect(env["mermaid"]).toMatchObject({
+      type: "graph LR",
+      title: "Dependency Graph",
+    });
+    const code = (env["mermaid"] as Record<string, unknown>)["code"] as string;
+    expect(code).toContain("vitest");
+    expect(code).toContain("typescript");
+  });
+
+  it("skips when path is unknown extension", () => {
+    const input = makeResult("github", {
+      status: "success",
+      action: "get_file",
+      data: { path: "README.md", content: "# hi" },
+    });
+    expect(applyMermaid(input)).toBe(input);
+  });
+});
+
+describe("applyMermaid — db", () => {
+  it("attaches an erDiagram for status=ok schema results", () => {
+    const out = applyMermaid(
+      makeResult("db", {
+        status: "ok",
+        tables: [
+          {
+            name: "users",
+            columns: [
+              { name: "id", data_type: "int", is_primary_key: true },
+              { name: "email", data_type: "text" },
+            ],
+          },
+        ],
+      }),
+    );
+    const env = out.envelope as Record<string, unknown>;
+    expect(env["mermaid"]).toMatchObject({
+      type: "erDiagram",
+      title: "Database Schema",
+    });
+    const code = (env["mermaid"] as Record<string, unknown>)["code"] as string;
+    expect(code).toContain("users");
+    expect(code).toContain("id PK");
+  });
+
+  it("skips when tables array is empty", () => {
+    const input = makeResult("db", { status: "ok", tables: [] });
+    expect(applyMermaid(input)).toBe(input);
+  });
+
+  it("skips when status is not ok", () => {
+    const input = makeResult("db", {
+      status: "denied",
+      tables: [{ name: "users", columns: [] }],
+    });
+    expect(applyMermaid(input)).toBe(input);
+  });
+});
+
+describe("SUPPORTED_CONNECTORS", () => {
+  it("includes all 7 wiki source/database connector short names", () => {
+    expect(new Set(SUPPORTED_CONNECTORS)).toEqual(
+      new Set(["aws", "gcp", "jira", "confluence", "notion", "github", "db"]),
+    );
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,15 +46,210 @@
         "@aws-sdk/client-lambda": "^3.1030.0",
         "@aws-sdk/client-rds": "^3.1030.0",
         "@aws-sdk/client-s3": "^3.1030.0",
-        "@narai/aws-agent-connector": "file:../aws-agent-connector",
-        "@narai/gcp-agent-connector": "file:../gcp-agent-connector"
+        "@narai/aws-agent-connector": "file:../connectors/aws-agent-connector",
+        "@narai/confluence-agent-connector": "file:../connectors/confluence-agent-connector",
+        "@narai/db-agent-connector": "file:../connectors/db-agent-connector",
+        "@narai/gcp-agent-connector": "file:../connectors/gcp-agent-connector",
+        "@narai/github-agent-connector": "file:../connectors/github-agent-connector",
+        "@narai/jira-agent-connector": "file:../connectors/jira-agent-connector",
+        "@narai/notion-agent-connector": "file:../connectors/notion-agent-connector"
       }
     },
     "../aws-agent-connector": {
-      "optional": true
+      "extraneous": true
+    },
+    "../connectors/aws-agent-connector": {
+      "name": "@narai/aws-agent-connector",
+      "version": "3.2.1",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@narai/connector-config": "^1.1.0",
+        "@narai/connector-toolkit": "^3.1.0",
+        "@narai/credential-providers": "^0.2.1",
+        "zod": "^3.23.0"
+      },
+      "bin": {
+        "aws-agent-connector": "dist/cli.js"
+      },
+      "devDependencies": {
+        "@aws-sdk/client-sts": "^3.1030.0",
+        "@types/node": "^20.19.39",
+        "@vitest/coverage-v8": "^3.2.4",
+        "typescript": "^5.9.3",
+        "vitest": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "optionalDependencies": {
+        "@aws-sdk/client-cloudwatch": "^3.1030.0",
+        "@aws-sdk/client-dynamodb": "^3.1030.0",
+        "@aws-sdk/client-lambda": "^3.1030.0",
+        "@aws-sdk/client-rds": "^3.1030.0",
+        "@aws-sdk/client-s3": "^3.1030.0",
+        "@aws-sdk/client-sts": "^3.1030.0"
+      }
+    },
+    "../connectors/confluence-agent-connector": {
+      "name": "@narai/confluence-agent-connector",
+      "version": "3.2.1",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@narai/connector-config": "^1.1.0",
+        "@narai/connector-toolkit": "^3.1.0",
+        "@narai/credential-providers": "^0.2.1",
+        "zod": "^3.23.0"
+      },
+      "bin": {
+        "confluence-agent-connector": "dist/cli.js"
+      },
+      "devDependencies": {
+        "@types/node": "^20.19.39",
+        "@vitest/coverage-v8": "^3.2.4",
+        "typescript": "^5.9.3",
+        "vitest": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "../connectors/db-agent-connector": {
+      "name": "@narai/db-agent-connector",
+      "version": "4.0.0",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@narai/connector-config": "^1.1.0",
+        "@narai/connector-toolkit": "^3.3.0",
+        "@narai/credential-providers": "^0.2.1",
+        "better-sqlite3": "^12.9.0",
+        "js-yaml": "^4.1.1",
+        "zod": "^3.23.0"
+      },
+      "bin": {
+        "db-agent-connector": "dist/cli.js"
+      },
+      "devDependencies": {
+        "@types/better-sqlite3": "^7.6.13",
+        "@types/js-yaml": "^4.0.9",
+        "@types/node": "^20.19.39",
+        "@types/pg": "^8.20.0",
+        "@vitest/coverage-v8": "^3.2.4",
+        "aws-sdk-client-mock": "^4.1.0",
+        "typescript": "^5.9.3",
+        "vitest": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=20.0.0 <21.0.0"
+      },
+      "optionalDependencies": {
+        "@aws-sdk/client-dynamodb": "^3.1030.0",
+        "mongodb": "^7.1.1",
+        "mssql": "^12.2.1",
+        "mysql2": "^3.22.0",
+        "oracledb": "^6.10.0",
+        "pg": "^8.20.0"
+      }
+    },
+    "../connectors/gcp-agent-connector": {
+      "name": "@narai/gcp-agent-connector",
+      "version": "3.2.1",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@narai/connector-config": "^1.1.0",
+        "@narai/connector-toolkit": "^3.1.0",
+        "zod": "^3.23.0"
+      },
+      "bin": {
+        "gcp-agent-connector": "dist/cli.js"
+      },
+      "devDependencies": {
+        "@types/node": "^20.19.39",
+        "@vitest/coverage-v8": "^3.2.4",
+        "typescript": "^5.9.3",
+        "vitest": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "../connectors/github-agent-connector": {
+      "name": "@narai/github-agent-connector",
+      "version": "3.2.0",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@narai/connector-config": "^1.1.0",
+        "@narai/connector-toolkit": "^3.1.0",
+        "@narai/credential-providers": "^0.2.1",
+        "zod": "^3.23.0"
+      },
+      "bin": {
+        "github-agent-connector": "dist/cli.js"
+      },
+      "devDependencies": {
+        "@types/node": "^20.19.39",
+        "@vitest/coverage-v8": "^3.2.4",
+        "typescript": "^5.9.3",
+        "vitest": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "../connectors/jira-agent-connector": {
+      "name": "@narai/jira-agent-connector",
+      "version": "3.2.1",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@narai/connector-config": "^1.1.0",
+        "@narai/connector-toolkit": "^3.1.0",
+        "@narai/credential-providers": "^0.2.1",
+        "zod": "^3.23.0"
+      },
+      "bin": {
+        "jira-agent-connector": "dist/cli.js"
+      },
+      "devDependencies": {
+        "@types/node": "^20.19.39",
+        "@vitest/coverage-v8": "^3.2.4",
+        "typescript": "^5.9.3",
+        "vitest": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "../connectors/notion-agent-connector": {
+      "name": "@narai/notion-agent-connector",
+      "version": "3.2.0",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@narai/connector-config": "^1.1.0",
+        "@narai/connector-toolkit": "^3.1.0",
+        "@narai/credential-providers": "^0.2.1",
+        "zod": "^3.23.0"
+      },
+      "bin": {
+        "notion-agent-connector": "dist/cli.js"
+      },
+      "devDependencies": {
+        "@types/node": "^20.19.39",
+        "@vitest/coverage-v8": "^3.2.4",
+        "typescript": "^5.9.3",
+        "vitest": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
     },
     "../gcp-agent-connector": {
-      "optional": true
+      "extraneous": true
     },
     "node_modules/@ampproject/remapping": {
       "version": "2.3.0",
@@ -2597,7 +2792,11 @@
       }
     },
     "node_modules/@narai/aws-agent-connector": {
-      "resolved": "../aws-agent-connector",
+      "resolved": "../connectors/aws-agent-connector",
+      "link": true
+    },
+    "node_modules/@narai/confluence-agent-connector": {
+      "resolved": "../connectors/confluence-agent-connector",
       "link": true
     },
     "node_modules/@narai/connector-config": {
@@ -2675,8 +2874,24 @@
         "node": ">=20.0.0"
       }
     },
+    "node_modules/@narai/db-agent-connector": {
+      "resolved": "../connectors/db-agent-connector",
+      "link": true
+    },
     "node_modules/@narai/gcp-agent-connector": {
-      "resolved": "../gcp-agent-connector",
+      "resolved": "../connectors/gcp-agent-connector",
+      "link": true
+    },
+    "node_modules/@narai/github-agent-connector": {
+      "resolved": "../connectors/github-agent-connector",
+      "link": true
+    },
+    "node_modules/@narai/jira-agent-connector": {
+      "resolved": "../connectors/jira-agent-connector",
+      "link": true
+    },
+    "node_modules/@narai/notion-agent-connector": {
+      "resolved": "../connectors/notion-agent-connector",
       "link": true
     },
     "node_modules/@nodable/entities": {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,12 @@
     "@aws-sdk/client-lambda": "^3.1030.0",
     "@aws-sdk/client-rds": "^3.1030.0",
     "@aws-sdk/client-s3": "^3.1030.0",
-    "@narai/aws-agent-connector": "file:../aws-agent-connector",
-    "@narai/gcp-agent-connector": "file:../gcp-agent-connector"
+    "@narai/aws-agent-connector": "file:../connectors/aws-agent-connector",
+    "@narai/confluence-agent-connector": "file:../connectors/confluence-agent-connector",
+    "@narai/db-agent-connector": "file:../connectors/db-agent-connector",
+    "@narai/gcp-agent-connector": "file:../connectors/gcp-agent-connector",
+    "@narai/github-agent-connector": "file:../connectors/github-agent-connector",
+    "@narai/jira-agent-connector": "file:../connectors/jira-agent-connector",
+    "@narai/notion-agent-connector": "file:../connectors/notion-agent-connector"
   }
 }


### PR DESCRIPTION
> **Stacked on top of #1.** Reviewer note: this PR's diff against \`main\` will look noisy until #1 merges; review against \`feat/decommission-legacy-wrappers\` for the actual delta.

## Summary

Lands the three loose threads the v3-layer extraction left behind:

1. **Commit `mermaid_augment.{ts,js}` + tests.** SKILL.md step 7 already references it — this lands the implementation.
2. **Fix broken `file:../` paths in `package.json`.** `aws` and `gcp` were declared as `file:../<name>` (pointing at \`~/src/<name>\`, which does not exist); they actually live at \`~/src/connectors/<name>\`. Previous paths resolved to nonexistent dirs and `npm install` silently dropped the optional deps.
3. **Declare 5 missing connector deps** (confluence, jira, github, notion, db) using the now-correct \`file:../connectors/<name>\` pattern. After \`npm install\` all 7 connectors are symlinked into \`node_modules\` so \`gather()\` can resolve them via standard Node module resolution.
4. **First end-to-end seam test** (\`.claude/agents/lib/tests/gather_integration.test.ts\`): fixture a realistic \`gather()\` output for all 7 connectors plus the three failure modes (error result, non-structural action, unknown connector), pipe through \`results.map(applyMermaid)\`, assert each builtin gets a Mermaid block of the right type, errors pass through, input array is not mutated. First test that exercises step 7 end-to-end.

## What changed

| File | Change |
|---|---|
| \`.claude/agents/lib/mermaid_augment.{ts,js}\` | Now committed (was untracked WIP). Comment cleanup: removed stale wrapper-mirror language. |
| \`.claude/agents/lib/tests/mermaid_augment.test.ts\` | Now committed (was untracked WIP). |
| \`.claude/agents/lib/tests/gather_integration.test.ts\` | New end-to-end seam test (8 cases). |
| \`package.json\` | Fixed 2 broken paths, added 5 missing connector entries. |
| \`package-lock.json\` | Updated by \`npm install\`. |

After \`npm install\` (verified locally):

\`\`\`
$ ls node_modules/@narai/
aws-agent-connector -> ../../../connectors/aws-agent-connector
confluence-agent-connector -> ../../../connectors/confluence-agent-connector
connector-config
connector-hub
connector-toolkit
credential-providers
db-agent-connector -> ../../../connectors/db-agent-connector
gcp-agent-connector -> ../../../connectors/gcp-agent-connector
github-agent-connector -> ../../../connectors/github-agent-connector
jira-agent-connector -> ../../../connectors/jira-agent-connector
notion-agent-connector -> ../../../connectors/notion-agent-connector
\`\`\`

## Test plan

- [x] \`npm run typecheck\` clean
- [x] \`npm run build\` clean
- [x] \`npm test\` — **886 passed**, 5 skipped (was 878 in #1; +8 from new \`gather_integration.test.ts\`)
- [x] \`gather_integration.test.ts\` covers all 7 builtin connectors + 3 failure modes
- [x] \`npm install\` symlinks all 7 connectors into \`node_modules/@narai/\`
- [ ] Manual /wiki-ingest end-to-end against a Confluence URL (deferred to follow-up; live verification needs creds in \`~/.connectors/config.yaml\`)
- [ ] Manual /wiki-ingest end-to-end against a GitHub repo (deferred)
- [ ] Manual /wiki-ingest end-to-end against a db:// source (deferred)