### PR TITLE
Add reference consumer flow for doc-wiki

### DIFF
--- a/.claude/skills/wiki/SKILL.md
+++ b/.claude/skills/wiki/SKILL.md
@@ -101,7 +101,31 @@ Ask the user about each external source integration:
 5. "Do you use **Notion** for documentation or knowledge base?"
 6. "Do you use **GitHub** wikis, discussions, or project boards?"
 
-Enable corresponding source agents in config for each "yes" answer.
+For each "yes", record the connector ID (e.g. `jira`, `confluence`) — these go into the enabled allowlist for `consumers.doc-wiki` in Phase 4b.
+
+**Phase 4b — Set up connector access:**
+
+`/wiki-ingest` step 7 calls `gather()` from `@narai/connector-hub`, which reads `~/.connectors/config.yaml` (user-global) and `./.connectors/config.yaml` (repo overlay) to know which connectors are enabled and how to authenticate. If neither file exists yet, walk the user through creating one.
+
+1. **Check existence:**
+   ```bash
+   ls -1 ~/.connectors/config.yaml ./.connectors/config.yaml 2>/dev/null
+   ```
+
+2. **If both are missing** — bootstrap from the example:
+   - Tell the user: "Your wiki needs `~/.connectors/config.yaml` to access the external services you enabled. I'll generate a starter from `.connectors/config.example.yaml`."
+   - For each connector the user said "yes" to in Phase 4, ask one credential question:
+     - **Jira/Confluence:** "Where does your Atlassian API token live? (env var name, keychain label, or file path)"
+     - **GitHub:** "Where does your GitHub personal access token live?"
+     - **Notion:** "Where does your Notion integration token live?"
+     - **AWS:** "Use the default SDK credential chain (env / `~/.aws/credentials` / IAM role)? Or a specific profile?"
+     - **GCP:** "Use Application Default Credentials? Or a service account key file?"
+   - Compose the YAML and write it to `~/.connectors/config.yaml`. Include only the enabled connectors and a `consumers.doc-wiki` block listing them.
+   - Verify the file parses by reading it back and looking for the expected `connectors` keys (no need to invoke `loadResolvedConfig()` from a one-shot script — a bad YAML file will be obvious).
+
+3. **If at least one already exists** — just confirm the enabled connectors line up with the user's Phase 4 answers. Suggest edits if there's a gap (e.g., user said "yes Confluence" but no `confluence:` block exists). Never edit an existing config without explicit confirmation.
+
+Once the file is in place, the user's `/wiki-ingest <source>` calls will resolve credentials automatically via the connector's own credential loader — doc-wiki never reads or stores the secrets directly.
 
 **Phase 5 — Choose autonomy mode:**
 

--- a/.connectors/config.example.yaml
+++ b/.connectors/config.example.yaml
@@ -1,0 +1,110 @@
+# .connectors/config.example.yaml
+#
+# Sample configuration for @narai/connector-hub when consumed by doc-wiki.
+#
+# Copy this file to one of:
+#   ~/.connectors/config.yaml   (user-global; applies to every project)
+#   ./.connectors/config.yaml   (per-repo overlay; wins on conflict)
+#
+# Then uncomment the connectors you want enabled, fill in the credential
+# references, and run `/wiki-ingest <source>` — gather() reads this file,
+# plans which connectors to invoke based on the prompt, and dispatches
+# them in parallel.
+#
+# Credential refs follow the @narai/credential-providers syntax:
+#   env:NAME           → process.env.NAME
+#   keychain:LABEL     → OS keychain entry (macOS Keychain / libsecret)
+#   file:/path/to/key  → contents of that file (with permission check)
+#   cloud:aws-secret/<arn>      → AWS Secrets Manager
+#   cloud:gcp-secret/<resource> → GCP Secret Manager
+#
+# Every connector ships with its own README documenting the env vars it
+# expects; the entries below are the canonical names.
+
+connectors:
+
+  # github:
+  #   enabled: true
+  #   skill: github-agent-connector
+  #   token: env:GITHUB_TOKEN
+
+  # jira:
+  #   enabled: true
+  #   skill: jira-agent-connector
+  #   server_url: env:JIRA_SERVER_URL    # e.g. https://your-org.atlassian.net
+  #   email: env:JIRA_EMAIL
+  #   api_token: env:JIRA_API_TOKEN
+
+  # confluence:
+  #   enabled: true
+  #   skill: confluence-agent-connector
+  #   server_url: env:CONFLUENCE_SERVER_URL
+  #   email: env:CONFLUENCE_EMAIL
+  #   api_token: env:CONFLUENCE_API_TOKEN
+
+  # notion:
+  #   enabled: true
+  #   skill: notion-agent-connector
+  #   token: env:NOTION_TOKEN
+
+  # aws:
+  #   enabled: true
+  #   skill: aws-agent-connector
+  #   # AWS uses the standard SDK credential chain (env, ~/.aws/credentials,
+  #   # IAM role). Override here only when you need a non-default profile.
+  #   # profile: my-profile
+  #   region: env:AWS_REGION
+
+  # gcp:
+  #   enabled: true
+  #   skill: gcp-agent-connector
+  #   project_id: env:GCP_PROJECT_ID
+  #   # Application Default Credentials are picked up from the gcloud SDK;
+  #   # set GOOGLE_APPLICATION_CREDENTIALS only when ADC isn't available.
+
+  # db:
+  #   enabled: true
+  #   skill: db-agent-connector
+  #   # The db connector takes a flat env name → connection string mapping.
+  #   # Each env is a logical alias the wiki refers to (e.g. "prod", "dev").
+  #   # See @narai/db-agent-connector README for engine-specific knobs.
+  #   environments:
+  #     dev:
+  #       driver: postgresql
+  #       host: env:DB_DEV_HOST
+  #       database: env:DB_DEV_NAME
+  #       user: env:DB_DEV_USER
+  #       password: env:DB_DEV_PASSWORD
+
+
+# ── Environment overlays (optional) ─────────────────────────────────────
+#
+# `gather({ environment: "prod" })` deep-merges `environments.prod` onto
+# the connectors block above. Use this to vary per-env behaviour without
+# duplicating the whole file. `environments.default` names the fallback.
+
+environments:
+  default: dev
+  # dev:
+  #   github:
+  #     model: claude-haiku-4-5    # cheaper model in dev
+  # prod:
+  #   github:
+  #     model: claude-sonnet-4-6
+
+
+# ── Consumer overrides ──────────────────────────────────────────────────
+#
+# `gather({ consumer: "doc-wiki" })` deep-merges `consumers.doc-wiki` onto
+# the resolved config. Use this to express wiki-specific preferences
+# (e.g. narrower allowlist, smaller models) without affecting other
+# tools that share the same connectors.
+
+consumers:
+  doc-wiki:
+    # Example: doc-wiki only ingests from public sources during /wiki-ingest;
+    # disable AWS/GCP for the wiki even if they're enabled globally.
+    # aws:
+    #   enabled: false
+    # gcp:
+    #   enabled: false

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,18 @@
 
 Documentation wiki generator and maintainer. Runs entirely inside Claude Code as skills + agents + TypeScript helper scripts.
 
