### PR TITLE
Bring PR #2 + PR #3 content onto main

### DIFF
--- a/.claude/agents/lib/mermaid_augment.js
+++ b/.claude/agents/lib/mermaid_augment.js
@@ -1,0 +1,399 @@
+import { formatErDiagram, formatGraph, } from "./mermaid_format.js";
+// ── Per-connector transformers ────────────────────────────────────────
+//
+// Each function takes the raw envelope (parsed JSON object, the same shape
+// the connector CLI prints to stdout) and returns a MermaidBlock or
+// undefined. When a connector's action set changes, update the matching
+// transformer here; this is the single site for wiki-side decoration.
+function mermaidForAws(result) {
+    if (result["status"] !== "success")
+        return undefined;
+    const action = result["action"];
+    const data = result["data"];
+    if (data === undefined)
+        return undefined;
+    if (action === "list_functions") {
+        const fns = data["functions"] ?? [];
+        if (fns.length === 0)
+            return undefined;
+        const region = data["region"] || "region";
+        const nodes = [
+            { id: `region_${region}`, label: `Region: ${region}`, shape: "rounded" },
+            ...fns.map((f) => ({
+                id: `fn_${f.name}`,
+                label: `${f.name} (${f.runtime || "unknown"})`,
+            })),
+        ];
+        const edges = fns.map((f) => ({
+            from: `region_${region}`,
+            to: `fn_${f.name}`,
+        }));
+        return formatGraph("TB", `AWS Lambda Functions — ${region}`, nodes, edges);
+    }
+    if (action === "describe_db") {
+        const region = data["region"] || "region";
+        const id = data["db_identifier"] || "db";
+        const engine = data["engine"] || "";
+        const cls = data["instance_class"] || "";
+        const label = engine || cls ? `${id} (${engine}${cls ? `, ${cls}` : ""})` : id;
+        const nodes = [
+            { id: `region_${region}`, label: `Region: ${region}`, shape: "rounded" },
+            { id: `db_${id}`, label, shape: "stadium" },
+        ];
+        const edges = [{ from: `region_${region}`, to: `db_${id}` }];
+        return formatGraph("TB", `AWS RDS — ${id}`, nodes, edges);
+    }
+    if (action === "list_buckets") {
+        const buckets = data["buckets"] ?? [];
+        if (buckets.length === 0)
+            return undefined;
+        const nodes = [
+            { id: "account", label: "AWS Account", shape: "rounded" },
+            ...buckets.map((b) => ({ id: `bucket_${b.name}`, label: b.name })),
+        ];
+        const edges = buckets.map((b) => ({
+            from: "account",
+            to: `bucket_${b.name}`,
+        }));
+        return formatGraph("TB", "AWS S3 Buckets", nodes, edges);
+    }
+    return undefined;
+}
+function mermaidForGcp(result) {
+    if (result["status"] !== "success")
+        return undefined;
+    const action = result["action"];
+    const data = result["data"];
+    if (data === undefined)
+        return undefined;
+    if (action === "list_services") {
+        const services = data["services"] ?? [];
+        if (services.length === 0)
+            return undefined;
+        const project = data["project_id"] || "project";
+        const nodes = [
+            { id: `proj_${project}`, label: `Project: ${project}`, shape: "rounded" },
+            ...services.map((s, i) => ({ id: `svc_${i}`, label: s.title || s.name })),
+        ];
+        const edges = services.map((_, i) => ({
+            from: `proj_${project}`,
+            to: `svc_${i}`,
+        }));
+        return formatGraph("TB", `GCP Services — ${project}`, nodes, edges);
+    }
+    if (action === "describe_db") {
+        const project = data["project_id"] || "project";
+        const instance = data["instance_id"] || "instance";
+        const engine = data["engine"] || "";
+        const version = data["version"] || "";
+        const label = engine || version ? `${instance} (${engine}${version ? ` ${version}` : ""})` : instance;
+        const nodes = [
+            { id: `proj_${project}`, label: `Project: ${project}`, shape: "rounded" },
+            { id: `db_${instance}`, label, shape: "stadium" },
+        ];
+        const edges = [{ from: `proj_${project}`, to: `db_${instance}` }];
+        return formatGraph("TB", `GCP Cloud SQL — ${instance}`, nodes, edges);
+    }
+    if (action === "list_topics") {
+        const topics = data["topics"] ?? [];
+        if (topics.length === 0)
+            return undefined;
+        const project = data["project_id"] || "project";
+        const nodes = [
+            { id: `proj_${project}`, label: `Project: ${project}`, shape: "rounded" },
+            ...topics.map((t, i) => ({ id: `topic_${i}`, label: t })),
+        ];
+        const edges = topics.map((_, i) => ({
+            from: `proj_${project}`,
+            to: `topic_${i}`,
+        }));
+        return formatGraph("TB", `GCP Pub/Sub Topics — ${project}`, nodes, edges);
+    }
+    return undefined;
+}
+function mermaidForJira(result) {
+    if (result["status"] !== "success")
+        return undefined;
+    if (result["action"] !== "jql_search")
+        return undefined;
+    const data = result["data"];
+    if (data === undefined)
+        return undefined;
+    const issues = data["issues"] ?? [];
+    if (issues.length === 0)
+        return undefined;
+    const byStatus = new Map();
+    for (const issue of issues) {
+        const status = (issue["status"] ?? "unknown") || "unknown";
+        let bucket = byStatus.get(status);
+        if (bucket === undefined) {
+            bucket = [];
+            byStatus.set(status, bucket);
+        }
+        bucket.push(issue);
+    }
+    const nodes = [];
+    const edges = [];
+    nodes.push({ id: "root", label: "Issues", shape: "rounded" });
+    let si = 0;
+    let ii = 0;
+    const PER_DIAGRAM_CAP = 40;
+    let drawn = 0;
+    for (const [status, bucket] of byStatus) {
+        if (drawn >= PER_DIAGRAM_CAP)
+            break;
+        const sid = `s${si++}`;
+        nodes.push({ id: sid, label: status });
+        edges.push({ from: "root", to: sid });
+        for (const issue of bucket) {
+            if (drawn >= PER_DIAGRAM_CAP)
+                break;
+            const key = issue["key"] ?? `I${ii}`;
+            const summary = (issue["summary"] ?? "").slice(0, 40);
+            const label = summary ? `${key}: ${summary}` : key;
+            const id = `i${ii++}`;
+            nodes.push({ id, label });
+            edges.push({ from: sid, to: id });
+            drawn++;
+        }
+    }
+    return formatGraph("TB", "Issue Status Tree", nodes, edges);
+}
+function mermaidForConfluence(result) {
+    if (result["status"] !== "success")
+        return undefined;
+    const action = result["action"];
+    const data = result["data"];
+    if (data === undefined)
+        return undefined;
+    if (action === "cql_search") {
+        const pages = data["pages"] ?? [];
+        if (pages.length === 0)
+            return undefined;
+        const spaceKeys = new Set(pages
+            .map((p) => p["space_key"] ?? "")
+            .filter((k) => k.length > 0));
+        const nodes = [];
+        const edges = [];
+        const capped = pages.slice(0, 30);
+        if (spaceKeys.size <= 1) {
+            const root = [...spaceKeys][0] ?? "Results";
+            nodes.push({ id: "space", label: root, shape: "rounded" });
+            for (const [i, p] of capped.entries()) {
+                const title = (p["title"] ?? `page ${i}`).slice(0, 60);
+                nodes.push({ id: `p${i}`, label: title });
+                edges.push({ from: "space", to: `p${i}` });
+            }
+        }
+        else {
+            const spaceIdx = new Map();
+            let si = 0;
+            for (const k of spaceKeys) {
+                const id = `s${si++}`;
+                spaceIdx.set(k, id);
+                nodes.push({ id, label: k, shape: "rounded" });
+            }
+            for (const [i, p] of capped.entries()) {
+                const key = p["space_key"] ?? "";
+                const parent = spaceIdx.get(key);
+                if (parent === undefined)
+                    continue;
+                const title = (p["title"] ?? `page ${i}`).slice(0, 60);
+                nodes.push({ id: `p${i}`, label: title });
+                edges.push({ from: parent, to: `p${i}` });
+            }
+        }
+        return formatGraph("TB", "Page Hierarchy", nodes, edges);
+    }
+    if (action === "get_page") {
+        const spaceKey = data["space_key"] ?? "";
+        const title = (data["title"] ?? "page").slice(0, 60);
+        if (title.length === 0)
+            return undefined;
+        const nodes = [];
+        const edges = [];
+        if (spaceKey.length > 0) {
+            nodes.push({ id: "space", label: spaceKey, shape: "rounded" });
+            nodes.push({ id: "page", label: title });
+            edges.push({ from: "space", to: "page" });
+        }
+        else {
+            nodes.push({ id: "page", label: title });
+        }
+        return formatGraph("TB", "Page Hierarchy", nodes, edges);
+    }
+    return undefined;
+}
+function mermaidForNotion(result) {
+    if (result["status"] !== "success")
+        return undefined;
+    const action = result["action"];
+    const data = result["data"];
+    if (data === undefined)
+        return undefined;
+    if (action === "search") {
+        const results = data["results"] ?? [];
+        if (results.length === 0)
+            return undefined;
+        const capped = results.slice(0, 30);
+        const nodes = [
+            { id: "root", label: "Search Results", shape: "rounded" },
+        ];
+        const edges = [];
+        for (const [i, r] of capped.entries()) {
+            const id = (r["id"] ?? `r${i}`).slice(0, 8);
+            const objType = (r["object_type"] ?? "page").slice(0, 20);
+            nodes.push({ id: `r${i}`, label: `${objType} ${id}` });
+            edges.push({ from: "root", to: `r${i}` });
+        }
+        return formatGraph("TB", "Notion Search Hierarchy", nodes, edges);
+    }
+    if (action === "query_database") {
+        const databaseId = data["database_id"] ?? "database";
+        const results = data["results"] ?? [];
+        if (results.length === 0)
+            return undefined;
+        const capped = results.slice(0, 30);
+        const dbLabel = databaseId.length > 8 ? databaseId.slice(0, 8) + "…" : databaseId;
+        const nodes = [
+            { id: "db", label: `DB ${dbLabel}`, shape: "rounded" },
+        ];
+        const edges = [];
+        for (const [i, r] of capped.entries()) {
+            const title = (r["title"] ?? `row ${i}`).slice(0, 60);
+            nodes.push({ id: `p${i}`, label: title });
+            edges.push({ from: "db", to: `p${i}` });
+        }
+        return formatGraph("TB", "Notion Page Tree", nodes, edges);
+    }
+    return undefined;
+}
+function parsePackageJsonDeps(content) {
+    try {
+        const parsed = JSON.parse(content);
+        const deps = [
+            ...Object.keys(parsed.dependencies ?? {}),
+            ...Object.keys(parsed.devDependencies ?? {}),
+        ];
+        return [...new Set(deps)];
+    }
+    catch {
+        return [];
+    }
+}
+function parseRequirementsTxt(content) {
+    const deps = [];
+    const seen = new Set();
+    for (const rawLine of content.split(/\r?\n/)) {
+        const line = rawLine.trim();
+        if (line === "" || line.startsWith("#"))
+            continue;
+        const m = line.match(/^([A-Za-z0-9_.\-]+)/);
+        if (!m)
+            continue;
+        const name = m[1];
+        if (seen.has(name))
+            continue;
+        seen.add(name);
+        deps.push(name);
+    }
+    return deps;
+}
+function mermaidForGithub(result) {
+    if (result["status"] !== "success")
+        return undefined;
+    if (result["action"] !== "get_file")
+        return undefined;
+    const data = result["data"];
+    if (data === undefined)
+        return undefined;
+    const filePath = (data["path"] ?? "").toLowerCase();
+    const content = data["content"] ?? "";
+    if (content === "")
+        return undefined;
+    let deps = [];
+    if (filePath.endsWith("package.json")) {
+        deps = parsePackageJsonDeps(content);
+    }
+    else if (filePath.endsWith("requirements.txt")) {
+        deps = parseRequirementsTxt(content);
+    }
+    if (deps.length === 0)
+        return undefined;
+    const capped = deps.slice(0, 40);
+    const rootLabel = data["path"] || "repo";
+    const nodes = [
+        { id: "root", label: rootLabel, shape: "rounded" },
+        ...capped.map((d, i) => ({ id: `dep_${i}`, label: d })),
+    ];
+    const edges = capped.map((_, i) => ({
+        from: "root",
+        to: `dep_${i}`,
+    }));
+    return formatGraph("LR", "Dependency Graph", nodes, edges);
+}
+function mermaidForDb(result) {
+    // db-agent uses `status: "ok"` instead of `success`, and emits the
+    // schema action's `tables` array at top level rather than nested in `data`.
+    if (result["status"] !== "ok")
+        return undefined;
+    const tables = result["tables"];
+    if (!Array.isArray(tables) || tables.length === 0)
+        return undefined;
+    const wrapped = tables;
+    const ermTables = wrapped.map((t) => {
+        const cols = t.columns.map((c) => {
+            const col = {
+                name: c.name,
+                type: c.data_type || "string",
+            };
+            if (c.is_primary_key)
+                col.key = "PK";
+            return col;
+        });
+        return { name: t.name, columns: cols };
+    });
+    return formatErDiagram("Database Schema", ermTables, []);
+}
+const TRANSFORMERS = {
+    aws: mermaidForAws,
+    gcp: mermaidForGcp,
+    jira: mermaidForJira,
+    confluence: mermaidForConfluence,
+    notion: mermaidForNotion,
+    github: mermaidForGithub,
+    db: mermaidForDb,
+};
+// ── Public API ────────────────────────────────────────────────────────
+/**
+ * Apply a wiki Mermaid block on top of a `DispatchResult.envelope` when the
+ * connector + action + payload qualify. Returns a fresh `DispatchResult` with
+ * the augmented envelope. Returns the input unchanged for:
+ *  - error results (no envelope to augment),
+ *  - non-object envelopes,
+ *  - unknown connector short names (no transformer registered),
+ *  - actions that don't produce diagram-worthy data.
+ *
+ * Never throws — mirrors wrappers' permissive contract.
+ */
+export function applyMermaid(result) {
+    if (result.error !== undefined)
+        return result;
+    const envelope = result.envelope;
+    if (envelope === null || typeof envelope !== "object")
+        return result;
+    const transformer = TRANSFORMERS[result.connector];
+    if (transformer === undefined)
+        return result;
+    const env = envelope;
+    const mermaid = transformer(env);
+    if (mermaid === undefined)
+        return result;
+    return {
+        ...result,
+        envelope: { ...env, mermaid },
+    };
+}
+/** Connector short names this module knows how to augment. Used by tests
+ *  and any caller that wants to filter to structural-action connectors. */
+export const SUPPORTED_CONNECTORS = new Set(Object.keys(TRANSFORMERS));

--- a/.claude/agents/lib/mermaid_augment.ts
+++ b/.claude/agents/lib/mermaid_augment.ts
@@ -1,0 +1,448 @@
+/**
+ * mermaid_augment.ts — wiki-side Mermaid augmentation for raw connector envelopes.
+ *
+ * Used by the wiki ingest pipeline (SKILL.md step 7). After
+ * `@narai/connector-hub`'s `gather()` dispatches connector CLIs in parallel
+ * and returns raw `DispatchResult` entries, this module applies the
+ * wiki-specific Mermaid diagram block (`mermaid: { type, title, code }`) on
+ * top of structural-action envelopes.
+ *
+ * Single decoration site for all 7 builtin connectors (aws, gcp, jira,
+ * confluence, notion, github, db). The legacy `wiki-<svc>-agent/scripts/*_wrapper.ts`
+ * scripts that previously held this logic were decommissioned — they only duplicated
+ * what the hub does (CLI dispatch) plus what this module does (Mermaid).
+ *
+ * Public API:
+ *   applyMermaid(result: DispatchResult): DispatchResult
+ *     - Returns a *new* `DispatchResult` whose `envelope` has been augmented
+ *       with a `mermaid` block when the connector + action + payload qualify.
+ *     - When the envelope cannot be augmented (error result, non-structural
+ *       action, empty data, unknown connector), the input is returned as-is.
+ *     - Never throws; permissive on malformed data.
+ */
+import type { DispatchResult } from "@narai/connector-hub";
+
+import {
+  formatErDiagram,
+  formatGraph,
+  type ErColumn,
+  type ErTable,
+  type GraphEdge,
+  type GraphNode,
+  type MermaidBlock,
+} from "./mermaid_format.js";
+
+// ── Per-connector transformers ────────────────────────────────────────
+//
+// Each function takes the raw envelope (parsed JSON object, the same shape
+// the connector CLI prints to stdout) and returns a MermaidBlock or
+// undefined. When a connector's action set changes, update the matching
+// transformer here; this is the single site for wiki-side decoration.
+
+function mermaidForAws(result: Record<string, unknown>): MermaidBlock | undefined {
+  if (result["status"] !== "success") return undefined;
+  const action = result["action"];
+  const data = result["data"] as Record<string, unknown> | undefined;
+  if (data === undefined) return undefined;
+
+  if (action === "list_functions") {
+    const fns =
+      (data["functions"] as Array<{ name: string; runtime: string }> | undefined) ?? [];
+    if (fns.length === 0) return undefined;
+    const region = (data["region"] as string) || "region";
+    const nodes: GraphNode[] = [
+      { id: `region_${region}`, label: `Region: ${region}`, shape: "rounded" },
+      ...fns.map((f) => ({
+        id: `fn_${f.name}`,
+        label: `${f.name} (${f.runtime || "unknown"})`,
+      })),
+    ];
+    const edges: GraphEdge[] = fns.map((f) => ({
+      from: `region_${region}`,
+      to: `fn_${f.name}`,
+    }));
+    return formatGraph("TB", `AWS Lambda Functions — ${region}`, nodes, edges);
+  }
+
+  if (action === "describe_db") {
+    const region = (data["region"] as string) || "region";
+    const id = (data["db_identifier"] as string) || "db";
+    const engine = (data["engine"] as string) || "";
+    const cls = (data["instance_class"] as string) || "";
+    const label = engine || cls ? `${id} (${engine}${cls ? `, ${cls}` : ""})` : id;
+    const nodes: GraphNode[] = [
+      { id: `region_${region}`, label: `Region: ${region}`, shape: "rounded" },
+      { id: `db_${id}`, label, shape: "stadium" },
+    ];
+    const edges: GraphEdge[] = [{ from: `region_${region}`, to: `db_${id}` }];
+    return formatGraph("TB", `AWS RDS — ${id}`, nodes, edges);
+  }
+
+  if (action === "list_buckets") {
+    const buckets = (data["buckets"] as Array<{ name: string }> | undefined) ?? [];
+    if (buckets.length === 0) return undefined;
+    const nodes: GraphNode[] = [
+      { id: "account", label: "AWS Account", shape: "rounded" },
+      ...buckets.map((b) => ({ id: `bucket_${b.name}`, label: b.name })),
+    ];
+    const edges: GraphEdge[] = buckets.map((b) => ({
+      from: "account",
+      to: `bucket_${b.name}`,
+    }));
+    return formatGraph("TB", "AWS S3 Buckets", nodes, edges);
+  }
+
+  return undefined;
+}
+
+function mermaidForGcp(result: Record<string, unknown>): MermaidBlock | undefined {
+  if (result["status"] !== "success") return undefined;
+  const action = result["action"];
+  const data = result["data"] as Record<string, unknown> | undefined;
+  if (data === undefined) return undefined;
+
+  if (action === "list_services") {
+    const services =
+      (data["services"] as Array<{ name: string; title: string }> | undefined) ?? [];
+    if (services.length === 0) return undefined;
+    const project = (data["project_id"] as string) || "project";
+    const nodes: GraphNode[] = [
+      { id: `proj_${project}`, label: `Project: ${project}`, shape: "rounded" },
+      ...services.map((s, i) => ({ id: `svc_${i}`, label: s.title || s.name })),
+    ];
+    const edges: GraphEdge[] = services.map((_, i) => ({
+      from: `proj_${project}`,
+      to: `svc_${i}`,
+    }));
+    return formatGraph("TB", `GCP Services — ${project}`, nodes, edges);
+  }
+
+  if (action === "describe_db") {
+    const project = (data["project_id"] as string) || "project";
+    const instance = (data["instance_id"] as string) || "instance";
+    const engine = (data["engine"] as string) || "";
+    const version = (data["version"] as string) || "";
+    const label = engine || version ? `${instance} (${engine}${version ? ` ${version}` : ""})` : instance;
+    const nodes: GraphNode[] = [
+      { id: `proj_${project}`, label: `Project: ${project}`, shape: "rounded" },
+      { id: `db_${instance}`, label, shape: "stadium" },
+    ];
+    const edges: GraphEdge[] = [{ from: `proj_${project}`, to: `db_${instance}` }];
+    return formatGraph("TB", `GCP Cloud SQL — ${instance}`, nodes, edges);
+  }
+
+  if (action === "list_topics") {
+    const topics = (data["topics"] as string[] | undefined) ?? [];
+    if (topics.length === 0) return undefined;
+    const project = (data["project_id"] as string) || "project";
+    const nodes: GraphNode[] = [
+      { id: `proj_${project}`, label: `Project: ${project}`, shape: "rounded" },
+      ...topics.map((t, i) => ({ id: `topic_${i}`, label: t })),
+    ];
+    const edges: GraphEdge[] = topics.map((_, i) => ({
+      from: `proj_${project}`,
+      to: `topic_${i}`,
+    }));
+    return formatGraph("TB", `GCP Pub/Sub Topics — ${project}`, nodes, edges);
+  }
+
+  return undefined;
+}
+
+function mermaidForJira(result: Record<string, unknown>): MermaidBlock | undefined {
+  if (result["status"] !== "success") return undefined;
+  if (result["action"] !== "jql_search") return undefined;
+  const data = result["data"] as Record<string, unknown> | undefined;
+  if (data === undefined) return undefined;
+  const issues =
+    (data["issues"] as Array<Record<string, unknown>> | undefined) ?? [];
+  if (issues.length === 0) return undefined;
+
+  const byStatus = new Map<string, Array<Record<string, unknown>>>();
+  for (const issue of issues) {
+    const status = ((issue["status"] as string | undefined) ?? "unknown") || "unknown";
+    let bucket = byStatus.get(status);
+    if (bucket === undefined) {
+      bucket = [];
+      byStatus.set(status, bucket);
+    }
+    bucket.push(issue);
+  }
+
+  const nodes: GraphNode[] = [];
+  const edges: GraphEdge[] = [];
+  nodes.push({ id: "root", label: "Issues", shape: "rounded" });
+  let si = 0;
+  let ii = 0;
+  const PER_DIAGRAM_CAP = 40;
+  let drawn = 0;
+  for (const [status, bucket] of byStatus) {
+    if (drawn >= PER_DIAGRAM_CAP) break;
+    const sid = `s${si++}`;
+    nodes.push({ id: sid, label: status });
+    edges.push({ from: "root", to: sid });
+    for (const issue of bucket) {
+      if (drawn >= PER_DIAGRAM_CAP) break;
+      const key = (issue["key"] as string | undefined) ?? `I${ii}`;
+      const summary = ((issue["summary"] as string | undefined) ?? "").slice(0, 40);
+      const label = summary ? `${key}: ${summary}` : key;
+      const id = `i${ii++}`;
+      nodes.push({ id, label });
+      edges.push({ from: sid, to: id });
+      drawn++;
+    }
+  }
+  return formatGraph("TB", "Issue Status Tree", nodes, edges);
+}
+
+function mermaidForConfluence(result: Record<string, unknown>): MermaidBlock | undefined {
+  if (result["status"] !== "success") return undefined;
+  const action = result["action"];
+  const data = result["data"] as Record<string, unknown> | undefined;
+  if (data === undefined) return undefined;
+
+  if (action === "cql_search") {
+    const pages = (data["pages"] as Array<Record<string, unknown>> | undefined) ?? [];
+    if (pages.length === 0) return undefined;
+    const spaceKeys = new Set(
+      pages
+        .map((p) => (p["space_key"] as string | undefined) ?? "")
+        .filter((k) => k.length > 0),
+    );
+    const nodes: GraphNode[] = [];
+    const edges: GraphEdge[] = [];
+    const capped = pages.slice(0, 30);
+    if (spaceKeys.size <= 1) {
+      const root = [...spaceKeys][0] ?? "Results";
+      nodes.push({ id: "space", label: root, shape: "rounded" });
+      for (const [i, p] of capped.entries()) {
+        const title = ((p["title"] as string | undefined) ?? `page ${i}`).slice(0, 60);
+        nodes.push({ id: `p${i}`, label: title });
+        edges.push({ from: "space", to: `p${i}` });
+      }
+    } else {
+      const spaceIdx = new Map<string, string>();
+      let si = 0;
+      for (const k of spaceKeys) {
+        const id = `s${si++}`;
+        spaceIdx.set(k, id);
+        nodes.push({ id, label: k, shape: "rounded" });
+      }
+      for (const [i, p] of capped.entries()) {
+        const key = (p["space_key"] as string | undefined) ?? "";
+        const parent = spaceIdx.get(key);
+        if (parent === undefined) continue;
+        const title = ((p["title"] as string | undefined) ?? `page ${i}`).slice(0, 60);
+        nodes.push({ id: `p${i}`, label: title });
+        edges.push({ from: parent, to: `p${i}` });
+      }
+    }
+    return formatGraph("TB", "Page Hierarchy", nodes, edges);
+  }
+
+  if (action === "get_page") {
+    const spaceKey = (data["space_key"] as string | undefined) ?? "";
+    const title = ((data["title"] as string | undefined) ?? "page").slice(0, 60);
+    if (title.length === 0) return undefined;
+    const nodes: GraphNode[] = [];
+    const edges: GraphEdge[] = [];
+    if (spaceKey.length > 0) {
+      nodes.push({ id: "space", label: spaceKey, shape: "rounded" });
+      nodes.push({ id: "page", label: title });
+      edges.push({ from: "space", to: "page" });
+    } else {
+      nodes.push({ id: "page", label: title });
+    }
+    return formatGraph("TB", "Page Hierarchy", nodes, edges);
+  }
+
+  return undefined;
+}
+
+function mermaidForNotion(result: Record<string, unknown>): MermaidBlock | undefined {
+  if (result["status"] !== "success") return undefined;
+  const action = result["action"];
+  const data = result["data"] as Record<string, unknown> | undefined;
+  if (data === undefined) return undefined;
+
+  if (action === "search") {
+    const results = (data["results"] as Array<Record<string, unknown>> | undefined) ?? [];
+    if (results.length === 0) return undefined;
+    const capped = results.slice(0, 30);
+    const nodes: GraphNode[] = [
+      { id: "root", label: "Search Results", shape: "rounded" },
+    ];
+    const edges: GraphEdge[] = [];
+    for (const [i, r] of capped.entries()) {
+      const id = ((r["id"] as string | undefined) ?? `r${i}`).slice(0, 8);
+      const objType = ((r["object_type"] as string | undefined) ?? "page").slice(0, 20);
+      nodes.push({ id: `r${i}`, label: `${objType} ${id}` });
+      edges.push({ from: "root", to: `r${i}` });
+    }
+    return formatGraph("TB", "Notion Search Hierarchy", nodes, edges);
+  }
+
+  if (action === "query_database") {
+    const databaseId = (data["database_id"] as string | undefined) ?? "database";
+    const results = (data["results"] as Array<Record<string, unknown>> | undefined) ?? [];
+    if (results.length === 0) return undefined;
+    const capped = results.slice(0, 30);
+    const dbLabel = databaseId.length > 8 ? databaseId.slice(0, 8) + "…" : databaseId;
+    const nodes: GraphNode[] = [
+      { id: "db", label: `DB ${dbLabel}`, shape: "rounded" },
+    ];
+    const edges: GraphEdge[] = [];
+    for (const [i, r] of capped.entries()) {
+      const title = ((r["title"] as string | undefined) ?? `row ${i}`).slice(0, 60);
+      nodes.push({ id: `p${i}`, label: title });
+      edges.push({ from: "db", to: `p${i}` });
+    }
+    return formatGraph("TB", "Notion Page Tree", nodes, edges);
+  }
+
+  return undefined;
+}
+
+function parsePackageJsonDeps(content: string): string[] {
+  try {
+    const parsed = JSON.parse(content) as {
+      dependencies?: Record<string, unknown>;
+      devDependencies?: Record<string, unknown>;
+    };
+    const deps = [
+      ...Object.keys(parsed.dependencies ?? {}),
+      ...Object.keys(parsed.devDependencies ?? {}),
+    ];
+    return [...new Set(deps)];
+  } catch {
+    return [];
+  }
+}
+
+function parseRequirementsTxt(content: string): string[] {
+  const deps: string[] = [];
+  const seen = new Set<string>();
+  for (const rawLine of content.split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (line === "" || line.startsWith("#")) continue;
+    const m = line.match(/^([A-Za-z0-9_.\-]+)/);
+    if (!m) continue;
+    const name = m[1]!;
+    if (seen.has(name)) continue;
+    seen.add(name);
+    deps.push(name);
+  }
+  return deps;
+}
+
+function mermaidForGithub(result: Record<string, unknown>): MermaidBlock | undefined {
+  if (result["status"] !== "success") return undefined;
+  if (result["action"] !== "get_file") return undefined;
+  const data = result["data"] as Record<string, unknown> | undefined;
+  if (data === undefined) return undefined;
+
+  const filePath = ((data["path"] as string) ?? "").toLowerCase();
+  const content = (data["content"] as string) ?? "";
+  if (content === "") return undefined;
+
+  let deps: string[] = [];
+  if (filePath.endsWith("package.json")) {
+    deps = parsePackageJsonDeps(content);
+  } else if (filePath.endsWith("requirements.txt")) {
+    deps = parseRequirementsTxt(content);
+  }
+
+  if (deps.length === 0) return undefined;
+  const capped = deps.slice(0, 40);
+  const rootLabel = (data["path"] as string) || "repo";
+  const nodes: GraphNode[] = [
+    { id: "root", label: rootLabel, shape: "rounded" },
+    ...capped.map((d, i) => ({ id: `dep_${i}`, label: d })),
+  ];
+  const edges: GraphEdge[] = capped.map((_, i) => ({
+    from: "root",
+    to: `dep_${i}`,
+  }));
+  return formatGraph("LR", "Dependency Graph", nodes, edges);
+}
+
+interface DbWrapperTable {
+  name: string;
+  columns: Array<{
+    name: string;
+    data_type?: string;
+    is_primary_key?: boolean;
+  }>;
+}
+
+function mermaidForDb(result: Record<string, unknown>): MermaidBlock | undefined {
+  // db-agent uses `status: "ok"` instead of `success`, and emits the
+  // schema action's `tables` array at top level rather than nested in `data`.
+  if (result["status"] !== "ok") return undefined;
+  const tables = result["tables"];
+  if (!Array.isArray(tables) || tables.length === 0) return undefined;
+  const wrapped = tables as DbWrapperTable[];
+  const ermTables: ErTable[] = wrapped.map((t) => {
+    const cols: ErColumn[] = t.columns.map((c) => {
+      const col: ErColumn = {
+        name: c.name,
+        type: c.data_type || "string",
+      };
+      if (c.is_primary_key) col.key = "PK";
+      return col;
+    });
+    return { name: t.name, columns: cols };
+  });
+  return formatErDiagram("Database Schema", ermTables, []);
+}
+
+// ── Dispatch table ────────────────────────────────────────────────────
+
+type Transformer = (envelope: Record<string, unknown>) => MermaidBlock | undefined;
+
+const TRANSFORMERS: Record<string, Transformer> = {
+  aws: mermaidForAws,
+  gcp: mermaidForGcp,
+  jira: mermaidForJira,
+  confluence: mermaidForConfluence,
+  notion: mermaidForNotion,
+  github: mermaidForGithub,
+  db: mermaidForDb,
+};
+
+// ── Public API ────────────────────────────────────────────────────────
+
+/**
+ * Apply a wiki Mermaid block on top of a `DispatchResult.envelope` when the
+ * connector + action + payload qualify. Returns a fresh `DispatchResult` with
+ * the augmented envelope. Returns the input unchanged for:
+ *  - error results (no envelope to augment),
+ *  - non-object envelopes,
+ *  - unknown connector short names (no transformer registered),
+ *  - actions that don't produce diagram-worthy data.
+ *
+ * Never throws — mirrors wrappers' permissive contract.
+ */
+export function applyMermaid(result: DispatchResult): DispatchResult {
+  if (result.error !== undefined) return result;
+  const envelope = result.envelope;
+  if (envelope === null || typeof envelope !== "object") return result;
+
+  const transformer = TRANSFORMERS[result.connector];
+  if (transformer === undefined) return result;
+
+  const env = envelope as Record<string, unknown>;
+  const mermaid = transformer(env);
+  if (mermaid === undefined) return result;
+
+  return {
+    ...result,
+    envelope: { ...env, mermaid },
+  };
+}
+
+/** Connector short names this module knows how to augment. Used by tests
+ *  and any caller that wants to filter to structural-action connectors. */
+export const SUPPORTED_CONNECTORS: ReadonlySet<string> = new Set(
+  Object.keys(TRANSFORMERS),
+);