+## Quickstart
+
+Three slash commands take a new repo from zero to a working wiki:
+
+```
+/wiki-init         # scaffold wiki/ + wiki.config.yaml
+/wiki-onboard      # detect stack, ORM, DB; set up ~/.connectors/config.yaml
+/wiki-ingest <src> # fetch a source, compile, link, diagram, index
+```
+
+`/wiki-onboard` walks the user through configuring `@narai/connector-hub`'s `~/.connectors/config.yaml` from `.connectors/config.example.yaml` (in this repo). After that, every `/wiki-ingest <jira-url>`, `/wiki-ingest <github-repo>`, etc. routes through `gather()` to the right connector — no per-service setup needed.
+
 ## Architecture
 
 - **Main skill:** `.claude/skills/wiki/SKILL.md` — orchestrates all `/wiki-*` commands


### PR DESCRIPTION
> **Stacked on top of #2** (which is stacked on #1). Reviewer note: GitHub will show the cumulative diff against \`main\` until earlier PRs merge; review against \`feat/solidify-critical-path\` for the actual delta.

## Summary

Closes the loop on \"make doc-wiki the reference consumer for the connectors workspace\". Three additions that turn the seam into a discoverable, documented onboarding path:

1. **\`.connectors/config.example.yaml\`** — sample config showing all 7 builtin connectors with placeholder env-var refs, an \`environments\` overlay, and a \`consumers.doc-wiki\` block. Heavily commented; users copy it to \`~/.connectors/config.yaml\` (or \`./.connectors/config.yaml\` for repo-local overrides) and uncomment what they need.

2. **\`/wiki-onboard\` Phase 4b** — a new step in the SKILL.md onboarding flow that:
   - detects whether \`~/.connectors/config.yaml\` already exists
   - if missing: asks one credential question per connector the user said \"yes\" to in Phase 4, then writes a starter config from those answers
   - if present: confirms the enabled connectors line up with the user's Phase 4 answers and offers edits
   - never overwrites an existing config without explicit confirmation

3. **CLAUDE.md Quickstart** — the three-command \"fresh repo to working wiki\" recipe at the top of the project README:
   \`\`\`
   /wiki-init         # scaffold wiki/ + wiki.config.yaml
   /wiki-onboard      # detect stack, ORM, DB; set up ~/.connectors/config.yaml
   /wiki-ingest <src> # fetch a source, compile, link, diagram, index
   \`\`\`

## What changed

| File | Change |
|---|---|
| \`.connectors/config.example.yaml\` | New, ~110 lines, all 7 connectors + environments + consumer overrides |
| \`.claude/skills/wiki/SKILL.md\` | Updated Phase 4 + new Phase 4b walking through connector setup |
| \`CLAUDE.md\` | New Quickstart section at the top |

## Test plan

- [x] \`npm test\` — 886 passed, 5 skipped (unchanged from #2; this PR is docs-only)
- [x] \`.connectors/config.example.yaml\` parses as valid YAML
- [ ] Manual fresh-user dry-run: \`rm -f ~/.connectors/config.yaml\` → \`/wiki-onboard\` from a new doc-wiki checkout → confirm starter config is generated and parses
- [ ] Manual: with the generated config, \`/wiki-ingest <jira-url>\` produces a wiki page with embedded Mermaid (deferred — needs real creds)

## Out of scope

- Adding new connectors (Linear, Slack, etc.) — separate workstream; the example file shows how a custom connector would slot in via \`ecosystem.agents.custom\` in \`wiki.config.yaml\`.
- Programmatic config validation script — \`loadResolvedConfig()\` from \`@narai/connector-config\` already does this when \`gather()\` runs; a separate one-shot validator wasn't necessary.

## Stack

- #1 — decommission legacy wrappers (53 files; -5042 lines net)
- #2 — solidify critical path (6 files; +1637/-8)
- **#3 (this) — reference consumer flow** (3 files; +147/-1)