--- a/.claude/agents/lib/tests/gather_integration.test.ts
+++ b/.claude/agents/lib/tests/gather_integration.test.ts
@@ -1,0 +1,292 @@
+/**
+ * Tests the seam between @narai/connector-hub's `gather()` and the wiki-side
+ * `applyMermaid()` decoration. Step 7 of /wiki-ingest depends on this contract:
+ *
+ *   const { results } = await gather({ prompt, consumer: "doc-wiki" });
+ *   const augmented = results.map(applyMermaid);
+ *
+ * This test fixtures the `gather()` output for all 7 builtin connectors plus
+ * the failure modes the hub emits (error, non-structural action, malformed
+ * envelope) and asserts that `applyMermaid` produces the shape `mermaid_inject.js`
+ * (step 9) consumes — i.e. either an envelope with a `mermaid: { type, title, code }`
+ * field, or a passthrough.
+ *
+ * Direct unit coverage of each transformer lives in `mermaid_augment.test.ts`.
+ * This file covers the orchestration: `results.map(applyMermaid)` over a
+ * realistic mixed batch.
+ */
+import { describe, expect, it } from "vitest";
+import type { DispatchResult } from "@narai/connector-hub";
+
+import { applyMermaid, SUPPORTED_CONNECTORS } from "../mermaid_augment.js";
+
+// ── Fixtures: a realistic gather() output ────────────────────────────
+
+/**
+ * One DispatchResult per builtin connector, plus three failure shapes.
+ * Models the hub's actual return shape (per @narai/connector-hub README):
+ *   { step, connector, action, params, envelope?, error? }
+ */
+function fakeGatherOutput(): DispatchResult[] {
+  return [
+    // 1. AWS — list_functions (structural, should get mermaid)
+    {
+      step: 0,
+      connector: "aws",
+      action: "list_functions",
+      params: { region: "us-east-1" },
+      envelope: {
+        status: "success",
+        action: "list_functions",
+        data: {
+          region: "us-east-1",
+          functions: [
+            { name: "ingest-handler", runtime: "nodejs20.x" },
+            { name: "transform-handler", runtime: "nodejs20.x" },
+          ],
+        },
+      },
+    },
+    // 2. GCP — list_services (structural, should get mermaid)
+    {
+      step: 1,
+      connector: "gcp",
+      action: "list_services",
+      params: { project_id: "my-proj" },
+      envelope: {
+        status: "success",
+        action: "list_services",
+        data: {
+          project_id: "my-proj",
+          services: [
+            { name: "api-gateway", title: "API Gateway" },
+            { name: "worker-pool", title: "Worker Pool" },
+          ],
+        },
+      },
+    },
+    // 3. Jira — jql_search (structural, should get mermaid)
+    {
+      step: 2,
+      connector: "jira",
+      action: "jql_search",
+      params: { jql: "project = AUTH" },
+      envelope: {
+        status: "success",
+        action: "jql_search",
+        data: {
+          issues: [
+            { key: "AUTH-1", status: "Done", summary: "Login flow" },
+            { key: "AUTH-2", status: "In Progress", summary: "MFA" },
+          ],
+        },
+      },
+    },
+    // 4. Confluence — cql_search (structural, should get mermaid)
+    {
+      step: 3,
+      connector: "confluence",
+      action: "cql_search",
+      params: { cql: "space = ARCH" },
+      envelope: {
+        status: "success",
+        action: "cql_search",
+        data: {
+          pages: [
+            { space_key: "ARCH", title: "Architecture overview" },
+            { space_key: "ARCH", title: "Auth design" },
+          ],
+        },
+      },
+    },
+    // 5. Notion — search (structural, should get mermaid)
+    {
+      step: 4,
+      connector: "notion",
+      action: "search",
+      params: { query: "auth" },
+      envelope: {
+        status: "success",
+        action: "search",
+        data: {
+          results: [
+            { id: "page-1", object_type: "page" },
+            { id: "page-2", object_type: "page" },
+          ],
+        },
+      },
+    },
+    // 6. GitHub — get_file (structural for package.json, should get mermaid)
+    {
+      step: 5,
+      connector: "github",
+      action: "get_file",
+      params: { owner: "acme", repo: "svc", path: "package.json" },
+      envelope: {
+        status: "success",
+        action: "get_file",
+        data: {
+          path: "package.json",
+          content: JSON.stringify({
+            name: "svc",
+            dependencies: { express: "^4.0.0", pg: "^8.0.0" },
+          }),
+        },
+      },
+    },
+    // 7. DB — schema (erDiagram path; db-agent envelope uses status:"ok" + top-level tables)
+    {
+      step: 6,
+      connector: "db",
+      action: "schema",
+      params: { env: "dev" },
+      envelope: {
+        status: "ok",
+        tables: [
+          {
+            name: "users",
+            columns: [
+              { name: "id", data_type: "uuid", is_primary_key: true },
+              { name: "email", data_type: "varchar" },
+            ],
+          },
+          {
+            name: "sessions",
+            columns: [
+              { name: "id", data_type: "uuid", is_primary_key: true },
+              { name: "user_id", data_type: "uuid" },
+            ],
+          },
+        ],
+      },
+    },
+    // Failure shapes the hub can emit:
+
+    // 8. Error result (planner failure / spawn failure / non-JSON stdout)
+    {
+      step: 7,
+      connector: "github",
+      action: "search_code",
+      params: { q: "broken-token" },
+      error: { code: "AUTH_ERROR", message: "Invalid GitHub token" },
+    },
+    // 9. Non-structural action (success but applyMermaid should skip)
+    {
+      step: 8,
+      connector: "github",
+      action: "search_code",
+      params: { q: "TODO" },
+      envelope: {
+        status: "success",
+        action: "search_code",
+        data: { results: [{ path: "src/x.ts" }] },
+      },
+    },
+    // 10. Unknown connector (custom from wiki.config.yaml; applyMermaid passthrough)
+    {
+      step: 9,
+      connector: "linear",
+      action: "list_issues",
+      params: {},
+      envelope: { status: "success", action: "list_issues", data: { issues: [] } },
+    },
+  ];
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────
+
+describe("gather() → applyMermaid() seam", () => {
+  it("covers all 7 builtin connectors in the SUPPORTED_CONNECTORS set", () => {
+    const fixture = fakeGatherOutput();
+    const builtinHits = fixture
+      .map((r) => r.connector)
+      .filter((c) => SUPPORTED_CONNECTORS.has(c));
+    // Each of the 7 builtin connectors appears at least once in the fixture
+    expect(new Set(builtinHits)).toEqual(
+      new Set(["aws", "gcp", "jira", "confluence", "notion", "github", "db"]),
+    );
+  });
+
+  it("attaches mermaid to all 7 structural connector results", () => {
+    const fixture = fakeGatherOutput();
+    const augmented = fixture.map(applyMermaid);
+
+    // The first 7 are structural-action successes — each must have mermaid
+    for (const i of [0, 1, 2, 3, 4, 5, 6]) {
+      const env = augmented[i]!.envelope as Record<string, unknown>;
+      const mermaid = env["mermaid"] as { type?: string; title?: string; code?: string } | undefined;
+      expect(mermaid, `step ${i} (${augmented[i]!.connector}) should have mermaid`).toBeDefined();
+      expect(typeof mermaid!.type).toBe("string");
+      expect(typeof mermaid!.title).toBe("string");
+      expect(typeof mermaid!.code).toBe("string");
+      expect(mermaid!.code!.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("uses erDiagram for db, graph LR for github get_file, graph TB for the rest", () => {
+    const augmented = fakeGatherOutput().map(applyMermaid);
+
+    const typeOf = (idx: number): string | undefined => {
+      const env = augmented[idx]!.envelope as Record<string, unknown>;
+      const mermaid = env["mermaid"] as { type?: string } | undefined;
+      return mermaid?.type;
+    };
+
+    expect(typeOf(0)).toBe("graph TB"); // aws
+    expect(typeOf(1)).toBe("graph TB"); // gcp
+    expect(typeOf(2)).toBe("graph TB"); // jira
+    expect(typeOf(3)).toBe("graph TB"); // confluence
+    expect(typeOf(4)).toBe("graph TB"); // notion
+    expect(typeOf(5)).toBe("graph LR"); // github get_file
+    expect(typeOf(6)).toBe("erDiagram"); // db schema
+  });
+
+  it("passes error results through unchanged", () => {
+    const fixture = fakeGatherOutput();
+    const augmented = fixture.map(applyMermaid);
+
+    const errorResult = augmented[7]!;
+    expect(errorResult).toBe(fixture[7]); // identity — input returned as-is
+    expect(errorResult.error).toEqual({ code: "AUTH_ERROR", message: "Invalid GitHub token" });
+    expect(errorResult.envelope).toBeUndefined();
+  });
+
+  it("leaves non-structural successful envelopes untouched", () => {
+    const fixture = fakeGatherOutput();
+    const augmented = fixture.map(applyMermaid);
+
+    // GitHub search_code is not a structural action — applyMermaid skips it
+    const nonStructural = augmented[8]!;
+    const env = nonStructural.envelope as Record<string, unknown>;
+    expect(env["mermaid"]).toBeUndefined();
+  });
+
+  it("passes unknown-connector envelopes through (custom registry agents)", () => {
+    const fixture = fakeGatherOutput();
+    const augmented = fixture.map(applyMermaid);
+
+    const custom = augmented[9]!;
+    expect(custom.connector).toBe("linear");
+    const env = custom.envelope as Record<string, unknown>;
+    expect(env["mermaid"]).toBeUndefined();
+  });
+
+  it("preserves step / connector / action / params on every entry", () => {
+    const fixture = fakeGatherOutput();
+    const augmented = fixture.map(applyMermaid);
+
+    for (let i = 0; i < fixture.length; i++) {
+      expect(augmented[i]!.step).toBe(fixture[i]!.step);
+      expect(augmented[i]!.connector).toBe(fixture[i]!.connector);
+      expect(augmented[i]!.action).toBe(fixture[i]!.action);
+      expect(augmented[i]!.params).toEqual(fixture[i]!.params);
+    }
+  });
+
+  it("does not mutate the input array or its entries", () => {
+    const fixture = fakeGatherOutput();
+    const beforeJson = JSON.stringify(fixture);
+    fixture.map(applyMermaid);
+    expect(JSON.stringify(fixture)).toBe(beforeJson);
+  });
+});

--- a/.claude/agents/lib/tests/mermaid_augment.test.ts
+++ b/.claude/agents/lib/tests/mermaid_augment.test.ts
@@ -1,0 +1,270 @@
+/**
+ * Tests for mermaid_augment.ts — apply Mermaid blocks to raw connector envelopes
+ * returned by `@narai/connector-hub`'s `gather()`.
+ *
+ * Each describe block covers one connector short name. We assert:
+ *  - happy path: a structural envelope gets a `mermaid: { type, title, code }`
+ *    field attached that matches the wrapper's diagram type.
+ *  - skip path: empty data (or a non-structural action) leaves the envelope
+ *    unchanged.
+ */
+import { describe, expect, it } from "vitest";
+import type { DispatchResult } from "@narai/connector-hub";
+
+import {
+  SUPPORTED_CONNECTORS,
+  applyMermaid,
+} from "../mermaid_augment.js";
+
+function makeResult(connector: string, envelope: unknown, action = "x"): DispatchResult {
+  return {
+    step: 0,
+    connector,
+    action,
+    params: {},
+    envelope,
+  };
+}
+
+describe("applyMermaid — passthrough cases", () => {
+  it("returns input unchanged when result has an error", () => {
+    const input: DispatchResult = {
+      step: 0,
+      connector: "aws",
+      action: "list_functions",
+      params: {},
+      error: { code: "X", message: "y" },
+    };
+    expect(applyMermaid(input)).toBe(input);
+  });
+
+  it("returns input unchanged for an unknown connector", () => {
+    const input = makeResult("unknown-svc", {
+      status: "success",
+      action: "list_functions",
+      data: { functions: [] },
+    });
+    expect(applyMermaid(input)).toBe(input);
+  });
+
+  it("returns input unchanged for a non-object envelope", () => {
+    const input = makeResult("aws", "raw-string");
+    expect(applyMermaid(input)).toBe(input);
+  });
+
+  it("returns input unchanged when transformer rejects (status != success)", () => {
+    const input = makeResult("aws", {
+      status: "error",
+      action: "list_functions",
+      data: { functions: [{ name: "f", runtime: "nodejs20.x" }] },
+    });
+    expect(applyMermaid(input)).toBe(input);
+  });
+});
+
+describe("applyMermaid — aws", () => {
+  it("attaches a graph TB diagram for list_functions", () => {
+    const out = applyMermaid(
+      makeResult("aws", {
+        status: "success",
+        action: "list_functions",
+        data: {
+          region: "us-east-1",
+          functions: [{ name: "fn1", runtime: "nodejs20.x" }],
+        },
+      }),
+    );
+    const env = out.envelope as Record<string, unknown>;
+    expect(env["mermaid"]).toMatchObject({
+      type: "graph TB",
+      title: "AWS Lambda Functions — us-east-1",
+    });
+  });
+
+  it("skips when functions list is empty", () => {
+    const input = makeResult("aws", {
+      status: "success",
+      action: "list_functions",
+      data: { region: "us-east-1", functions: [] },
+    });
+    expect(applyMermaid(input)).toBe(input);
+  });
+});
+
+describe("applyMermaid — gcp", () => {
+  it("attaches a graph TB diagram for list_services", () => {
+    const out = applyMermaid(
+      makeResult("gcp", {
+        status: "success",
+        action: "list_services",
+        data: {
+          project_id: "p1",
+          services: [{ name: "svc1.googleapis.com", title: "Service One" }],
+        },
+      }),
+    );
+    const env = out.envelope as Record<string, unknown>;
+    expect(env["mermaid"]).toMatchObject({
+      type: "graph TB",
+      title: "GCP Services — p1",
+    });
+  });
+});
+
+describe("applyMermaid — jira", () => {
+  it("groups issues by status under a root node", () => {
+    const out = applyMermaid(
+      makeResult("jira", {
+        status: "success",
+        action: "jql_search",
+        data: {
+          issues: [
+            { key: "AUTH-1", status: "Open", summary: "Login broken" },
+            { key: "AUTH-2", status: "Done", summary: "Add 2FA" },
+          ],
+        },
+      }),
+    );
+    const env = out.envelope as Record<string, unknown>;
+    expect(env["mermaid"]).toMatchObject({
+      type: "graph TB",
+      title: "Issue Status Tree",
+    });
+    const code = (env["mermaid"] as Record<string, unknown>)["code"] as string;
+    expect(code).toContain("AUTH-1");
+    expect(code).toContain("Open");
+  });
+
+  it("skips when issues list is empty", () => {
+    const input = makeResult("jira", {
+      status: "success",
+      action: "jql_search",
+      data: { issues: [] },
+    });
+    expect(applyMermaid(input)).toBe(input);
+  });
+});
+
+describe("applyMermaid — confluence", () => {
+  it("attaches a page-hierarchy diagram for cql_search", () => {
+    const out = applyMermaid(
+      makeResult("confluence", {
+        status: "success",
+        action: "cql_search",
+        data: {
+          pages: [
+            { title: "Page 1", space_key: "DEV" },
+            { title: "Page 2", space_key: "DEV" },
+          ],
+        },
+      }),
+    );
+    const env = out.envelope as Record<string, unknown>;
+    expect(env["mermaid"]).toMatchObject({
+      type: "graph TB",
+      title: "Page Hierarchy",
+    });
+  });
+});
+
+describe("applyMermaid — notion", () => {
+  it("attaches a search-hierarchy diagram for search", () => {
+    const out = applyMermaid(
+      makeResult("notion", {
+        status: "success",
+        action: "search",
+        data: {
+          results: [{ id: "abcd1234", object_type: "page" }],
+        },
+      }),
+    );
+    const env = out.envelope as Record<string, unknown>;
+    expect(env["mermaid"]).toMatchObject({
+      type: "graph TB",
+      title: "Notion Search Hierarchy",
+    });
+  });
+});
+
+describe("applyMermaid — github", () => {
+  it("attaches a dependency graph for package.json content", () => {
+    const out = applyMermaid(
+      makeResult("github", {
+        status: "success",
+        action: "get_file",
+        data: {
+          path: "package.json",
+          content: JSON.stringify({
+            dependencies: { vitest: "^3" },
+            devDependencies: { typescript: "^5" },
+          }),
+        },
+      }),
+    );
+    const env = out.envelope as Record<string, unknown>;
+    expect(env["mermaid"]).toMatchObject({
+      type: "graph LR",
+      title: "Dependency Graph",
+    });
+    const code = (env["mermaid"] as Record<string, unknown>)["code"] as string;
+    expect(code).toContain("vitest");
+    expect(code).toContain("typescript");
+  });
+
+  it("skips when path is unknown extension", () => {
+    const input = makeResult("github", {
+      status: "success",
+      action: "get_file",
+      data: { path: "README.md", content: "# hi" },
+    });
+    expect(applyMermaid(input)).toBe(input);
+  });
+});
+
+describe("applyMermaid — db", () => {
+  it("attaches an erDiagram for status=ok schema results", () => {
+    const out = applyMermaid(
+      makeResult("db", {
+        status: "ok",
+        tables: [
+          {
+            name: "users",
+            columns: [
+              { name: "id", data_type: "int", is_primary_key: true },
+              { name: "email", data_type: "text" },
+            ],
+          },
+        ],
+      }),
+    );
+    const env = out.envelope as Record<string, unknown>;
+    expect(env["mermaid"]).toMatchObject({
+      type: "erDiagram",
+      title: "Database Schema",
+    });
+    const code = (env["mermaid"] as Record<string, unknown>)["code"] as string;
+    expect(code).toContain("users");
+    expect(code).toContain("id PK");
+  });
+
+  it("skips when tables array is empty", () => {
+    const input = makeResult("db", { status: "ok", tables: [] });
+    expect(applyMermaid(input)).toBe(input);
+  });
+
+  it("skips when status is not ok", () => {
+    const input = makeResult("db", {
+      status: "denied",
+      tables: [{ name: "users", columns: [] }],
+    });
+    expect(applyMermaid(input)).toBe(input);
+  });
+});
+
+describe("SUPPORTED_CONNECTORS", () => {
+  it("includes all 7 wiki source/database connector short names", () => {
+    expect(new Set(SUPPORTED_CONNECTORS)).toEqual(
+      new Set(["aws", "gcp", "jira", "confluence", "notion", "github", "db"]),
+    );
+  });
+});

--- a/.claude/skills/wiki/SKILL.md
+++ b/.claude/skills/wiki/SKILL.md
@@ -101,7 +101,31 @@ Ask the user about each external source integration:
 5. "Do you use **Notion** for documentation or knowledge base?"
 6. "Do you use **GitHub** wikis, discussions, or project boards?"
 
-Enable corresponding source agents in config for each "yes" answer.
+For each "yes", record the connector ID (e.g. `jira`, `confluence`) — these go into the enabled allowlist for `consumers.doc-wiki` in Phase 4b.
+
+**Phase 4b — Set up connector access:**
+
+`/wiki-ingest` step 7 calls `gather()` from `@narai/connector-hub`, which reads `~/.connectors/config.yaml` (user-global) and `./.connectors/config.yaml` (repo overlay) to know which connectors are enabled and how to authenticate. If neither file exists yet, walk the user through creating one.
+
+1. **Check existence:**
+   ```bash
+   ls -1 ~/.connectors/config.yaml ./.connectors/config.yaml 2>/dev/null
+   ```
+
+2. **If both are missing** — bootstrap from the example:
+   - Tell the user: "Your wiki needs `~/.connectors/config.yaml` to access the external services you enabled. I'll generate a starter from `.connectors/config.example.yaml`."
+   - For each connector the user said "yes" to in Phase 4, ask one credential question:
+     - **Jira/Confluence:** "Where does your Atlassian API token live? (env var name, keychain label, or file path)"
+     - **GitHub:** "Where does your GitHub personal access token live?"
+     - **Notion:** "Where does your Notion integration token live?"
+     - **AWS:** "Use the default SDK credential chain (env / `~/.aws/credentials` / IAM role)? Or a specific profile?"
+     - **GCP:** "Use Application Default Credentials? Or a service account key file?"
+   - Compose the YAML and write it to `~/.connectors/config.yaml`. Include only the enabled connectors and a `consumers.doc-wiki` block listing them.
+   - Verify the file parses by reading it back and looking for the expected `connectors` keys (no need to invoke `loadResolvedConfig()` from a one-shot script — a bad YAML file will be obvious).
+
+3. **If at least one already exists** — just confirm the enabled connectors line up with the user's Phase 4 answers. Suggest edits if there's a gap (e.g., user said "yes Confluence" but no `confluence:` block exists). Never edit an existing config without explicit confirmation.
+
+Once the file is in place, the user's `/wiki-ingest <source>` calls will resolve credentials automatically via the connector's own credential loader — doc-wiki never reads or stores the secrets directly.
 
 **Phase 5 — Choose autonomy mode:**
 

--- a/.connectors/config.example.yaml
+++ b/.connectors/config.example.yaml
@@ -1,0 +1,110 @@
+# .connectors/config.example.yaml
+#
+# Sample configuration for @narai/connector-hub when consumed by doc-wiki.
+#
+# Copy this file to one of:
+#   ~/.connectors/config.yaml   (user-global; applies to every project)
+#   ./.connectors/config.yaml   (per-repo overlay; wins on conflict)
+#
+# Then uncomment the connectors you want enabled, fill in the credential
+# references, and run `/wiki-ingest <source>` — gather() reads this file,
+# plans which connectors to invoke based on the prompt, and dispatches
+# them in parallel.
+#
+# Credential refs follow the @narai/credential-providers syntax:
+#   env:NAME           → process.env.NAME
+#   keychain:LABEL     → OS keychain entry (macOS Keychain / libsecret)
+#   file:/path/to/key  → contents of that file (with permission check)
+#   cloud:aws-secret/<arn>      → AWS Secrets Manager
+#   cloud:gcp-secret/<resource> → GCP Secret Manager
+#
+# Every connector ships with its own README documenting the env vars it
+# expects; the entries below are the canonical names.
+
+connectors:
+
+  # github:
+  #   enabled: true
+  #   skill: github-agent-connector
+  #   token: env:GITHUB_TOKEN
+
+  # jira:
+  #   enabled: true
+  #   skill: jira-agent-connector
+  #   server_url: env:JIRA_SERVER_URL    # e.g. https://your-org.atlassian.net
+  #   email: env:JIRA_EMAIL
+  #   api_token: env:JIRA_API_TOKEN
+
+  # confluence:
+  #   enabled: true
+  #   skill: confluence-agent-connector
+  #   server_url: env:CONFLUENCE_SERVER_URL
+  #   email: env:CONFLUENCE_EMAIL
+  #   api_token: env:CONFLUENCE_API_TOKEN
+
+  # notion:
+  #   enabled: true
+  #   skill: notion-agent-connector
+  #   token: env:NOTION_TOKEN
+
+  # aws:
+  #   enabled: true
+  #   skill: aws-agent-connector
+  #   # AWS uses the standard SDK credential chain (env, ~/.aws/credentials,
+  #   # IAM role). Override here only when you need a non-default profile.
+  #   # profile: my-profile
+  #   region: env:AWS_REGION
+
+  # gcp:
+  #   enabled: true
+  #   skill: gcp-agent-connector
+  #   project_id: env:GCP_PROJECT_ID
+  #   # Application Default Credentials are picked up from the gcloud SDK;
+  #   # set GOOGLE_APPLICATION_CREDENTIALS only when ADC isn't available.
+
+  # db:
+  #   enabled: true
+  #   skill: db-agent-connector
+  #   # The db connector takes a flat env name → connection string mapping.
+  #   # Each env is a logical alias the wiki refers to (e.g. "prod", "dev").
+  #   # See @narai/db-agent-connector README for engine-specific knobs.
+  #   environments:
+  #     dev:
+  #       driver: postgresql
+  #       host: env:DB_DEV_HOST
+  #       database: env:DB_DEV_NAME
+  #       user: env:DB_DEV_USER
+  #       password: env:DB_DEV_PASSWORD
+
+
+# ── Environment overlays (optional) ─────────────────────────────────────
+#
+# `gather({ environment: "prod" })` deep-merges `environments.prod` onto
+# the connectors block above. Use this to vary per-env behaviour without
+# duplicating the whole file. `environments.default` names the fallback.
+
+environments:
+  default: dev
+  # dev:
+  #   github:
+  #     model: claude-haiku-4-5    # cheaper model in dev
+  # prod:
+  #   github:
+  #     model: claude-sonnet-4-6
+
+
+# ── Consumer overrides ──────────────────────────────────────────────────
+#
+# `gather({ consumer: "doc-wiki" })` deep-merges `consumers.doc-wiki` onto
+# the resolved config. Use this to express wiki-specific preferences
+# (e.g. narrower allowlist, smaller models) without affecting other
+# tools that share the same connectors.
+
+consumers:
+  doc-wiki:
+    # Example: doc-wiki only ingests from public sources during /wiki-ingest;
+    # disable AWS/GCP for the wiki even if they're enabled globally.
+    # aws:
+    #   enabled: false
+    # gcp:
+    #   enabled: false

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,18 @@
 
 Documentation wiki generator and maintainer. Runs entirely inside Claude Code as skills + agents + TypeScript helper scripts.
 
+## Quickstart
+
+Three slash commands take a new repo from zero to a working wiki:
+
+```
+/wiki-init         # scaffold wiki/ + wiki.config.yaml
+/wiki-onboard      # detect stack, ORM, DB; set up ~/.connectors/config.yaml
+/wiki-ingest <src> # fetch a source, compile, link, diagram, index
+```
+
+`/wiki-onboard` walks the user through configuring `@narai/connector-hub`'s `~/.connectors/config.yaml` from `.connectors/config.example.yaml` (in this repo). After that, every `/wiki-ingest <jira-url>`, `/wiki-ingest <github-repo>`, etc. routes through `gather()` to the right connector — no per-service setup needed.
+
 ## Architecture
 
 - **Main skill:** `.claude/skills/wiki/SKILL.md` — orchestrates all `/wiki-*` commands

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,15 +46,210 @@
         "@aws-sdk/client-lambda": "^3.1030.0",
         "@aws-sdk/client-rds": "^3.1030.0",
         "@aws-sdk/client-s3": "^3.1030.0",
-        "@narai/aws-agent-connector": "file:../aws-agent-connector",
-        "@narai/gcp-agent-connector": "file:../gcp-agent-connector"
+        "@narai/aws-agent-connector": "file:../connectors/aws-agent-connector",
+        "@narai/confluence-agent-connector": "file:../connectors/confluence-agent-connector",
+        "@narai/db-agent-connector": "file:../connectors/db-agent-connector",
+        "@narai/gcp-agent-connector": "file:../connectors/gcp-agent-connector",
+        "@narai/github-agent-connector": "file:../connectors/github-agent-connector",
+        "@narai/jira-agent-connector": "file:../connectors/jira-agent-connector",
+        "@narai/notion-agent-connector": "file:../connectors/notion-agent-connector"
       }
     },
     "../aws-agent-connector": {
-      "optional": true
+      "extraneous": true
+    },
+    "../connectors/aws-agent-connector": {
+      "name": "@narai/aws-agent-connector",
+      "version": "3.2.1",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@narai/connector-config": "^1.1.0",
+        "@narai/connector-toolkit": "^3.1.0",
+        "@narai/credential-providers": "^0.2.1",
+        "zod": "^3.23.0"
+      },
+      "bin": {
+        "aws-agent-connector": "dist/cli.js"
+      },
+      "devDependencies": {
+        "@aws-sdk/client-sts": "^3.1030.0",
+        "@types/node": "^20.19.39",
+        "@vitest/coverage-v8": "^3.2.4",
+        "typescript": "^5.9.3",
+        "vitest": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "optionalDependencies": {
+        "@aws-sdk/client-cloudwatch": "^3.1030.0",
+        "@aws-sdk/client-dynamodb": "^3.1030.0",
+        "@aws-sdk/client-lambda": "^3.1030.0",
+        "@aws-sdk/client-rds": "^3.1030.0",
+        "@aws-sdk/client-s3": "^3.1030.0",
+        "@aws-sdk/client-sts": "^3.1030.0"
+      }
+    },
+    "../connectors/confluence-agent-connector": {
+      "name": "@narai/confluence-agent-connector",
+      "version": "3.2.1",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@narai/connector-config": "^1.1.0",
+        "@narai/connector-toolkit": "^3.1.0",
+        "@narai/credential-providers": "^0.2.1",
+        "zod": "^3.23.0"
+      },
+      "bin": {
+        "confluence-agent-connector": "dist/cli.js"
+      },
+      "devDependencies": {
+        "@types/node": "^20.19.39",
+        "@vitest/coverage-v8": "^3.2.4",
+        "typescript": "^5.9.3",
+        "vitest": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "../connectors/db-agent-connector": {
+      "name": "@narai/db-agent-connector",
+      "version": "4.0.0",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@narai/connector-config": "^1.1.0",
+        "@narai/connector-toolkit": "^3.3.0",
+        "@narai/credential-providers": "^0.2.1",
+        "better-sqlite3": "^12.9.0",
+        "js-yaml": "^4.1.1",
+        "zod": "^3.23.0"
+      },
+      "bin": {
+        "db-agent-connector": "dist/cli.js"
+      },
+      "devDependencies": {
+        "@types/better-sqlite3": "^7.6.13",
+        "@types/js-yaml": "^4.0.9",
+        "@types/node": "^20.19.39",
+        "@types/pg": "^8.20.0",
+        "@vitest/coverage-v8": "^3.2.4",
+        "aws-sdk-client-mock": "^4.1.0",
+        "typescript": "^5.9.3",
+        "vitest": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=20.0.0 <21.0.0"
+      },
+      "optionalDependencies": {
+        "@aws-sdk/client-dynamodb": "^3.1030.0",
+        "mongodb": "^7.1.1",
+        "mssql": "^12.2.1",
+        "mysql2": "^3.22.0",
+        "oracledb": "^6.10.0",
+        "pg": "^8.20.0"
+      }
+    },
+    "../connectors/gcp-agent-connector": {
+      "name": "@narai/gcp-agent-connector",
+      "version": "3.2.1",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@narai/connector-config": "^1.1.0",
+        "@narai/connector-toolkit": "^3.1.0",
+        "zod": "^3.23.0"
+      },
+      "bin": {
+        "gcp-agent-connector": "dist/cli.js"
+      },
+      "devDependencies": {
+        "@types/node": "^20.19.39",
+        "@vitest/coverage-v8": "^3.2.4",
+        "typescript": "^5.9.3",
+        "vitest": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "../connectors/github-agent-connector": {
+      "name": "@narai/github-agent-connector",
+      "version": "3.2.0",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@narai/connector-config": "^1.1.0",
+        "@narai/connector-toolkit": "^3.1.0",
+        "@narai/credential-providers": "^0.2.1",
+        "zod": "^3.23.0"
+      },
+      "bin": {
+        "github-agent-connector": "dist/cli.js"
+      },
+      "devDependencies": {
+        "@types/node": "^20.19.39",
+        "@vitest/coverage-v8": "^3.2.4",
+        "typescript": "^5.9.3",
+        "vitest": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "../connectors/jira-agent-connector": {
+      "name": "@narai/jira-agent-connector",
+      "version": "3.2.1",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@narai/connector-config": "^1.1.0",
+        "@narai/connector-toolkit": "^3.1.0",
+        "@narai/credential-providers": "^0.2.1",
+        "zod": "^3.23.0"
+      },
+      "bin": {
+        "jira-agent-connector": "dist/cli.js"
+      },
+      "devDependencies": {
+        "@types/node": "^20.19.39",
+        "@vitest/coverage-v8": "^3.2.4",
+        "typescript": "^5.9.3",
+        "vitest": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "../connectors/notion-agent-connector": {
+      "name": "@narai/notion-agent-connector",
+      "version": "3.2.0",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@narai/connector-config": "^1.1.0",
+        "@narai/connector-toolkit": "^3.1.0",
+        "@narai/credential-providers": "^0.2.1",
+        "zod": "^3.23.0"
+      },
+      "bin": {
+        "notion-agent-connector": "dist/cli.js"
+      },
+      "devDependencies": {
+        "@types/node": "^20.19.39",
+        "@vitest/coverage-v8": "^3.2.4",
+        "typescript": "^5.9.3",
+        "vitest": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
     },
     "../gcp-agent-connector": {
-      "optional": true
+      "extraneous": true
     },
     "node_modules/@ampproject/remapping": {
       "version": "2.3.0",
@@ -2597,7 +2792,11 @@
       }
     },
     "node_modules/@narai/aws-agent-connector": {
-      "resolved": "../aws-agent-connector",
+      "resolved": "../connectors/aws-agent-connector",
+      "link": true
+    },
+    "node_modules/@narai/confluence-agent-connector": {
+      "resolved": "../connectors/confluence-agent-connector",
       "link": true
     },
     "node_modules/@narai/connector-config": {
@@ -2675,8 +2874,24 @@
         "node": ">=20.0.0"
       }
     },
+    "node_modules/@narai/db-agent-connector": {
+      "resolved": "../connectors/db-agent-connector",
+      "link": true
+    },
     "node_modules/@narai/gcp-agent-connector": {
-      "resolved": "../gcp-agent-connector",
+      "resolved": "../connectors/gcp-agent-connector",
+      "link": true
+    },
+    "node_modules/@narai/github-agent-connector": {
+      "resolved": "../connectors/github-agent-connector",
+      "link": true
+    },
+    "node_modules/@narai/jira-agent-connector": {
+      "resolved": "../connectors/jira-agent-connector",
+      "link": true
+    },
+    "node_modules/@narai/notion-agent-connector": {
+      "resolved": "../connectors/notion-agent-connector",
       "link": true
     },
     "node_modules/@nodable/entities": {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,12 @@
     "@aws-sdk/client-lambda": "^3.1030.0",
     "@aws-sdk/client-rds": "^3.1030.0",
     "@aws-sdk/client-s3": "^3.1030.0",
-    "@narai/aws-agent-connector": "file:../aws-agent-connector",
-    "@narai/gcp-agent-connector": "file:../gcp-agent-connector"
+    "@narai/aws-agent-connector": "file:../connectors/aws-agent-connector",
+    "@narai/confluence-agent-connector": "file:../connectors/confluence-agent-connector",
+    "@narai/db-agent-connector": "file:../connectors/db-agent-connector",
+    "@narai/gcp-agent-connector": "file:../connectors/gcp-agent-connector",
+    "@narai/github-agent-connector": "file:../connectors/github-agent-connector",
+    "@narai/jira-agent-connector": "file:../connectors/jira-agent-connector",
+    "@narai/notion-agent-connector": "file:../connectors/notion-agent-connector"
   }
 }


### PR DESCRIPTION
## Why

Stacked-PR gotcha — PR #2 and PR #3 each merged into their (now-stale) stack base instead of \`main\` because GitHub didn't auto-rebase the base after the parent merged:

| PR | Title | Base when merged | On \`main\`? |
|----|-------|------------------|---|
| #1 | Decommission legacy wrappers | \`main\` | ✅ |
| #2 | Solidify critical path | \`feat/decommission-legacy-wrappers\` | ❌ stranded |
| #3 | Reference consumer flow | \`feat/solidify-critical-path\` | ❌ stranded |

This PR carries the cumulative state of \`feat/reference-consumer-flow\` onto \`main\`. Diff is exactly PR #2 + PR #3 content (PR #1 already on main; nothing duplicated).

## What's in this PR

Identical to the merged content of #2 and #3:

**From PR #2** ([Solidify critical path](https://github.com/narailabs/doc-wiki/pull/2)):
- Commit \`mermaid_augment.{ts,js}\` + \`mermaid_augment.test.ts\` (was untracked WIP).
- Fix broken \`file:../aws-agent-connector\` → \`file:../connectors/aws-agent-connector\` paths in \`package.json\`; add 5 missing connector deps.
- New \`gather_integration.test.ts\` — first end-to-end seam test (8 cases covering all 7 builtin connectors + 3 failure modes).

**From PR #3** ([Reference consumer flow](https://github.com/narailabs/doc-wiki/pull/3)):
- New \`.connectors/config.example.yaml\` (~110 lines, all 7 connectors documented).
- New \`/wiki-onboard\` Phase 4b that walks through generating \`~/.connectors/config.yaml\`.
- CLAUDE.md Quickstart section.

## Stat

\`\`\`
9 files changed, 1784 insertions(+), 9 deletions(-)
\`\`\`

## Test plan

- [x] \`npm run typecheck\` clean
- [x] \`npm run build\` clean
- [x] \`npm test\` — 886 passed, 5 skipped (live-DB tests gated by \`TEST_LIVE_*\`)
- [x] No conflicts with \`main\` (PR #1 content already there)
- [ ] Manual /wiki-ingest end-to-end against live services (deferred — needs real creds in \`~/.connectors/config.yaml\`)