### PR TITLE
feat(atlas): audience-aware globals + gap report + Mermaid seeds

### DIFF
--- a/agents/lib/atlas_synthesize.js
+++ b/agents/lib/atlas_synthesize.js
@@ -26,6 +26,8 @@ import * as path from "node:path";
 import { fileURLToPath } from "node:url";
 import { parseFlags } from "../../skills/doc-wiki/scripts/_cli_args.js";
 import { parseFrontmatter } from "../../skills/doc-wiki/scripts/_frontmatter.js";
+import { formatPhaseFlow, } from "./mermaid_format.js";
+import { builtinConnectorIds } from "./source_registry.js";
 /**
  * Walk `<wikiRoot>/wiki/` and yield every `.md` page whose frontmatter has a
  * `atlas_facet` field matching one of `wantedFacets`. The wanted facets
@@ -93,26 +95,87 @@ function _extractTldr(body) {
         return "";
     return (m[1] ?? "").trim();
 }
+/**
+ * Resolve the page's audience for routing purposes. Honors an explicit
+ * `audience` frontmatter field if present; otherwise falls back to a default
+ * derived from the `atlas_facet`. Mirrors the table documented in
+ * `references/compilation.md` ("Additional frontmatter for atlas pages").
+ */
+function _inferAudience(facet, frontmatterAudience) {
+    if (typeof frontmatterAudience === "string" && frontmatterAudience.length > 0) {
+        return frontmatterAudience;
+    }
+    switch (facet) {
+        case "getting-started":
+            return "new-user";
+        case "commands":
+        case "configuration":
+        case "operations":
+            return "operator";
+        case "architecture":
+        case "data-model":
+        case "environments":
+        case "overview":
+            return "contributor";
+        case "api":
+        case "integrations":
+        case "deploy":
+            return "integrator";
+        case "troubleshooting":
+            return "debugger";
+        default:
+            return "contributor";
+    }
+}
 // ── Overview bundle ────────────────────────────────────────────────
 /**
  * Assemble the input for `wiki/overview.md` synthesis: every per-topic
  * `architecture.md` body in full, plus the TL;DR sections of the other per-
- * topic facets. The intent is to give the LLM the full architecture story
- * for each topic plus a one-paragraph snapshot of every other facet (data
- * model, environments, api, operations) so the synthesized narrative can
- * cross-reference without needing every page in full.
+ * topic facets, prefixed by an audience-routing table generated from each
+ * page's `audience` frontmatter field (default-inferred from facet). The
+ * routing table mirrors `docs/README.md`'s "Where to start" section so the
+ * synthesized overview can route human readers to the right depth.
  */
 export function assembleOverviewInputs(wikiRoot) {
-    const arch = _findAtlasPages(wikiRoot, ["architecture"]);
-    const others = _findAtlasPages(wikiRoot, [
-        "data-model",
-        "environments",
-        "api",
-        "operations",
-    ]);
+    const allPages = _findAtlasPages(wikiRoot);
+    const arch = allPages.filter((p) => p.facet === "architecture");
+    const others = allPages.filter((p) => p.facet === "data-model" ||
+        p.facet === "environments" ||
+        p.facet === "api" ||
+        p.facet === "operations");
     const sources = [];
     const parts = [];
     const notes = [];
+    // Audience-routing table at the top — gives the LLM a structural anchor
+    // for the synthesized page's "Where to start" section.
+    if (allPages.length > 0) {
+        const grouped = new Map();
+        for (const page of allPages) {
+            const audience = _inferAudience(page.facet, page.frontmatter["audience"]);
+            const list = grouped.get(audience);
+            if (list)
+                list.push(page.page);
+            else
+                grouped.set(audience, [page.page]);
+        }
+        parts.push("## Audience routing\n");
+        parts.push("| Audience | Pages |");
+        parts.push("|---|---|");
+        const order = ["new-user", "operator", "contributor", "integrator", "debugger"];
+        for (const audience of order) {
+            const pages = grouped.get(audience);
+            if (!pages || pages.length === 0)
+                continue;
+            parts.push(`| ${audience} | ${pages.join(", ")} |`);
+        }
+        // Surface any audience labels not in the canonical order at the end.
+        for (const [audience, pages] of grouped) {
+            if (order.includes(audience))
+                continue;
+            parts.push(`| ${audience} | ${pages.join(", ")} |`);
+        }
+        parts.push("");
+    }
     if (arch.length === 0) {
         notes.push("no architecture.md pages found — overview will be sparse");
     }
@@ -163,10 +226,7 @@ export function assembleIntegrationsInputs(wikiRoot, connectorsConfigPath) {
     }
     // Architecture pages — extract external-service-ish lines.
     const archPages = _findAtlasPages(wikiRoot, ["architecture"]);
-    const integrationKeywords = [
-        "jira", "github", "confluence", "notion", "aws", "gcp",
-        "stripe", "datadog", "sentry", "auth0", "okta", "twilio", "sendgrid",
-    ];
+    const integrationKeywords = _getIntegrationKeywords();
     for (const page of archPages) {
         const lines = page.body.split("\n");
         const hits = [];
@@ -290,23 +350,456 @@ export function assembleDeployInputs(repoRoot) {
     }
     return { sources, text: parts.join("\n"), notes };
 }
+/**
+ * Sourced integration-keyword list. Used by `assembleIntegrationsInputs`
+ * to scan architecture pages for external-service mentions. Pulls
+ * builtin connector ids from `source_registry` (data-driven; satisfies
+ * architecture invariant #6) and unions in a curated list of common SaaS
+ * integrations that aren't bundled connectors but are still worth
+ * surfacing in the synthesized integrations page.
+ *
+ * The `db` connector is filtered out — it's a database connector, not an
+ * external service in the sense the integrations page covers.
+ */
+const _COMMON_SAAS_KEYWORDS = [
+    "stripe",
+    "datadog",
+    "sentry",
+    "auth0",
+    "okta",
+    "twilio",
+    "sendgrid",
+];
+function _getIntegrationKeywords() {
+    const fromRegistry = builtinConnectorIds().filter((id) => id !== "db");
+    return [...new Set([...fromRegistry, ..._COMMON_SAAS_KEYWORDS])];
+}
+// ── Commands bundle ────────────────────────────────────────────────
+/**
+ * Build a Mermaid `flowchart TD` showing the slash-command fan-out:
+ * User → each `/<command>` → skill orchestrator. Project-agnostic — the
+ * shape is identical for any repo, only the command list varies.
+ *
+ * Returned as a fenced Mermaid block wrapped in `<!-- mermaid-seed -->`
+ * markers so the synthesis step (the orchestrator LLM) preserves it
+ * verbatim or refines without re-deriving the topology from the bundle
+ * text. Idempotent: passing the same slug list yields the same code.
+ */
+function _commandsLifecycleSeed(slugs) {
+    if (slugs.length === 0)
+        return "";
+    const nodes = [
+        { id: "user", label: "User", className: "actor" },
+        { id: "orch", label: "doc-wiki<br/>skill orchestrator", className: "orch" },
+    ];
+    const edges = [];
+    for (const slug of slugs) {
+        const id = "cmd_" + slug.replace(/[^a-z0-9]/gi, "_");
+        nodes.push({ id, label: `/${slug}`, className: "cmd" });
+        edges.push({ from: "user", to: id });
+        edges.push({ from: id, to: "orch" });
+    }
+    const classDefs = [
+        { name: "actor", fill: "#cfe2f3", stroke: "#0c5394" },
+        { name: "cmd", fill: "#fff3cd", stroke: "#856404" },
+        { name: "orch", fill: "#d4edda", stroke: "#155724" },
+    ];
+    const block = formatPhaseFlow("slash-command fan-out", nodes, edges, classDefs);
+    return [
+        "<!-- mermaid-seed: slash-command fan-out — preserve in synthesized page -->",
+        "```mermaid",
+        block.code,
+        "```",
+        "<!-- /mermaid-seed -->",
+        "",
+    ].join("\n");
+}
+/**
+ * Assemble the input for `wiki/commands.md` synthesis: a Mermaid flowchart
+ * seed of the slash-command fan-out, every `commands/*.md` wrapper file in
+ * the repo, plus any `### /` headings extracted from the project's
+ * `SKILL.md` files. The intent is to give the LLM all the slash-command
+ * surface area plus a structural anchor for the diagram, so it can produce
+ * a single operator-friendly reference page with a real Mermaid block.
+ */
+export function assembleCommandsInputs(repoRoot) {
+    const sources = [];
+    const parts = [];
+    const notes = [];
+    const slugs = [];
+    // commands/*.md wrappers
+    const commandsDir = path.join(repoRoot, "commands");
+    if (fs.existsSync(commandsDir)) {
+        let files;
+        try {
+            files = fs
+                .readdirSync(commandsDir)
+                .filter((f) => f.endsWith(".md"))
+                .sort();
+        }
+        catch {
+            files = [];
+            notes.push(`could not read ${commandsDir}`);
+        }
+        for (const f of files) {
+            const abs = path.join(commandsDir, f);
+            try {
+                const body = fs.readFileSync(abs, "utf-8");
+                const rel = path.posix.join("commands", f);
+                sources.push(rel);
+                parts.push(`## ${rel}\n\n${body.trim()}\n`);
+                slugs.push(f.replace(/\.md$/, ""));
+            }
+            catch {
+                notes.push(`could not read commands/${f}`);
+            }
+        }
+    }
+    else {
+        notes.push("no commands/ directory — commands page will be sparse");
+    }
+    // Prepend the Mermaid seed so the LLM sees the diagram before the
+    // per-command bodies. Skipped silently when no commands/ exists.
+    const seed = _commandsLifecycleSeed(slugs);
+    if (seed.length > 0)
+        parts.unshift(seed);
+    // ### / headings extracted from any SKILL.md under skills/
+    const skillsDir = path.join(repoRoot, "skills");
+    if (fs.existsSync(skillsDir)) {
+        const skillFiles = [];
+        const walk = (d) => {
+            let entries;
+            try {
+                entries = fs.readdirSync(d, { withFileTypes: true });
+            }
+            catch {
+                return;
+            }
+            for (const e of entries) {
+                const full = path.join(d, e.name);
+                if (e.isDirectory())
+                    walk(full);
+                else if (e.isFile() && e.name === "SKILL.md")
+                    skillFiles.push(full);
+            }
+        };
+        walk(skillsDir);
+        for (const skillFile of skillFiles) {
+            let body;
+            try {
+                body = fs.readFileSync(skillFile, "utf-8");
+            }
+            catch {
+                continue;
+            }
+            const headings = [];
+            for (const line of body.split("\n")) {
+                if (/^###\s+\//.test(line))
+                    headings.push(line.trim());
+            }
+            if (headings.length > 0) {
+                const rel = path.relative(repoRoot, skillFile).split(path.sep).join("/");
+                sources.push(rel);
+                parts.push(`## Slash-command headings in ${rel}\n\n${headings.join("\n")}\n`);
+            }
+        }
+    }
+    return { sources, text: parts.join("\n"), notes };
+}
+// ── Getting-started bundle ─────────────────────────────────────────
+const _BOOTSTRAP_FILE_CANDIDATES = [
+    "setup.sh",
+    "bootstrap.sh",
+    "install.sh",
+    "Makefile",
+];
+/**
+ * Assemble the input for `wiki/getting-started.md` synthesis: top-level
+ * README + package.json scripts + any common bootstrap files (setup.sh,
+ * Makefile, etc.). Gives the LLM enough raw material to produce a
+ * numbered first-run walkthrough for new users.
+ */
+export function assembleGettingStartedInputs(repoRoot) {
+    const sources = [];
+    const parts = [];
+    const notes = [];
+    // README.md (truncated if huge)
+    const readmePath = path.join(repoRoot, "README.md");
+    if (fs.existsSync(readmePath)) {
+        try {
+            const body = fs.readFileSync(readmePath, "utf-8");
+            const truncated = body.length > 50 * 1024
+                ? body.slice(0, 50 * 1024) + "\n... [truncated]\n"
+                : body;
+            sources.push("README.md");
+            parts.push(`## README.md\n\n${truncated}\n`);
+        }
+        catch {
+            notes.push("could not read README.md");
+        }
+    }
+    else {
+        notes.push("no README.md — getting-started will be sparse");
+    }
+    // package.json scripts (Node projects)
+    const pkgPath = path.join(repoRoot, "package.json");
+    if (fs.existsSync(pkgPath)) {
+        try {
+            const body = fs.readFileSync(pkgPath, "utf-8");
+            const json = JSON.parse(body);
+            if (json.scripts && Object.keys(json.scripts).length > 0) {
+                sources.push("package.json");
+                parts.push("## package.json scripts\n\n```json\n" +
+                    JSON.stringify(json.scripts, null, 2) +
+                    "\n```\n");
+            }
+        }
+        catch {
+            notes.push("could not parse package.json");
+        }
+    }
+    // Bootstrap-y top-level files
+    for (const name of _BOOTSTRAP_FILE_CANDIDATES) {
+        const p = path.join(repoRoot, name);
+        if (!fs.existsSync(p))
+            continue;
+        try {
+            const body = fs.readFileSync(p, "utf-8");
+            const truncated = body.length > 50 * 1024
+                ? body.slice(0, 50 * 1024) + "\n... [truncated]\n"
+                : body;
+            sources.push(name);
+            parts.push(`## ${name}\n\n\`\`\`\n${truncated}\n\`\`\`\n`);
+        }
+        catch {
+            notes.push(`could not read ${name}`);
+        }
+    }
+    return { sources, text: parts.join("\n"), notes };
+}
+// ── Configuration bundle ───────────────────────────────────────────
+const _CONFIGURATION_FILE_GLOBS = [
+    /^[a-z][a-z0-9-]*\.config\.(ya?ml|json|toml)$/i,
+    /^wiki\.config\.ya?ml$/i,
+    /^\.env\.example$/i,
+    /^\.env\.template$/i,
+    /^\.env\.sample$/i,
+    /^pyproject\.toml$/i,
+    /^Cargo\.toml$/i,
+    /^setup\.cfg$/i,
+    /^settings\.gradle(\.kts)?$/i,
+    /^application\.(properties|ya?ml)$/i,
+];
+const _CONFIGURATION_DIR_PATTERNS = [
+    { dir: "config", rx: /\.(ya?ml|json|toml|conf|ini|properties)$/i },
+    { dir: ".connectors", rx: /\.ya?ml$/i },
+];
+/**
+ * Assemble the input for `wiki/configuration.md` synthesis: top-level
+ * configuration files (wiki.config.yaml, *.config.yaml, .env.example, …)
+ * plus the contents of `config/` and `.connectors/` directories. Gives
+ * the LLM enough surface to produce an operator-facing schema reference.
+ *
+ * Big files (>200 KB) are truncated; a `... [truncated]` marker is left
+ * inline so the synthesis step can note the truncation when relevant.
+ */
+export function assembleConfigurationInputs(repoRoot) {
+    const sources = [];
+    const parts = [];
+    const notes = [];
+    // Top-level files matching configuration globs.
+    let topLevel;
+    try {
+        topLevel = fs.readdirSync(repoRoot, { withFileTypes: true });
+    }
+    catch {
+        notes.push(`could not read repo root: ${repoRoot}`);
+        return { sources, text: "", notes };
+    }
+    for (const e of topLevel) {
+        if (!e.isFile())
+            continue;
+        if (_CONFIGURATION_FILE_GLOBS.some((rx) => rx.test(e.name))) {
+            sources.push(e.name);
+        }
+    }
+    // Directory patterns.
+    for (const { dir, rx } of _CONFIGURATION_DIR_PATTERNS) {
+        const abs = path.join(repoRoot, dir);
+        if (!fs.existsSync(abs))
+            continue;
+        const walk = (d, relBase) => {
+            let entries;
+            try {
+                entries = fs.readdirSync(d, { withFileTypes: true });
+            }
+            catch {
+                return;
+            }
+            for (const e of entries) {
+                const full = path.join(d, e.name);
+                const rel = path.posix.join(relBase, e.name);
+                if (e.isDirectory())
+                    walk(full, rel);
+                else if (e.isFile() && rx.test(e.name))
+                    sources.push(rel);
+            }
+        };
+        walk(abs, dir);
+    }
+    sources.sort();
+    if (sources.length === 0) {
+        notes.push("no configuration files matched — wiki/configuration.md will be sparse");
+        return { sources, text: "", notes };
+    }
+    for (const rel of sources) {
+        const abs = path.join(repoRoot, rel);
+        let body;
+        try {
+            body = fs.readFileSync(abs, "utf-8");
+        }
+        catch {
+            notes.push(`could not read ${rel}`);
+            continue;
+        }
+        const truncated = body.length > 200 * 1024
+            ? body.slice(0, 200 * 1024) + "\n... [truncated]\n"
+            : body;
+        parts.push(`## ${rel}\n\n\`\`\`\n${truncated}\n\`\`\`\n`);
+    }
+    return { sources, text: parts.join("\n"), notes };
+}
+// ── Troubleshooting bundle ─────────────────────────────────────────
+const _TROUBLESHOOTING_EVENT_LIMIT = 30;
+function _isErrorEvent(rec) {
+    if (rec["error"] !== undefined && rec["error"] !== null)
+        return true;
+    if (rec["status"] === "failed" || rec["status"] === "error")
+        return true;
+    const details = rec["details"];
+    if (details && typeof details === "object" && !Array.isArray(details)) {
+        const d = details;
+        if (d["error"] !== undefined && d["error"] !== null)
+            return true;
+        if (d["status"] === "failed" || d["status"] === "error")
+            return true;
+    }
+    return false;
+}
+/**
+ * Assemble the input for `wiki/troubleshooting.md` synthesis: the most
+ * recent error/failure events from `events.jsonl` plus the latest atlas
+ * drift report (if present). Gives the LLM symptom signals the page can
+ * organize into symptom → cause → fix triplets.
+ */
+export function assembleTroubleshootingInputs(wikiRoot) {
+    const sources = [];
+    const parts = [];
+    const notes = [];
+    // Recent error events from events.jsonl
+    const eventsPath = path.join(wikiRoot, "log", "events.jsonl");
+    if (fs.existsSync(eventsPath)) {
+        let lines;
+        try {
+            lines = fs.readFileSync(eventsPath, "utf-8").split("\n");
+        }
+        catch {
+            lines = [];
+        }
+        const errors = [];
+        for (let i = lines.length - 1; i >= 0 && errors.length < _TROUBLESHOOTING_EVENT_LIMIT; i--) {
+            const line = lines[i];
+            if (!line)
+                continue;
+            let parsed;
+            try {
+                parsed = JSON.parse(line);
+            }
+            catch {
+                continue;
+            }
+            if (!parsed || typeof parsed !== "object" || Array.isArray(parsed))
+                continue;
+            const rec = parsed;
+            if (_isErrorEvent(rec)) {
+                errors.push({ raw: line, parsed: rec });
+            }
+        }
+        if (errors.length > 0) {
+            sources.push("log/events.jsonl");
+            parts.push("## Recent error/failure events\n");
+            parts.push("```jsonl");
+            // Reverse so oldest-first within the recent window
+            for (const e of [...errors].reverse())
+                parts.push(e.raw);
+            parts.push("```\n");
+        }
+        else {
+            notes.push("no error events in events.jsonl — troubleshooting will be sparse");
+        }
+    }
+    else {
+        notes.push("no log/events.jsonl found");
+    }
+    // Latest atlas drift report
+    const atlasOutputs = path.join(wikiRoot, "outputs", "atlas");
+    if (fs.existsSync(atlasOutputs)) {
+        let runs;
+        try {
+            runs = fs
+                .readdirSync(atlasOutputs, { withFileTypes: true })
+                .filter((e) => e.isDirectory())
+                .map((e) => e.name)
+                .sort()
+                .reverse();
+        }
+        catch {
+            runs = [];
+        }
+        for (const run of runs) {
+            const driftPath = path.join(atlasOutputs, run, "drift-report.md");
+            if (!fs.existsSync(driftPath))
+                continue;
+            try {
+                const body = fs.readFileSync(driftPath, "utf-8");
+                const rel = path.posix.join("outputs", "atlas", run, "drift-report.md");
+                sources.push(rel);
+                parts.push(`## Drift report (${run})\n\n${body.trim()}\n`);
+                break; // only the most recent
+            }
+            catch {
+                notes.push(`could not read ${driftPath}`);
+            }
+        }
+    }
+    return { sources, text: parts.join("\n"), notes };
+}
 // ── CLI ────────────────────────────────────────────────────────────
 const FLAG_SPEC = {
     "--wiki-root": "wikiRoot",
     "--repo-root": "repoRoot",
     "--connectors-config": "connectorsConfig",
 };
-const HELP_TEXT = `usage: atlas_synthesize.js {overview,integrations,deploy} [...]
+const HELP_TEXT = `usage: atlas_synthesize.js {overview,integrations,deploy,commands,configuration,getting-started,troubleshooting} [...]
 
 Read-only input assembly for /doc-wiki:atlas global synthesis.
 
 Subcommands:
-  overview       --wiki-root <p>
-                 Concatenated architecture pages + per-facet TL;DRs.
-  integrations   --wiki-root <p> [--connectors-config <p>]
-                 api.md pages + external-service mentions + connector config.
-  deploy         --wiki-root <p> [--repo-root <p>]
-                 Build/deploy files: Dockerfile, compose, workflows, terraform.
+  overview          --wiki-root <p>
+                    Audience-routing table + concatenated architecture pages +
+                    per-facet TL;DRs.
+  integrations      --wiki-root <p> [--connectors-config <p>]
+                    api.md pages + external-service mentions + connector config.
+  deploy            --wiki-root <p> [--repo-root <p>]
+                    Build/deploy files: Dockerfile, compose, workflows, terraform.
+  commands          --repo-root <p>
+                    commands/*.md wrappers + ### / headings from SKILL.md files.
+  configuration     --repo-root <p>
+                    Top-level config files + config/ + .connectors/ dirs.
+  getting-started   --repo-root <p>
+                    README + package.json scripts + bootstrap files.
+  troubleshooting   --wiki-root <p>
+                    Recent error events + latest atlas drift report.
 
 Each prints one JSON object on stdout with keys: sources, text, notes.
 `;
@@ -329,28 +822,49 @@ export function main(argv = process.argv.slice(2)) {
         return 0;
     }
     const wikiRoot = parsed.values["wikiRoot"];
-    if (typeof wikiRoot !== "string" || wikiRoot.length === 0) {
-        process.stderr.write("--wiki-root is required\n");
-        return 2;
-    }
-    if (sub === "overview") {
-        const bundle = assembleOverviewInputs(wikiRoot);
+    const repoRoot = typeof parsed.values["repoRoot"] === "string" && parsed.values["repoRoot"].length > 0
+        ? parsed.values["repoRoot"]
+        : process.cwd();
+    // Subcommands that need --wiki-root.
+    if (sub === "overview" || sub === "integrations" || sub === "troubleshooting") {
+        if (typeof wikiRoot !== "string" || wikiRoot.length === 0) {
+            process.stderr.write("--wiki-root is required\n");
+            return 2;
+        }
+        let bundle;
+        if (sub === "overview") {
+            bundle = assembleOverviewInputs(wikiRoot);
+        }
+        else if (sub === "integrations") {
+            const cfg = typeof parsed.values["connectorsConfig"] === "string"
+                ? parsed.values["connectorsConfig"]
+                : undefined;
+            bundle = assembleIntegrationsInputs(wikiRoot, cfg);
+        }
+        else {
+            bundle = assembleTroubleshootingInputs(wikiRoot);
+        }
         process.stdout.write(JSON.stringify(bundle) + "\n");
         return 0;
     }
-    if (sub === "integrations") {
-        const cfg = typeof parsed.values["connectorsConfig"] === "string"
-            ? parsed.values["connectorsConfig"]
-            : undefined;
-        const bundle = assembleIntegrationsInputs(wikiRoot, cfg);
-        process.stdout.write(JSON.stringify(bundle) + "\n");
-        return 0;
-    }
+    // Subcommands that work off repoRoot (cwd by default).
     if (sub === "deploy") {
-        const repoRoot = typeof parsed.values["repoRoot"] === "string" && parsed.values["repoRoot"].length > 0
-            ? parsed.values["repoRoot"]
-            : process.cwd();
         const bundle = assembleDeployInputs(repoRoot);
+        process.stdout.write(JSON.stringify(bundle) + "\n");
+        return 0;
+    }
+    if (sub === "commands") {
+        const bundle = assembleCommandsInputs(repoRoot);
+        process.stdout.write(JSON.stringify(bundle) + "\n");
+        return 0;
+    }
+    if (sub === "getting-started") {
+        const bundle = assembleGettingStartedInputs(repoRoot);
+        process.stdout.write(JSON.stringify(bundle) + "\n");
+        return 0;
+    }
+    if (sub === "configuration") {
+        const bundle = assembleConfigurationInputs(repoRoot);
         process.stdout.write(JSON.stringify(bundle) + "\n");
         return 0;
     }

--- a/agents/lib/atlas_synthesize.ts
+++ b/agents/lib/atlas_synthesize.ts
@@ -27,6 +27,13 @@ import { fileURLToPath } from "node:url";
 
 import { parseFlags } from "../../skills/doc-wiki/scripts/_cli_args.js";
 import { parseFrontmatter } from "../../skills/doc-wiki/scripts/_frontmatter.js";
+import {
+  formatPhaseFlow,
+  type ClassDef,
+  type PhaseEdge,
+  type PhaseNode,
+} from "./mermaid_format.js";
+import { builtinConnectorIds } from "./source_registry.js";
 
 // ── Shared types ───────────────────────────────────────────────────
 
@@ -114,27 +121,92 @@ function _extractTldr(body: string): string {
   return (m[1] ?? "").trim();
 }
 
+/**
+ * Resolve the page's audience for routing purposes. Honors an explicit
+ * `audience` frontmatter field if present; otherwise falls back to a default
+ * derived from the `atlas_facet`. Mirrors the table documented in
+ * `references/compilation.md` ("Additional frontmatter for atlas pages").
+ */
+function _inferAudience(
+  facet: string,
+  frontmatterAudience: unknown,
+): string {
+  if (typeof frontmatterAudience === "string" && frontmatterAudience.length > 0) {
+    return frontmatterAudience;
+  }
+  switch (facet) {
+    case "getting-started":
+      return "new-user";
+    case "commands":
+    case "configuration":
+    case "operations":
+      return "operator";
+    case "architecture":
+    case "data-model":
+    case "environments":
+    case "overview":
+      return "contributor";
+    case "api":
+    case "integrations":
+    case "deploy":
+      return "integrator";
+    case "troubleshooting":
+      return "debugger";
+    default:
+      return "contributor";
+  }
+}
+
 // ── Overview bundle ────────────────────────────────────────────────
 
 /**
  * Assemble the input for `wiki/overview.md` synthesis: every per-topic
  * `architecture.md` body in full, plus the TL;DR sections of the other per-
- * topic facets. The intent is to give the LLM the full architecture story
- * for each topic plus a one-paragraph snapshot of every other facet (data
- * model, environments, api, operations) so the synthesized narrative can
- * cross-reference without needing every page in full.
+ * topic facets, prefixed by an audience-routing table generated from each
+ * page's `audience` frontmatter field (default-inferred from facet). The
+ * routing table mirrors `docs/README.md`'s "Where to start" section so the
+ * synthesized overview can route human readers to the right depth.
  */
 export function assembleOverviewInputs(wikiRoot: string): SynthesisBundle {
-  const arch = _findAtlasPages(wikiRoot, ["architecture"]);
-  const others = _findAtlasPages(wikiRoot, [
-    "data-model",
-    "environments",
-    "api",
-    "operations",
-  ]);
+  const allPages = _findAtlasPages(wikiRoot);
+  const arch = allPages.filter((p) => p.facet === "architecture");
+  const others = allPages.filter(
+    (p) =>
+      p.facet === "data-model" ||
+      p.facet === "environments" ||
+      p.facet === "api" ||
+      p.facet === "operations",
+  );
   const sources: string[] = [];
   const parts: string[] = [];
   const notes: string[] = [];
+
+  // Audience-routing table at the top — gives the LLM a structural anchor
+  // for the synthesized page's "Where to start" section.
+  if (allPages.length > 0) {
+    const grouped = new Map<string, string[]>();
+    for (const page of allPages) {
+      const audience = _inferAudience(page.facet, page.frontmatter["audience"]);
+      const list = grouped.get(audience);
+      if (list) list.push(page.page);
+      else grouped.set(audience, [page.page]);
+    }
+    parts.push("## Audience routing\n");
+    parts.push("| Audience | Pages |");
+    parts.push("|---|---|");
+    const order = ["new-user", "operator", "contributor", "integrator", "debugger"];
+    for (const audience of order) {
+      const pages = grouped.get(audience);
+      if (!pages || pages.length === 0) continue;
+      parts.push(`| ${audience} | ${pages.join(", ")} |`);
+    }
+    // Surface any audience labels not in the canonical order at the end.
+    for (const [audience, pages] of grouped) {
+      if (order.includes(audience)) continue;
+      parts.push(`| ${audience} | ${pages.join(", ")} |`);
+    }
+    parts.push("");
+  }
 
   if (arch.length === 0) {
     notes.push("no architecture.md pages found — overview will be sparse");
@@ -194,10 +266,7 @@ export function assembleIntegrationsInputs(
 
   // Architecture pages — extract external-service-ish lines.
   const archPages = _findAtlasPages(wikiRoot, ["architecture"]);
-  const integrationKeywords = [
-    "jira", "github", "confluence", "notion", "aws", "gcp",
-    "stripe", "datadog", "sentry", "auth0", "okta", "twilio", "sendgrid",
-  ];
+  const integrationKeywords = _getIntegrationKeywords();
   for (const page of archPages) {
     const lines = page.body.split("\n");
     const hits: string[] = [];
@@ -324,6 +393,441 @@ export function assembleDeployInputs(repoRoot: string): SynthesisBundle {
   return { sources, text: parts.join("\n"), notes };
 }
 
+/**
+ * Sourced integration-keyword list. Used by `assembleIntegrationsInputs`
+ * to scan architecture pages for external-service mentions. Pulls
+ * builtin connector ids from `source_registry` (data-driven; satisfies
+ * architecture invariant #6) and unions in a curated list of common SaaS
+ * integrations that aren't bundled connectors but are still worth
+ * surfacing in the synthesized integrations page.
+ *
+ * The `db` connector is filtered out — it's a database connector, not an
+ * external service in the sense the integrations page covers.
+ */
+const _COMMON_SAAS_KEYWORDS: readonly string[] = [
+  "stripe",
+  "datadog",
+  "sentry",
+  "auth0",
+  "okta",
+  "twilio",
+  "sendgrid",
+];
+
+function _getIntegrationKeywords(): string[] {
+  const fromRegistry = builtinConnectorIds().filter((id) => id !== "db");
+  return [...new Set([...fromRegistry, ..._COMMON_SAAS_KEYWORDS])];
+}
+
+// ── Commands bundle ────────────────────────────────────────────────
+
+/**
+ * Build a Mermaid `flowchart TD` showing the slash-command fan-out:
+ * User → each `/<command>` → skill orchestrator. Project-agnostic — the
+ * shape is identical for any repo, only the command list varies.
+ *
+ * Returned as a fenced Mermaid block wrapped in `<!-- mermaid-seed -->`
+ * markers so the synthesis step (the orchestrator LLM) preserves it
+ * verbatim or refines without re-deriving the topology from the bundle
+ * text. Idempotent: passing the same slug list yields the same code.
+ */
+function _commandsLifecycleSeed(slugs: readonly string[]): string {
+  if (slugs.length === 0) return "";
+  const nodes: PhaseNode[] = [
+    { id: "user", label: "User", className: "actor" },
+    { id: "orch", label: "doc-wiki<br/>skill orchestrator", className: "orch" },
+  ];
+  const edges: PhaseEdge[] = [];
+  for (const slug of slugs) {
+    const id = "cmd_" + slug.replace(/[^a-z0-9]/gi, "_");
+    nodes.push({ id, label: `/${slug}`, className: "cmd" });
+    edges.push({ from: "user", to: id });
+    edges.push({ from: id, to: "orch" });
+  }
+  const classDefs: ClassDef[] = [
+    { name: "actor", fill: "#cfe2f3", stroke: "#0c5394" },
+    { name: "cmd", fill: "#fff3cd", stroke: "#856404" },
+    { name: "orch", fill: "#d4edda", stroke: "#155724" },
+  ];
+  const block = formatPhaseFlow("slash-command fan-out", nodes, edges, classDefs);
+  return [
+    "<!-- mermaid-seed: slash-command fan-out — preserve in synthesized page -->",
+    "```mermaid",
+    block.code,
+    "```",
+    "<!-- /mermaid-seed -->",
+    "",
+  ].join("\n");
+}
+
+/**
+ * Assemble the input for `wiki/commands.md` synthesis: a Mermaid flowchart
+ * seed of the slash-command fan-out, every `commands/*.md` wrapper file in
+ * the repo, plus any `### /` headings extracted from the project's
+ * `SKILL.md` files. The intent is to give the LLM all the slash-command
+ * surface area plus a structural anchor for the diagram, so it can produce
+ * a single operator-friendly reference page with a real Mermaid block.
+ */
+export function assembleCommandsInputs(repoRoot: string): SynthesisBundle {
+  const sources: string[] = [];
+  const parts: string[] = [];
+  const notes: string[] = [];
+  const slugs: string[] = [];
+
+  // commands/*.md wrappers
+  const commandsDir = path.join(repoRoot, "commands");
+  if (fs.existsSync(commandsDir)) {
+    let files: string[];
+    try {
+      files = fs
+        .readdirSync(commandsDir)
+        .filter((f) => f.endsWith(".md"))
+        .sort();
+    } catch {
+      files = [];
+      notes.push(`could not read ${commandsDir}`);
+    }
+    for (const f of files) {
+      const abs = path.join(commandsDir, f);
+      try {
+        const body = fs.readFileSync(abs, "utf-8");
+        const rel = path.posix.join("commands", f);
+        sources.push(rel);
+        parts.push(`## ${rel}\n\n${body.trim()}\n`);
+        slugs.push(f.replace(/\.md$/, ""));
+      } catch {
+        notes.push(`could not read commands/${f}`);
+      }
+    }
+  } else {
+    notes.push("no commands/ directory — commands page will be sparse");
+  }
+
+  // Prepend the Mermaid seed so the LLM sees the diagram before the
+  // per-command bodies. Skipped silently when no commands/ exists.
+  const seed = _commandsLifecycleSeed(slugs);
+  if (seed.length > 0) parts.unshift(seed);
+
+  // ### / headings extracted from any SKILL.md under skills/
+  const skillsDir = path.join(repoRoot, "skills");
+  if (fs.existsSync(skillsDir)) {
+    const skillFiles: string[] = [];
+    const walk = (d: string): void => {
+      let entries: fs.Dirent[];
+      try {
+        entries = fs.readdirSync(d, { withFileTypes: true });
+      } catch {
+        return;
+      }
+      for (const e of entries) {
+        const full = path.join(d, e.name);
+        if (e.isDirectory()) walk(full);
+        else if (e.isFile() && e.name === "SKILL.md") skillFiles.push(full);
+      }
+    };
+    walk(skillsDir);
+    for (const skillFile of skillFiles) {
+      let body: string;
+      try {
+        body = fs.readFileSync(skillFile, "utf-8");
+      } catch {
+        continue;
+      }
+      const headings: string[] = [];
+      for (const line of body.split("\n")) {
+        if (/^###\s+\//.test(line)) headings.push(line.trim());
+      }
+      if (headings.length > 0) {
+        const rel = path.relative(repoRoot, skillFile).split(path.sep).join("/");
+        sources.push(rel);
+        parts.push(
+          `## Slash-command headings in ${rel}\n\n${headings.join("\n")}\n`,
+        );
+      }
+    }
+  }
+
+  return { sources, text: parts.join("\n"), notes };
+}
+
+// ── Getting-started bundle ─────────────────────────────────────────
+
+const _BOOTSTRAP_FILE_CANDIDATES: readonly string[] = [
+  "setup.sh",
+  "bootstrap.sh",
+  "install.sh",
+  "Makefile",
+];
+
+/**
+ * Assemble the input for `wiki/getting-started.md` synthesis: top-level
+ * README + package.json scripts + any common bootstrap files (setup.sh,
+ * Makefile, etc.). Gives the LLM enough raw material to produce a
+ * numbered first-run walkthrough for new users.
+ */
+export function assembleGettingStartedInputs(repoRoot: string): SynthesisBundle {
+  const sources: string[] = [];
+  const parts: string[] = [];
+  const notes: string[] = [];
+
+  // README.md (truncated if huge)
+  const readmePath = path.join(repoRoot, "README.md");
+  if (fs.existsSync(readmePath)) {
+    try {
+      const body = fs.readFileSync(readmePath, "utf-8");
+      const truncated =
+        body.length > 50 * 1024
+          ? body.slice(0, 50 * 1024) + "\n... [truncated]\n"
+          : body;
+      sources.push("README.md");
+      parts.push(`## README.md\n\n${truncated}\n`);
+    } catch {
+      notes.push("could not read README.md");
+    }
+  } else {
+    notes.push("no README.md — getting-started will be sparse");
+  }
+
+  // package.json scripts (Node projects)
+  const pkgPath = path.join(repoRoot, "package.json");
+  if (fs.existsSync(pkgPath)) {
+    try {
+      const body = fs.readFileSync(pkgPath, "utf-8");
+      const json = JSON.parse(body) as { scripts?: Record<string, string> };
+      if (json.scripts && Object.keys(json.scripts).length > 0) {
+        sources.push("package.json");
+        parts.push(
+          "## package.json scripts\n\n```json\n" +
+            JSON.stringify(json.scripts, null, 2) +
+            "\n```\n",
+        );
+      }
+    } catch {
+      notes.push("could not parse package.json");
+    }
+  }
+
+  // Bootstrap-y top-level files
+  for (const name of _BOOTSTRAP_FILE_CANDIDATES) {
+    const p = path.join(repoRoot, name);
+    if (!fs.existsSync(p)) continue;
+    try {
+      const body = fs.readFileSync(p, "utf-8");
+      const truncated =
+        body.length > 50 * 1024
+          ? body.slice(0, 50 * 1024) + "\n... [truncated]\n"
+          : body;
+      sources.push(name);
+      parts.push(`## ${name}\n\n\`\`\`\n${truncated}\n\`\`\`\n`);
+    } catch {
+      notes.push(`could not read ${name}`);
+    }
+  }
+
+  return { sources, text: parts.join("\n"), notes };
+}
+
+// ── Configuration bundle ───────────────────────────────────────────
+
+const _CONFIGURATION_FILE_GLOBS: ReadonlyArray<RegExp> = [
+  /^[a-z][a-z0-9-]*\.config\.(ya?ml|json|toml)$/i,
+  /^wiki\.config\.ya?ml$/i,
+  /^\.env\.example$/i,
+  /^\.env\.template$/i,
+  /^\.env\.sample$/i,
+  /^pyproject\.toml$/i,
+  /^Cargo\.toml$/i,
+  /^setup\.cfg$/i,
+  /^settings\.gradle(\.kts)?$/i,
+  /^application\.(properties|ya?ml)$/i,
+];
+
+const _CONFIGURATION_DIR_PATTERNS: ReadonlyArray<{ dir: string; rx: RegExp }> = [
+  { dir: "config", rx: /\.(ya?ml|json|toml|conf|ini|properties)$/i },
+  { dir: ".connectors", rx: /\.ya?ml$/i },
+];
+
+/**
+ * Assemble the input for `wiki/configuration.md` synthesis: top-level
+ * configuration files (wiki.config.yaml, *.config.yaml, .env.example, …)
+ * plus the contents of `config/` and `.connectors/` directories. Gives
+ * the LLM enough surface to produce an operator-facing schema reference.
+ *
+ * Big files (>200 KB) are truncated; a `... [truncated]` marker is left
+ * inline so the synthesis step can note the truncation when relevant.
+ */
+export function assembleConfigurationInputs(repoRoot: string): SynthesisBundle {
+  const sources: string[] = [];
+  const parts: string[] = [];
+  const notes: string[] = [];
+
+  // Top-level files matching configuration globs.
+  let topLevel: fs.Dirent[];
+  try {
+    topLevel = fs.readdirSync(repoRoot, { withFileTypes: true });
+  } catch {
+    notes.push(`could not read repo root: ${repoRoot}`);
+    return { sources, text: "", notes };
+  }
+  for (const e of topLevel) {
+    if (!e.isFile()) continue;
+    if (_CONFIGURATION_FILE_GLOBS.some((rx) => rx.test(e.name))) {
+      sources.push(e.name);
+    }
+  }
+
+  // Directory patterns.
+  for (const { dir, rx } of _CONFIGURATION_DIR_PATTERNS) {
+    const abs = path.join(repoRoot, dir);
+    if (!fs.existsSync(abs)) continue;
+    const walk = (d: string, relBase: string): void => {
+      let entries: fs.Dirent[];
+      try {
+        entries = fs.readdirSync(d, { withFileTypes: true });
+      } catch {
+        return;
+      }
+      for (const e of entries) {
+        const full = path.join(d, e.name);
+        const rel = path.posix.join(relBase, e.name);
+        if (e.isDirectory()) walk(full, rel);
+        else if (e.isFile() && rx.test(e.name)) sources.push(rel);
+      }
+    };
+    walk(abs, dir);
+  }
+
+  sources.sort();
+  if (sources.length === 0) {
+    notes.push("no configuration files matched — wiki/configuration.md will be sparse");
+    return { sources, text: "", notes };
+  }
+
+  for (const rel of sources) {
+    const abs = path.join(repoRoot, rel);
+    let body: string;
+    try {
+      body = fs.readFileSync(abs, "utf-8");
+    } catch {
+      notes.push(`could not read ${rel}`);
+      continue;
+    }
+    const truncated =
+      body.length > 200 * 1024
+        ? body.slice(0, 200 * 1024) + "\n... [truncated]\n"
+        : body;
+    parts.push(`## ${rel}\n\n\`\`\`\n${truncated}\n\`\`\`\n`);
+  }
+  return { sources, text: parts.join("\n"), notes };
+}
+
+// ── Troubleshooting bundle ─────────────────────────────────────────
+
+const _TROUBLESHOOTING_EVENT_LIMIT = 30;
+
+interface AtlasErrorEventLine {
+  raw: string;
+  parsed: Record<string, unknown>;
+}
+
+function _isErrorEvent(rec: Record<string, unknown>): boolean {
+  if (rec["error"] !== undefined && rec["error"] !== null) return true;
+  if (rec["status"] === "failed" || rec["status"] === "error") return true;
+  const details = rec["details"];
+  if (details && typeof details === "object" && !Array.isArray(details)) {
+    const d = details as Record<string, unknown>;
+    if (d["error"] !== undefined && d["error"] !== null) return true;
+    if (d["status"] === "failed" || d["status"] === "error") return true;
+  }
+  return false;
+}
+
+/**
+ * Assemble the input for `wiki/troubleshooting.md` synthesis: the most
+ * recent error/failure events from `events.jsonl` plus the latest atlas
+ * drift report (if present). Gives the LLM symptom signals the page can
+ * organize into symptom → cause → fix triplets.
+ */
+export function assembleTroubleshootingInputs(wikiRoot: string): SynthesisBundle {
+  const sources: string[] = [];
+  const parts: string[] = [];
+  const notes: string[] = [];
+
+  // Recent error events from events.jsonl
+  const eventsPath = path.join(wikiRoot, "log", "events.jsonl");
+  if (fs.existsSync(eventsPath)) {
+    let lines: string[];
+    try {
+      lines = fs.readFileSync(eventsPath, "utf-8").split("\n");
+    } catch {
+      lines = [];
+    }
+    const errors: AtlasErrorEventLine[] = [];
+    for (
+      let i = lines.length - 1;
+      i >= 0 && errors.length < _TROUBLESHOOTING_EVENT_LIMIT;
+      i--
+    ) {
+      const line = lines[i];
+      if (!line) continue;
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(line);
+      } catch {
+        continue;
+      }
+      if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) continue;
+      const rec = parsed as Record<string, unknown>;
+      if (_isErrorEvent(rec)) {
+        errors.push({ raw: line, parsed: rec });
+      }
+    }
+    if (errors.length > 0) {
+      sources.push("log/events.jsonl");
+      parts.push("## Recent error/failure events\n");
+      parts.push("```jsonl");
+      // Reverse so oldest-first within the recent window
+      for (const e of [...errors].reverse()) parts.push(e.raw);
+      parts.push("```\n");
+    } else {
+      notes.push("no error events in events.jsonl — troubleshooting will be sparse");
+    }
+  } else {
+    notes.push("no log/events.jsonl found");
+  }
+
+  // Latest atlas drift report
+  const atlasOutputs = path.join(wikiRoot, "outputs", "atlas");
+  if (fs.existsSync(atlasOutputs)) {
+    let runs: string[];
+    try {
+      runs = fs
+        .readdirSync(atlasOutputs, { withFileTypes: true })
+        .filter((e) => e.isDirectory())
+        .map((e) => e.name)
+        .sort()
+        .reverse();
+    } catch {
+      runs = [];
+    }
+    for (const run of runs) {
+      const driftPath = path.join(atlasOutputs, run, "drift-report.md");
+      if (!fs.existsSync(driftPath)) continue;
+      try {
+        const body = fs.readFileSync(driftPath, "utf-8");
+        const rel = path.posix.join("outputs", "atlas", run, "drift-report.md");
+        sources.push(rel);
+        parts.push(`## Drift report (${run})\n\n${body.trim()}\n`);
+        break; // only the most recent
+      } catch {
+        notes.push(`could not read ${driftPath}`);
+      }
+    }
+  }
+
+  return { sources, text: parts.join("\n"), notes };
+}
+
 // ── CLI ────────────────────────────────────────────────────────────
 
 const FLAG_SPEC = {
@@ -332,17 +836,26 @@ const FLAG_SPEC = {
   "--connectors-config": "connectorsConfig",
 } as const;
 
-const HELP_TEXT = `usage: atlas_synthesize.js {overview,integrations,deploy} [...]
+const HELP_TEXT = `usage: atlas_synthesize.js {overview,integrations,deploy,commands,configuration,getting-started,troubleshooting} [...]
 
 Read-only input assembly for /doc-wiki:atlas global synthesis.
 
 Subcommands:
-  overview       --wiki-root <p>
-                 Concatenated architecture pages + per-facet TL;DRs.
-  integrations   --wiki-root <p> [--connectors-config <p>]
-                 api.md pages + external-service mentions + connector config.
-  deploy         --wiki-root <p> [--repo-root <p>]
-                 Build/deploy files: Dockerfile, compose, workflows, terraform.
+  overview          --wiki-root <p>
+                    Audience-routing table + concatenated architecture pages +
+                    per-facet TL;DRs.
+  integrations      --wiki-root <p> [--connectors-config <p>]
+                    api.md pages + external-service mentions + connector config.
+  deploy            --wiki-root <p> [--repo-root <p>]
+                    Build/deploy files: Dockerfile, compose, workflows, terraform.
+  commands          --repo-root <p>
+                    commands/*.md wrappers + ### / headings from SKILL.md files.
+  configuration     --repo-root <p>
+                    Top-level config files + config/ + .connectors/ dirs.
+  getting-started   --repo-root <p>
+                    README + package.json scripts + bootstrap files.
+  troubleshooting   --wiki-root <p>
+                    Recent error events + latest atlas drift report.
 
 Each prints one JSON object on stdout with keys: sources, text, notes.
 `;
@@ -365,31 +878,51 @@ export function main(argv: readonly string[] = process.argv.slice(2)): number {
     return 0;
   }
   const wikiRoot = parsed.values["wikiRoot"];
-  if (typeof wikiRoot !== "string" || wikiRoot.length === 0) {
-    process.stderr.write("--wiki-root is required\n");
-    return 2;
+  const repoRoot =
+    typeof parsed.values["repoRoot"] === "string" && parsed.values["repoRoot"].length > 0
+      ? parsed.values["repoRoot"]
+      : process.cwd();
+
+  // Subcommands that need --wiki-root.
+  if (sub === "overview" || sub === "integrations" || sub === "troubleshooting") {
+    if (typeof wikiRoot !== "string" || wikiRoot.length === 0) {
+      process.stderr.write("--wiki-root is required\n");
+      return 2;
+    }
+    let bundle: SynthesisBundle;
+    if (sub === "overview") {
+      bundle = assembleOverviewInputs(wikiRoot);
+    } else if (sub === "integrations") {
+      const cfg =
+        typeof parsed.values["connectorsConfig"] === "string"
+          ? parsed.values["connectorsConfig"]
+          : undefined;
+      bundle = assembleIntegrationsInputs(wikiRoot, cfg);
+    } else {
+      bundle = assembleTroubleshootingInputs(wikiRoot);
+    }
+    process.stdout.write(JSON.stringify(bundle) + "\n");
+    return 0;
   }
 
-  if (sub === "overview") {
-    const bundle = assembleOverviewInputs(wikiRoot);
-    process.stdout.write(JSON.stringify(bundle) + "\n");
-    return 0;
-  }
-  if (sub === "integrations") {
-    const cfg =
-      typeof parsed.values["connectorsConfig"] === "string"
-        ? parsed.values["connectorsConfig"]
-        : undefined;
-    const bundle = assembleIntegrationsInputs(wikiRoot, cfg);
-    process.stdout.write(JSON.stringify(bundle) + "\n");
-    return 0;
-  }
+  // Subcommands that work off repoRoot (cwd by default).
   if (sub === "deploy") {
-    const repoRoot =
-      typeof parsed.values["repoRoot"] === "string" && parsed.values["repoRoot"].length > 0
-        ? parsed.values["repoRoot"]
-        : process.cwd();
     const bundle = assembleDeployInputs(repoRoot);
+    process.stdout.write(JSON.stringify(bundle) + "\n");
+    return 0;
+  }
+  if (sub === "commands") {
+    const bundle = assembleCommandsInputs(repoRoot);
+    process.stdout.write(JSON.stringify(bundle) + "\n");
+    return 0;
+  }
+  if (sub === "getting-started") {
+    const bundle = assembleGettingStartedInputs(repoRoot);
+    process.stdout.write(JSON.stringify(bundle) + "\n");
+    return 0;
+  }
+  if (sub === "configuration") {
+    const bundle = assembleConfigurationInputs(repoRoot);
     process.stdout.write(JSON.stringify(bundle) + "\n");
     return 0;
   }

--- a/agents/lib/mermaid_format.js
+++ b/agents/lib/mermaid_format.js
@@ -123,3 +123,85 @@ export function formatErDiagram(title, tables, relationships = []) {
     }
     return { type: "erDiagram", title, code: lines.join("\n") };
 }
+/**
+ * Sanitize a phase-pipeline node label. Same character-escape policy as
+ * `sanitizeLabel`, but preserves multi-line content by converting real
+ * newlines to `<br/>` so Mermaid renders them as line breaks inside the
+ * node box.
+ */
+function sanitizePhaseLabel(label) {
+    return label
+        .replace(/&/g, "&amp;")
+        .replace(/"/g, "&quot;")
+        .replace(/\|/g, "&#124;")
+        .replace(/\[/g, "&#91;")
+        .replace(/\]/g, "&#93;")
+        .replace(/\{/g, "&#123;")
+        .replace(/\}/g, "&#125;")
+        .replace(/\r\n|\n|\r/g, "<br/>")
+        .trim();
+}
+/**
+ * Format a `flowchart TD` phase-pipeline diagram with optional classDef
+ * styling. Use for self-describing process diagrams: orchestrator phases,
+ * decision gates, lifecycle flows. Mirrors the styled-flowchart pattern
+ * documented in `docs/architecture.md` (the atlas-pipeline diagram).
+ *
+ *   - Rectangular nodes (default): `${id}["label"]`
+ *   - Diamond decision nodes: `${id}{"label"}`
+ *   - Edges: `from --> to` or `from -- label --> to`
+ *   - Per-class color via `classDef name fill:#hex,stroke:#hex`
+ *   - Class assignment grouped: `class id1,id2 className`
+ *
+ * Multi-line labels are preserved (real `\n` becomes `<br/>`).
+ */
+export function formatPhaseFlow(title, nodes, edges, classDefs = []) {
+    const lines = ["flowchart TD"];
+    const seen = new Set();
+    for (const n of nodes) {
+        const id = sanitizeNodeId(n.id);
+        if (seen.has(id))
+            continue;
+        seen.add(id);
+        const label = sanitizePhaseLabel(n.label);
+        if (n.shape === "diamond") {
+            lines.push(`    ${id}{"${label}"}`);
+        }
+        else {
+            lines.push(`    ${id}["${label}"]`);
+        }
+    }
+    for (const e of edges) {
+        const from = sanitizeNodeId(e.from);
+        const to = sanitizeNodeId(e.to);
+        if (e.label !== undefined && e.label !== "") {
+            lines.push(`    ${from} -- ${sanitizePhaseLabel(e.label)} --> ${to}`);
+        }
+        else {
+            lines.push(`    ${from} --> ${to}`);
+        }
+    }
+    for (const c of classDefs) {
+        lines.push(`    classDef ${c.name} fill:${c.fill},stroke:${c.stroke}`);
+    }
+    // Group class assignments by className so each className gets one line.
+    const byClass = new Map();
+    for (const n of nodes) {
+        if (!n.className)
+            continue;
+        const id = sanitizeNodeId(n.id);
+        const list = byClass.get(n.className);
+        if (list)
+            list.push(id);
+        else
+            byClass.set(n.className, [id]);
+    }
+    for (const [name, ids] of byClass) {
+        lines.push(`    class ${ids.join(",")} ${name}`);
+    }
+    return {
+        type: "flowchart TD",
+        title,
+        code: lines.join("\n"),
+    };
+}

--- a/agents/lib/mermaid_format.ts
+++ b/agents/lib/mermaid_format.ts
@@ -73,6 +73,35 @@ export interface ErRelationship {
   label: string;
 }
 
+/** One node in a `flowchart TD` phase-pipeline diagram. */
+export interface PhaseNode {
+  id: string;
+  /** Multi-line labels are supported — `\n` becomes `<br/>` in the output. */
+  label: string;
+  /** `rect` (default) renders as `["label"]`; `diamond` as `{"label"}` for decisions. */
+  shape?: "rect" | "diamond";
+  /** Optional class name from `classDefs` to apply this node's styling. */
+  className?: string;
+}
+
+/** One directed edge in a `flowchart TD` phase-pipeline diagram. */
+export interface PhaseEdge {
+  from: string;
+  to: string;
+  /** Optional edge label — rendered as `-- label -->` (Mermaid flowchart syntax). */
+  label?: string;
+}
+
+/** One classDef styling block for a phase-pipeline diagram. */
+export interface ClassDef {
+  /** Class name referenced by `PhaseNode.className`. */
+  name: string;
+  /** CSS color, e.g. `#fff3cd`. */
+  fill: string;
+  /** CSS stroke color, e.g. `#856404`. */
+  stroke: string;
+}
+
 /**
  * Replace characters that Mermaid treats specially inside node labels
  * with HTML-escaped equivalents. Keeps the label readable while making
@@ -187,4 +216,87 @@ export function formatErDiagram(
     );
   }
   return { type: "erDiagram", title, code: lines.join("\n") };
+}
+
+/**
+ * Sanitize a phase-pipeline node label. Same character-escape policy as
+ * `sanitizeLabel`, but preserves multi-line content by converting real
+ * newlines to `<br/>` so Mermaid renders them as line breaks inside the
+ * node box.
+ */
+function sanitizePhaseLabel(label: string): string {
+  return label
+    .replace(/&/g, "&amp;")
+    .replace(/"/g, "&quot;")
+    .replace(/\|/g, "&#124;")
+    .replace(/\[/g, "&#91;")
+    .replace(/\]/g, "&#93;")
+    .replace(/\{/g, "&#123;")
+    .replace(/\}/g, "&#125;")
+    .replace(/\r\n|\n|\r/g, "<br/>")
+    .trim();
+}
+
+/**
+ * Format a `flowchart TD` phase-pipeline diagram with optional classDef
+ * styling. Use for self-describing process diagrams: orchestrator phases,
+ * decision gates, lifecycle flows. Mirrors the styled-flowchart pattern
+ * documented in `docs/architecture.md` (the atlas-pipeline diagram).
+ *
+ *   - Rectangular nodes (default): `${id}["label"]`
+ *   - Diamond decision nodes: `${id}{"label"}`
+ *   - Edges: `from --> to` or `from -- label --> to`
+ *   - Per-class color via `classDef name fill:#hex,stroke:#hex`
+ *   - Class assignment grouped: `class id1,id2 className`
+ *
+ * Multi-line labels are preserved (real `\n` becomes `<br/>`).
+ */
+export function formatPhaseFlow(
+  title: string,
+  nodes: readonly PhaseNode[],
+  edges: readonly PhaseEdge[],
+  classDefs: readonly ClassDef[] = [],
+): MermaidBlock {
+  const lines: string[] = ["flowchart TD"];
+  const seen = new Set<string>();
+  for (const n of nodes) {
+    const id = sanitizeNodeId(n.id);
+    if (seen.has(id)) continue;
+    seen.add(id);
+    const label = sanitizePhaseLabel(n.label);
+    if (n.shape === "diamond") {
+      lines.push(`    ${id}{"${label}"}`);
+    } else {
+      lines.push(`    ${id}["${label}"]`);
+    }
+  }
+  for (const e of edges) {
+    const from = sanitizeNodeId(e.from);
+    const to = sanitizeNodeId(e.to);
+    if (e.label !== undefined && e.label !== "") {
+      lines.push(`    ${from} -- ${sanitizePhaseLabel(e.label)} --> ${to}`);
+    } else {
+      lines.push(`    ${from} --> ${to}`);
+    }
+  }
+  for (const c of classDefs) {
+    lines.push(`    classDef ${c.name} fill:${c.fill},stroke:${c.stroke}`);
+  }
+  // Group class assignments by className so each className gets one line.
+  const byClass = new Map<string, string[]>();
+  for (const n of nodes) {
+    if (!n.className) continue;
+    const id = sanitizeNodeId(n.id);
+    const list = byClass.get(n.className);
+    if (list) list.push(id);
+    else byClass.set(n.className, [id]);
+  }
+  for (const [name, ids] of byClass) {
+    lines.push(`    class ${ids.join(",")} ${name}`);
+  }
+  return {
+    type: "flowchart TD",
+    title,
+    code: lines.join("\n"),
+  };
 }

--- a/agents/lib/source_registry.js
+++ b/agents/lib/source_registry.js
@@ -91,6 +91,15 @@ const BUILTIN_PATTERNS = [
         label: "Database",
     },
 ];
+/**
+ * Builtin connector short IDs (e.g. "jira", "confluence", "github").
+ * Read-only view over `BUILTIN_PATTERNS` — does NOT mutate the global
+ * registry. Use this when you only need the connector names (atlas
+ * integration-keyword detection, doc generation), not full manifests.
+ */
+export function builtinConnectorIds() {
+    return BUILTIN_PATTERNS.map((p) => p.id);
+}
 function patternToManifest(p) {
     const name = `wiki-${p.id}-agent`;
     return {

--- a/agents/lib/source_registry.ts
+++ b/agents/lib/source_registry.ts
@@ -159,6 +159,16 @@ const BUILTIN_PATTERNS: readonly BuiltinPattern[] = [
   },
 ];
 
+/**
+ * Builtin connector short IDs (e.g. "jira", "confluence", "github").
+ * Read-only view over `BUILTIN_PATTERNS` — does NOT mutate the global
+ * registry. Use this when you only need the connector names (atlas
+ * integration-keyword detection, doc generation), not full manifests.
+ */
+export function builtinConnectorIds(): string[] {
+  return BUILTIN_PATTERNS.map((p) => p.id);
+}
+
 function patternToManifest(p: BuiltinPattern): AgentManifest {
   const name = `wiki-${p.id}-agent`;
   return {

--- a/agents/lib/tests/atlas_synthesize.test.ts
+++ b/agents/lib/tests/atlas_synthesize.test.ts
@@ -1,0 +1,495 @@
+/**
+ * Tests for atlas_synthesize.ts — read-only input bundles for the
+ * /doc-wiki:atlas Phase 7 global synthesis. Each `assembleX` function
+ * produces a `SynthesisBundle` ({sources, text, notes}) that the LLM
+ * synthesis step consumes.
+ */
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as yaml from "js-yaml";
+
+import {
+  assembleCommandsInputs,
+  assembleConfigurationInputs,
+  assembleDeployInputs,
+  assembleGettingStartedInputs,
+  assembleIntegrationsInputs,
+  assembleOverviewInputs,
+  assembleTroubleshootingInputs,
+} from "../atlas_synthesize.js";
+import { makeTmpPath, cleanupTmpPath } from "./fixtures.js";
+
+// ── Helpers ─────────────────────────────────────────────────────────
+
+function writeAtlasPage(
+  wikiRoot: string,
+  relPath: string,
+  facet: string,
+  body: string = "body",
+  extraFrontmatter: Record<string, unknown> = {},
+): void {
+  const full = path.join(wikiRoot, relPath);
+  fs.mkdirSync(path.dirname(full), { recursive: true });
+  fs.writeFileSync(
+    full,
+    "---\n" +
+      yaml.dump({
+        title: facet,
+        atlas_facet: facet,
+        atlas_run_id: "r1",
+        ...extraFrontmatter,
+      }) +
+      "---\n\n" +
+      body +
+      "\n",
+  );
+}
+
+function makeWikiRoot(tmpPath: string): string {
+  fs.mkdirSync(path.join(tmpPath, "wiki"), { recursive: true });
+  fs.mkdirSync(path.join(tmpPath, "log"), { recursive: true });
+  return tmpPath;
+}
+
+// ── assembleOverviewInputs ─────────────────────────────────────────
+
+describe("assembleOverviewInputs", () => {
+  let tmpPath: string;
+  let wikiRoot: string;
+
+  beforeEach(() => {
+    tmpPath = makeTmpPath("atlas-syn-overview-");
+    wikiRoot = makeWikiRoot(tmpPath);
+  });
+
+  afterEach(() => {
+    cleanupTmpPath(tmpPath);
+  });
+
+  it("returns a sparse bundle with a note when no architecture pages exist", () => {
+    const bundle = assembleOverviewInputs(wikiRoot);
+    expect(bundle.sources).toEqual([]);
+    expect(bundle.notes).toContain("no architecture.md pages found — overview will be sparse");
+  });
+
+  it("emits an audience-routing table at the top when atlas pages exist", () => {
+    writeAtlasPage(wikiRoot, "wiki/auth/architecture.md", "architecture", "auth body");
+    writeAtlasPage(wikiRoot, "wiki/billing/data-model.md", "data-model", "billing body");
+    const bundle = assembleOverviewInputs(wikiRoot);
+    expect(bundle.text).toContain("## Audience routing");
+    expect(bundle.text).toContain("| Audience | Pages |");
+    // architecture + data-model both default to contributor — same row.
+    const lines = bundle.text.split("\n");
+    const contribRow = lines.find((l) => l.startsWith("| contributor |"));
+    expect(contribRow).toBeTruthy();
+    expect(contribRow).toContain("wiki/auth/architecture.md");
+    expect(contribRow).toContain("wiki/billing/data-model.md");
+  });
+
+  it("orders the audience-routing rows new-user → operator → contributor → integrator → debugger", () => {
+    writeAtlasPage(wikiRoot, "wiki/auth/architecture.md", "architecture");
+    writeAtlasPage(wikiRoot, "wiki/auth/api.md", "api");
+    writeAtlasPage(wikiRoot, "wiki/auth/operations.md", "operations");
+    writeAtlasPage(wikiRoot, "wiki/auth/troubleshooting.md", "troubleshooting");
+    writeAtlasPage(wikiRoot, "wiki/auth/getting-started.md", "getting-started");
+    const bundle = assembleOverviewInputs(wikiRoot);
+    const lines = bundle.text.split("\n");
+    const rowIndex = (audience: string): number =>
+      lines.findIndex((l) => l.startsWith(`| ${audience} |`));
+    const order = [
+      rowIndex("new-user"),
+      rowIndex("operator"),
+      rowIndex("contributor"),
+      rowIndex("integrator"),
+      rowIndex("debugger"),
+    ];
+    // Every audience produced a row.
+    for (const i of order) expect(i).toBeGreaterThan(0);
+    // Each later audience appears after the previous one.
+    for (let i = 1; i < order.length; i++) {
+      expect(order[i]).toBeGreaterThan(order[i - 1]!);
+    }
+  });
+
+  it("honors an explicit `audience` frontmatter override", () => {
+    writeAtlasPage(
+      wikiRoot,
+      "wiki/auth/architecture.md",
+      "architecture",
+      "body",
+      { audience: "operator" },
+    );
+    const bundle = assembleOverviewInputs(wikiRoot);
+    const lines = bundle.text.split("\n");
+    const opRow = lines.find((l) => l.startsWith("| operator |"));
+    expect(opRow).toContain("wiki/auth/architecture.md");
+    // No contributor row at all — the only page got remapped.
+    expect(lines.find((l) => l.startsWith("| contributor |"))).toBeFalsy();
+  });
+
+  it("includes architecture page bodies in full and per-facet TL;DRs", () => {
+    writeAtlasPage(
+      wikiRoot,
+      "wiki/auth/architecture.md",
+      "architecture",
+      "FULL ARCHITECTURE BODY",
+    );
+    writeAtlasPage(
+      wikiRoot,
+      "wiki/auth/data-model.md",
+      "data-model",
+      "## TL;DR\nthe data-model summary\n\n## Body\nirrelevant",
+    );
+    const bundle = assembleOverviewInputs(wikiRoot);
+    expect(bundle.text).toContain("FULL ARCHITECTURE BODY");
+    expect(bundle.text).toContain("the data-model summary");
+    expect(bundle.text).toContain("## Per-facet TL;DRs");
+  });
+});
+
+// ── assembleIntegrationsInputs ─────────────────────────────────────
+
+describe("assembleIntegrationsInputs", () => {
+  let tmpPath: string;
+  let wikiRoot: string;
+
+  beforeEach(() => {
+    tmpPath = makeTmpPath("atlas-syn-integ-");
+    wikiRoot = makeWikiRoot(tmpPath);
+  });
+
+  afterEach(() => {
+    cleanupTmpPath(tmpPath);
+  });
+
+  it("flags architecture-page lines that mention a builtin connector id", () => {
+    // jira / github / etc. are sourced from BUILTIN_PATTERNS via source_registry.
+    writeAtlasPage(
+      wikiRoot,
+      "wiki/auth/architecture.md",
+      "architecture",
+      "We sync issues to JIRA via the connector.\nGITHUB notifications go to Slack.",
+    );
+    const bundle = assembleIntegrationsInputs(wikiRoot);
+    expect(bundle.text).toContain("external-mentions in wiki/auth/architecture.md");
+    expect(bundle.text.toLowerCase()).toContain("jira");
+    expect(bundle.text.toLowerCase()).toContain("github");
+  });
+
+  it("still flags mentions of common SaaS keywords not in BUILTIN_PATTERNS", () => {
+    writeAtlasPage(
+      wikiRoot,
+      "wiki/billing/architecture.md",
+      "architecture",
+      "Payments use Stripe and observability is Datadog.",
+    );
+    const bundle = assembleIntegrationsInputs(wikiRoot);
+    expect(bundle.text.toLowerCase()).toContain("stripe");
+    expect(bundle.text.toLowerCase()).toContain("datadog");
+  });
+
+  it("does NOT flag the `db` keyword (filtered out as not an external service)", () => {
+    writeAtlasPage(
+      wikiRoot,
+      "wiki/auth/architecture.md",
+      "architecture",
+      "We talk to the local postgres DB at startup.",
+    );
+    const bundle = assembleIntegrationsInputs(wikiRoot);
+    // "db" should not produce an external-mention row.
+    expect(bundle.text).not.toContain("external-mentions");
+  });
+
+  it("notes when no api pages exist", () => {
+    const bundle = assembleIntegrationsInputs(wikiRoot);
+    expect(bundle.notes.some((n) => n.includes("no api.md pages found"))).toBe(true);
+  });
+});
+
+// ── assembleDeployInputs (smoke test for new behavior alongside existing) ──
+
+describe("assembleDeployInputs", () => {
+  let tmpPath: string;
+
+  beforeEach(() => {
+    tmpPath = makeTmpPath("atlas-syn-deploy-");
+  });
+
+  afterEach(() => {
+    cleanupTmpPath(tmpPath);
+  });
+
+  it("notes when no deploy files match", () => {
+    const bundle = assembleDeployInputs(tmpPath);
+    expect(bundle.sources).toEqual([]);
+    expect(bundle.notes.some((n) => n.includes("no build/deploy files matched"))).toBe(true);
+  });
+
+  it("picks up a top-level Dockerfile", () => {
+    fs.writeFileSync(path.join(tmpPath, "Dockerfile"), "FROM node:20\nRUN ls\n");
+    const bundle = assembleDeployInputs(tmpPath);
+    expect(bundle.sources).toContain("Dockerfile");
+    expect(bundle.text).toContain("FROM node:20");
+  });
+});
+
+// ── assembleCommandsInputs ────────────────────────────────────────
+
+describe("assembleCommandsInputs", () => {
+  let tmpPath: string;
+
+  beforeEach(() => {
+    tmpPath = makeTmpPath("atlas-syn-cmds-");
+  });
+
+  afterEach(() => {
+    cleanupTmpPath(tmpPath);
+  });
+
+  it("notes when no commands/ directory exists", () => {
+    const bundle = assembleCommandsInputs(tmpPath);
+    expect(bundle.sources).toEqual([]);
+    expect(bundle.notes.some((n) => n.includes("no commands/ directory"))).toBe(true);
+  });
+
+  it("includes every commands/*.md wrapper", () => {
+    fs.mkdirSync(path.join(tmpPath, "commands"), { recursive: true });
+    fs.writeFileSync(path.join(tmpPath, "commands", "init.md"), "## init\n\nbootstrap\n");
+    fs.writeFileSync(path.join(tmpPath, "commands", "ingest.md"), "## ingest\n\nfetch\n");
+    const bundle = assembleCommandsInputs(tmpPath);
+    expect(bundle.sources).toContain("commands/init.md");
+    expect(bundle.sources).toContain("commands/ingest.md");
+    expect(bundle.text).toContain("bootstrap");
+    expect(bundle.text).toContain("fetch");
+  });
+
+  it("prepends a Mermaid `flowchart TD` seed of the slash-command fan-out", () => {
+    fs.mkdirSync(path.join(tmpPath, "commands"), { recursive: true });
+    fs.writeFileSync(path.join(tmpPath, "commands", "init.md"), "init body");
+    fs.writeFileSync(path.join(tmpPath, "commands", "ingest.md"), "ingest body");
+    const bundle = assembleCommandsInputs(tmpPath);
+    expect(bundle.text).toContain("<!-- mermaid-seed: slash-command fan-out");
+    expect(bundle.text).toContain("```mermaid");
+    expect(bundle.text).toContain("flowchart TD");
+    expect(bundle.text).toContain('cmd_init["/init"]');
+    expect(bundle.text).toContain('cmd_ingest["/ingest"]');
+    expect(bundle.text).toContain("user --> cmd_init");
+    expect(bundle.text).toContain("cmd_init --> orch");
+    // classDef styling must be present so audience-conditional rendering
+    // can pick up the actor / cmd / orch buckets.
+    expect(bundle.text).toContain("classDef actor");
+    expect(bundle.text).toContain("classDef cmd");
+    expect(bundle.text).toContain("classDef orch");
+    // The seed appears before the per-command bodies (parts.unshift).
+    const seedIdx = bundle.text.indexOf("mermaid-seed");
+    const firstCmdIdx = bundle.text.indexOf("## commands/init.md");
+    expect(seedIdx).toBeGreaterThanOrEqual(0);
+    expect(firstCmdIdx).toBeGreaterThan(seedIdx);
+  });
+
+  it("does not emit a Mermaid seed when no commands/ directory exists", () => {
+    const bundle = assembleCommandsInputs(tmpPath);
+    expect(bundle.text).not.toContain("mermaid-seed");
+    expect(bundle.text).not.toContain("flowchart TD");
+  });
+
+  it("extracts `### /` slash-command headings from any SKILL.md under skills/", () => {
+    const skillDir = path.join(tmpPath, "skills", "my-skill");
+    fs.mkdirSync(skillDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(skillDir, "SKILL.md"),
+      [
+        "# My Skill",
+        "",
+        "## Commands",
+        "",
+        "### /my-skill:foo",
+        "",
+        "Do foo.",
+        "",
+        "### /my-skill:bar",
+        "",
+        "Do bar.",
+        "",
+        "### Not a slash command",
+        "",
+      ].join("\n"),
+    );
+    const bundle = assembleCommandsInputs(tmpPath);
+    expect(bundle.text).toContain("### /my-skill:foo");
+    expect(bundle.text).toContain("### /my-skill:bar");
+    expect(bundle.text).not.toContain("### Not a slash command");
+    expect(bundle.sources.some((s) => s.endsWith("SKILL.md"))).toBe(true);
+  });
+});
+
+// ── assembleGettingStartedInputs ──────────────────────────────────
+
+describe("assembleGettingStartedInputs", () => {
+  let tmpPath: string;
+
+  beforeEach(() => {
+    tmpPath = makeTmpPath("atlas-syn-gs-");
+  });
+
+  afterEach(() => {
+    cleanupTmpPath(tmpPath);
+  });
+
+  it("notes when no README and no bootstrap files exist", () => {
+    const bundle = assembleGettingStartedInputs(tmpPath);
+    expect(bundle.sources).toEqual([]);
+    expect(bundle.notes.some((n) => n.includes("no README.md"))).toBe(true);
+  });
+
+  it("includes README + package.json scripts + Makefile", () => {
+    fs.writeFileSync(path.join(tmpPath, "README.md"), "# Project\n\nQuick start\n");
+    fs.writeFileSync(
+      path.join(tmpPath, "package.json"),
+      JSON.stringify({ scripts: { test: "vitest", build: "tsc" } }),
+    );
+    fs.writeFileSync(path.join(tmpPath, "Makefile"), "build:\n\tnpm run build\n");
+    const bundle = assembleGettingStartedInputs(tmpPath);
+    expect(bundle.sources).toContain("README.md");
+    expect(bundle.sources).toContain("package.json");
+    expect(bundle.sources).toContain("Makefile");
+    expect(bundle.text).toContain("Quick start");
+    expect(bundle.text).toContain('"vitest"');
+    expect(bundle.text).toContain("npm run build");
+  });
+
+  it("truncates very large README bodies", () => {
+    const big = "A".repeat(100 * 1024);
+    fs.writeFileSync(path.join(tmpPath, "README.md"), big);
+    const bundle = assembleGettingStartedInputs(tmpPath);
+    expect(bundle.text).toContain("... [truncated]");
+  });
+
+  it("skips package.json scripts section when empty/missing", () => {
+    fs.writeFileSync(path.join(tmpPath, "README.md"), "x");
+    fs.writeFileSync(path.join(tmpPath, "package.json"), JSON.stringify({ name: "x" }));
+    const bundle = assembleGettingStartedInputs(tmpPath);
+    expect(bundle.text).not.toContain("package.json scripts");
+  });
+});
+
+// ── assembleConfigurationInputs ───────────────────────────────────
+
+describe("assembleConfigurationInputs", () => {
+  let tmpPath: string;
+
+  beforeEach(() => {
+    tmpPath = makeTmpPath("atlas-syn-config-");
+  });
+
+  afterEach(() => {
+    cleanupTmpPath(tmpPath);
+  });
+
+  it("notes when no configuration files match", () => {
+    const bundle = assembleConfigurationInputs(tmpPath);
+    expect(bundle.sources).toEqual([]);
+    expect(bundle.notes.some((n) => n.includes("no configuration files matched"))).toBe(true);
+  });
+
+  it("picks up top-level config files matching the globs", () => {
+    fs.writeFileSync(path.join(tmpPath, "wiki.config.yaml"), "domain: test\n");
+    fs.writeFileSync(path.join(tmpPath, ".env.example"), "DB_URL=\n");
+    fs.writeFileSync(path.join(tmpPath, "pyproject.toml"), "[tool.poetry]\nname=\"x\"\n");
+    const bundle = assembleConfigurationInputs(tmpPath);
+    expect(bundle.sources).toContain("wiki.config.yaml");
+    expect(bundle.sources).toContain(".env.example");
+    expect(bundle.sources).toContain("pyproject.toml");
+    expect(bundle.text).toContain("domain: test");
+  });
+
+  it("walks the config/ and .connectors/ directories", () => {
+    fs.mkdirSync(path.join(tmpPath, "config"), { recursive: true });
+    fs.writeFileSync(path.join(tmpPath, "config", "app.yaml"), "app: yes\n");
+    fs.mkdirSync(path.join(tmpPath, ".connectors"), { recursive: true });
+    fs.writeFileSync(
+      path.join(tmpPath, ".connectors", "config.yaml"),
+      "consumers:\n  doc-wiki: {}\n",
+    );
+    const bundle = assembleConfigurationInputs(tmpPath);
+    expect(bundle.sources).toContain("config/app.yaml");
+    expect(bundle.sources).toContain(".connectors/config.yaml");
+  });
+
+  it("does NOT include unrelated top-level files", () => {
+    fs.writeFileSync(path.join(tmpPath, "README.md"), "x");
+    fs.writeFileSync(path.join(tmpPath, "package.json"), "{}");
+    const bundle = assembleConfigurationInputs(tmpPath);
+    expect(bundle.sources).not.toContain("README.md");
+    expect(bundle.sources).not.toContain("package.json");
+  });
+});
+
+// ── assembleTroubleshootingInputs ─────────────────────────────────
+
+describe("assembleTroubleshootingInputs", () => {
+  let tmpPath: string;
+  let wikiRoot: string;
+
+  beforeEach(() => {
+    tmpPath = makeTmpPath("atlas-syn-tshoot-");
+    wikiRoot = makeWikiRoot(tmpPath);
+  });
+
+  afterEach(() => {
+    cleanupTmpPath(tmpPath);
+  });
+
+  it("notes when events.jsonl does not exist", () => {
+    const bundle = assembleTroubleshootingInputs(wikiRoot);
+    expect(bundle.notes.some((n) => n.includes("no log/events.jsonl found"))).toBe(true);
+  });
+
+  it("surfaces error events from events.jsonl", () => {
+    const eventsPath = path.join(wikiRoot, "log", "events.jsonl");
+    fs.writeFileSync(
+      eventsPath,
+      [
+        JSON.stringify({ op: "ingest", status: "ok" }),
+        JSON.stringify({ op: "ingest", status: "failed", error: "timeout" }),
+        JSON.stringify({ op: "atlas", details: { error: "permission denied" } }),
+      ].join("\n") + "\n",
+    );
+    const bundle = assembleTroubleshootingInputs(wikiRoot);
+    expect(bundle.sources).toContain("log/events.jsonl");
+    expect(bundle.text).toContain("Recent error/failure events");
+    expect(bundle.text).toContain("timeout");
+    expect(bundle.text).toContain("permission denied");
+    // The non-error ingest event must not appear.
+    expect(bundle.text).not.toContain('"op":"ingest","status":"ok"');
+  });
+
+  it("notes when no error events exist", () => {
+    const eventsPath = path.join(wikiRoot, "log", "events.jsonl");
+    fs.writeFileSync(eventsPath, JSON.stringify({ op: "ingest", status: "ok" }) + "\n");
+    const bundle = assembleTroubleshootingInputs(wikiRoot);
+    expect(bundle.notes.some((n) => n.includes("no error events in events.jsonl"))).toBe(true);
+  });
+
+  it("includes the latest atlas drift report when present", () => {
+    const runDir = path.join(wikiRoot, "outputs", "atlas", "2026-04-30T10-00-00");
+    fs.mkdirSync(runDir, { recursive: true });
+    fs.writeFileSync(path.join(runDir, "drift-report.md"), "# Drift\n\nstale auth/architecture.md\n");
+    const bundle = assembleTroubleshootingInputs(wikiRoot);
+    expect(bundle.sources.some((s) => s.includes("drift-report.md"))).toBe(true);
+    expect(bundle.text).toContain("stale auth/architecture.md");
+  });
+
+  it("picks the most recent drift report when multiple runs exist", () => {
+    const older = path.join(wikiRoot, "outputs", "atlas", "2026-04-29T10-00-00");
+    const newer = path.join(wikiRoot, "outputs", "atlas", "2026-04-30T10-00-00");
+    fs.mkdirSync(older, { recursive: true });
+    fs.mkdirSync(newer, { recursive: true });
+    fs.writeFileSync(path.join(older, "drift-report.md"), "OLD DRIFT");
+    fs.writeFileSync(path.join(newer, "drift-report.md"), "NEW DRIFT");
+    const bundle = assembleTroubleshootingInputs(wikiRoot);
+    expect(bundle.text).toContain("NEW DRIFT");
+    expect(bundle.text).not.toContain("OLD DRIFT");
+  });
+});

--- a/agents/lib/tests/mermaid_format.test.ts
+++ b/agents/lib/tests/mermaid_format.test.ts
@@ -6,9 +6,13 @@ import { describe, expect, it } from "vitest";
 import {
   formatErDiagram,
   formatGraph,
+  formatPhaseFlow,
   sanitizeLabel,
   sanitizeNodeId,
+  type ClassDef,
   type MermaidBlock,
+  type PhaseEdge,
+  type PhaseNode,
 } from "../mermaid_format.js";
 
 describe("sanitizeLabel", () => {
@@ -128,5 +132,101 @@ describe("formatErDiagram", () => {
   it("handles tables with no columns and no relationships", () => {
     const block = formatErDiagram("Empty", [], []);
     expect(block.code).toBe("erDiagram");
+  });
+});
+
+describe("formatPhaseFlow", () => {
+  it("emits the flowchart TD header and quoted-bracket rectangles", () => {
+    const nodes: PhaseNode[] = [
+      { id: "p1", label: "Phase 1: Detect" },
+      { id: "p2", label: "Phase 2: Discover" },
+    ];
+    const edges: PhaseEdge[] = [{ from: "p1", to: "p2" }];
+    const block = formatPhaseFlow("pipeline", nodes, edges);
+    expect(block.type).toBe("flowchart TD");
+    expect(block.title).toBe("pipeline");
+    expect(block.code.startsWith("flowchart TD\n")).toBe(true);
+    expect(block.code).toContain('p1["Phase 1: Detect"]');
+    expect(block.code).toContain('p2["Phase 2: Discover"]');
+    expect(block.code).toContain("p1 --> p2");
+  });
+
+  it("renders diamond shape for decision nodes", () => {
+    const nodes: PhaseNode[] = [
+      { id: "gate", label: "over budget?", shape: "diamond" },
+      { id: "abort", label: "Abort" },
+      { id: "go", label: "Continue" },
+    ];
+    const edges: PhaseEdge[] = [
+      { from: "gate", to: "abort", label: "yes" },
+      { from: "gate", to: "go", label: "no" },
+    ];
+    const block = formatPhaseFlow("decision", nodes, edges);
+    expect(block.code).toContain('gate{"over budget?"}');
+    expect(block.code).toContain("gate -- yes --> abort");
+    expect(block.code).toContain("gate -- no --> go");
+  });
+
+  it("converts real newlines in labels to <br/>", () => {
+    const block = formatPhaseFlow(
+      "multi-line",
+      [{ id: "n", label: "line one\nline two\nline three" }],
+      [],
+    );
+    expect(block.code).toContain('n["line one<br/>line two<br/>line three"]');
+    expect(block.code).not.toMatch(/line one\nline two/);
+  });
+
+  it("emits classDef blocks and groups class assignments by className", () => {
+    const nodes: PhaseNode[] = [
+      { id: "a", label: "A", className: "det" },
+      { id: "b", label: "B", className: "llm" },
+      { id: "c", label: "C", className: "det" },
+      { id: "d", label: "D" },
+    ];
+    const classDefs: ClassDef[] = [
+      { name: "det", fill: "#d4edda", stroke: "#155724" },
+      { name: "llm", fill: "#fff3cd", stroke: "#856404" },
+    ];
+    const block = formatPhaseFlow("classes", nodes, [], classDefs);
+    expect(block.code).toContain("classDef det fill:#d4edda,stroke:#155724");
+    expect(block.code).toContain("classDef llm fill:#fff3cd,stroke:#856404");
+    // a and c share className "det" — should be on one line, not two.
+    expect(block.code).toContain("class a,c det");
+    expect(block.code).toContain("class b llm");
+    // d has no className → no class line for it.
+    expect(block.code).not.toMatch(/class d /);
+  });
+
+  it("dedupes repeated node ids", () => {
+    const nodes: PhaseNode[] = [
+      { id: "p1", label: "First" },
+      { id: "p1", label: "Duplicate" },
+    ];
+    const block = formatPhaseFlow("dedupe", nodes, []);
+    const p1Lines = block.code.split("\n").filter((l) => l.includes('p1["'));
+    expect(p1Lines.length).toBe(1);
+    expect(block.code).toContain('p1["First"]');
+  });
+
+  it("escapes special characters inside labels", () => {
+    const block = formatPhaseFlow(
+      "escape",
+      [{ id: "n", label: 'has "quote" and [bracket] and | pipe' }],
+      [],
+    );
+    expect(block.code).toContain("&quot;quote&quot;");
+    expect(block.code).toContain("&#91;bracket&#93;");
+    expect(block.code).toContain("&#124; pipe");
+  });
+
+  it("omits the classDef section entirely when no classDefs are passed", () => {
+    const block = formatPhaseFlow(
+      "no-classes",
+      [{ id: "n", label: "n" }],
+      [],
+    );
+    expect(block.code).not.toContain("classDef");
+    expect(block.code).not.toMatch(/^\s*class /m);
   });
 });

--- a/skills/doc-wiki/SKILL.md
+++ b/skills/doc-wiki/SKILL.md
@@ -204,11 +204,12 @@ This is **a meta-orchestrator over `/doc-wiki:ingest`**. It does not replace the
    - `state == "existing"` → wiki has ≥ 3 atlas pages AND prior atlas event. Run all phases.
    - `state == "hybrid"` → pages exist but no prior atlas event (manual ingests only). Existing-mode discovery; Phase 5's semantic check skips non-atlas pages (those lacking `atlas_run_id` frontmatter).
 
-2. **Discover topics** — union four signals into a deduplicated list:
+2. **Discover topics** — union five signals into a deduplicated list:
    - **Code dirs**: enumerate top-level subdirs of `src/`, `app/`, `services/`, etc. Skip vendor / `node_modules` / `.git`.
    - **ORM domains**: dispatch `wiki-orm-agent` and group entities into topic candidates (e.g., `User` → `auth`; `Invoice` → `billing`).
    - **Existing wiki dirs**: list `wiki/<topic>/` subdirectories (excluding `wiki/outputs/` and similar).
    - **Gitlog churn**: `node {skill_path}/scripts/atlas_gitlog.js classify --wiki-root <root> --since <window> --topics <csv>` flags paths whose changes haven't propagated.
+   - **Tooling / CLI repos** (`domain: tooling` in `wiki.config.yaml` AND a top-level `commands/` directory): also enumerate `commands/*.md` slugs as topic candidates so each slash-command can have its own per-command architecture page. The four audience-flavor pages (commands / configuration / getting-started / troubleshooting) are emitted as Phase 7 globals regardless — this signal only adds per-command topic depth.
 
    Canonicalize each topic name: lowercase-kebab-case, strip `-service`, `-svc`, `-module` suffixes. Deduplicate by canonical name.
 
@@ -233,13 +234,19 @@ This is **a meta-orchestrator over `/doc-wiki:ingest`**. It does not replace the
    - For uncovered files matching a current-run topic (per autonomy mode): `/doc-wiki:ingest <file> --output <inferred>`.
    - Use `scripts/checkpoint.ts` with `opName: "atlas"` to record completed `(topic, facet)` pairs as `<topic>:<facet>`. On `--resume`, load the snapshot via `load-plan` and skip recorded pairs.
 
-7. **Synthesize globals** — always regenerated, regardless of `--facets` and `--scope`:
-   - `wiki/overview.md`: `node agents/lib/atlas_synthesize.js overview --wiki-root <root>` returns a JSON bundle (`{sources, text, notes}`). LLM-synthesize the master architecture narrative; write to `wiki/overview.md` with `atlas_facet: overview` and the run id in frontmatter.
-   - `wiki/integrations.md`: `atlas_synthesize.js integrations --wiki-root <root>`. LLM-synthesize the external-services map.
-   - `wiki/deploy.md`: `atlas_synthesize.js deploy --wiki-root <root>`. Hand the bundle to `/doc-wiki:ingest <synthetic-source> --output wiki/deploy.md`.
+7. **Synthesize globals** — always regenerated, regardless of `--facets` and `--scope`. **Seven global pages**, in this order; each carries `atlas_facet: <slug>` plus the run id in frontmatter, and a default `audience` derived from the slug (see `references/compilation.md` "Additional frontmatter for atlas pages"):
+   - `wiki/overview.md` (audience: `contributor`): `node agents/lib/atlas_synthesize.js overview --wiki-root <root>` returns a JSON bundle (`{sources, text, notes}`) prefixed with an audience-routing table. LLM-synthesize the master architecture narrative.
+   - `wiki/integrations.md` (audience: `integrator`): `atlas_synthesize.js integrations --wiki-root <root>`. Integration-keyword detection is data-driven from `BUILTIN_PATTERNS` (in `agents/lib/source_registry.ts`) plus a curated SaaS list — adding a connector via `wiki.config.yaml`'s `ecosystem.agents.custom` automatically extends the scan. LLM-synthesize the external-services map.
+   - `wiki/deploy.md` (audience: `integrator`): `atlas_synthesize.js deploy --wiki-root <root>`. Hand the bundle to `/doc-wiki:ingest <synthetic-source> --output wiki/deploy.md`.
+   - `wiki/commands.md` (audience: `operator`): `atlas_synthesize.js commands --repo-root <root>` walks `commands/*.md` plus `### /` headings from any `SKILL.md`. LLM-synthesize a synopsis-table-per-command operator reference.
+   - `wiki/configuration.md` (audience: `operator`): `atlas_synthesize.js configuration --repo-root <root>` walks top-level config files (`wiki.config.yaml`, `*.config.*`, `.env.example`, `pyproject.toml`, …) plus `config/` and `.connectors/` directories. LLM-synthesize a configuration schema reference.
+   - `wiki/getting-started.md` (audience: `new-user`): `atlas_synthesize.js getting-started --repo-root <root>` walks README + `package.json` scripts + bootstrap files (`setup.sh`, `Makefile`, …). LLM-synthesize a numbered first-run walkthrough.
+   - `wiki/troubleshooting.md` (audience: `debugger`): `atlas_synthesize.js troubleshooting --wiki-root <root>` walks recent error events from `events.jsonl` plus the latest atlas drift report. LLM-synthesize symptom → cause → fix triplets.
 
 8. **Finalize**:
    - Run `/doc-wiki:lint` (no `--fix`) and append findings to the drift report.
+   - **Cross-doc-ownership scan**: `node {skill_path}/scripts/atlas_validate.js cross-doc --wiki-root <root>` flags pairs of architecture pages that share both ≥1 source path AND ≥1 Mermaid diagram title. Surface as drift findings — one page should own each shared concept (mirrors the "Cross-doc concerns" registry pattern in `docs/README.md`).
+   - **Gap report**: `node {skill_path}/scripts/atlas_orchestrator.js gap-report --wiki-root <root> --plan '<json>' --run-id <id> --gitlog '<json>'` writes `wiki/outputs/atlas/<run-id>/gap-report.md` enumerating topics-without-pages, facets-without-coverage, source-files-with-no-page, gitlog-uncovered-files, and external-services-without-documentation. Always emitted; non-empty sections are actionable items for a follow-up `--scope` ingest.
    - Update `wiki/index.md` (re-list all atlas pages by facet).
    - Run global crosslink + tag-harmonize over the entire wiki.
    - `node {skill_path}/scripts/event_logger.js log --op atlas --wiki-root <root> --details '<json>'` with fields: `atlas_run_id`, `phase_durations`, `total_cost_usd`, `pages_generated`, `pages_refreshed`, `pages_drifted`, `topics_covered`.
@@ -253,11 +260,11 @@ This is **a meta-orchestrator over `/doc-wiki:ingest`**. It does not replace the
 
 These let atlas recognize its own pages on re-runs and skip semantic-cache invalidation when nothing changed.
 
-**Page template** (every atlas page; targets 300–800 lines, splits to sibling subpages beyond):
+**Page template** — every atlas page targets 300–800 lines, splits to sibling subpages beyond, starts with a TL;DR, and ends with auto-managed cross-links. The body section is **facet-conditional** so each audience gets the structure it needs.
 
 ```text
 ---
-<frontmatter incl. atlas_facet, atlas_run_id, sources, summary>
+<frontmatter incl. atlas_facet, atlas_run_id, sources, summary, audience>
 ---
 
 # <Title>
@@ -265,7 +272,7 @@ These let atlas recognize its own pages on re-runs and skip semantic-cache inval
 ## TL;DR
 <3–5 sentences>
 
-## <body sections>
+<body sections — see facet table below>
 
 ## How to Go Deeper
 <links to deeper sources or sibling pages>
@@ -273,6 +280,25 @@ These let atlas recognize its own pages on re-runs and skip semantic-cache inval
 ## Related Pages
 <auto-managed by crosslink hook>
 ```
+
+**Body sections by facet** (the LLM should follow these structural conventions; they mirror the patterns documented in `docs/architecture.md`, `docs/commands.md`, `docs/troubleshooting.md`):
+
+| Facet | Audience | Body sections (mandatory unless noted) |
+|---|---|---|
+| `architecture` | `contributor` | A layered model section + Mermaid `flowchart` or `sequenceDiagram` + `## Architecture contracts` (numbered load-bearing invariants) |
+| `data-model` | `contributor` | Summary-metrics table + entity↔table mapping + `erDiagram` (mandatory) + unmapped-tables list |
+| `environments` | `contributor` | Per-env table + secret-resolution rules + network topology |
+| `api` | `integrator` | Per-endpoint synopsis + request/response samples + `sequenceDiagram` (recommended) |
+| `operations` | `operator` | Runbook with triggers + recovery steps + escalation contacts |
+| `commands` | `operator` | Per-command `## /<command>:<sub>` with synopsis + args table + examples (shell blocks) |
+| `configuration` | `operator` | One `## <filename>` heading per config file (with a `field \| type \| default \| meaning` table). Then a top-level `## Credential reference grammar` heading (table mapping schemes — `env:`, `keychain:`, `file:`, `cloud:aws-secret/`, `cloud:gcp-secret/` — to resolution targets). Then a top-level `## Resolution order` heading (numbered list, most-specific-wins). Then a top-level `## Worked example`. Subsections like "credential grammar" must NOT live inside the per-file headings — keep them top-level so readers can link directly. |
+| `getting-started` | `new-user` | Numbered prereq → install → first-command walkthrough |
+| `troubleshooting` | `debugger` | `### Symptom / ### Cause / ### Fix` triplets, one per common failure mode |
+| `overview` | `contributor` | Audience-routing table at top, then a layered architecture narrative |
+| `integrations` | `integrator` | Per-service subsection: credentials + actions + sample CLI |
+| `deploy` | `integrator` | Per-target build/deploy sequence + environment matrix |
+
+The `audience` frontmatter drives the section choice; the `atlas_facet` drives which Mermaid diagrams are mandatory (per `quality_score.ts` `MERMAID_EXPECTED_TAGS`). When an existing page contradicts this template (e.g., an `architecture` page with `### Symptom` headings), Phase 5 surfaces it as a structural drift finding.
 
 **Additive re-runs invariant**: pages from prior runs are NEVER deleted by a smaller-`--facets` re-run. Validation (Phase 5) runs on every existing atlas page regardless of current `--facets`. (Re-)generation (Phase 6) only touches facets in the current `--facets` set that are stale or missing.
 

--- a/skills/doc-wiki/references/compilation.md
+++ b/skills/doc-wiki/references/compilation.md
@@ -56,6 +56,31 @@ references:
     content_hash: e3b0c44298fc...
 ```
 
+### Additional frontmatter for atlas pages (audience targeting)
+
+Atlas-generated pages should include an `audience` field so readers can route to the
+right depth. Five values are recognized:
+
+- `new-user` — Reader is installing or running for the first time.
+- `operator` — Reader is using the tool day-to-day; needs args, examples, recipes.
+- `contributor` — Reader is modifying internals; needs architecture and contracts.
+- `integrator` — Reader is wiring an external system into the project.
+- `debugger` — Reader is diagnosing a failure; wants symptom → cause → fix.
+
+Defaults inferred from `atlas_facet` when the field is absent:
+
+| Facet | Default audience |
+|---|---|
+| `getting-started` | `new-user` |
+| `commands`, `configuration`, `operations` | `operator` |
+| `architecture`, `data-model`, `environments` | `contributor` |
+| `api`, `integrations`, `deploy` | `integrator` |
+| `troubleshooting` | `debugger` |
+| `overview` | `contributor` |
+
+The audience drives the page-template variant chosen for the body (see `SKILL.md`
+page template) and the routing table at the top of `wiki/overview.md`.
+
 ## Link Enrichment
 
 Before compiling a page, load ~300 characters from the top 2-3 linked pages as context. This produces better cross-references and catches contradictions at write time.

--- a/skills/doc-wiki/scripts/atlas_orchestrator.js
+++ b/skills/doc-wiki/scripts/atlas_orchestrator.js
@@ -237,8 +237,34 @@ export function getRollingPerIngestAvg(wikiRoot, sampleSize = 50) {
     return sum / samples.length;
 }
 // ── Cost estimation ────────────────────────────────────────────────
-const GLOBAL_PAGES_COUNT = 3; // overview, integrations, deploy
+/**
+ * Names of every global synthesis page Phase 7 regenerates. Three were
+ * added in the audience-aware coverage tranche (commands, configuration,
+ * getting-started, troubleshooting) on top of the original three
+ * (overview, integrations, deploy). Every entry costs `GLOBAL_PAGE_AVG_USD`
+ * once per atlas run.
+ */
+const STATIC_GLOBAL_PAGES = [
+    "overview",
+    "integrations",
+    "deploy",
+    "commands",
+    "configuration",
+    "getting-started",
+    "troubleshooting",
+];
 const GLOBAL_PAGE_AVG_USD = 0.20; // synthesis-only, smaller than ingest
+/**
+ * Count of global synthesis pages that will be regenerated unconditionally
+ * in Phase 7 for a given plan. The `facets` argument is reserved for
+ * future per-facet-driven globals (e.g., a `data-model-overview` page only
+ * when the `data-model` facet is in scope). Today every global is
+ * unconditional, so the count is fixed regardless of facets.
+ */
+export function expectedGlobalCount(facets) {
+    void facets;
+    return STATIC_GLOBAL_PAGES.length;
+}
 /**
  * Estimate the cost of running a plan on a wiki. For each `(topic, facet)`
  * entry whose first source resolves to existing readable content with a
@@ -265,7 +291,7 @@ export function estimateCost(wikiRoot, plan, perIngestAvgUsd) {
         }
     }
     const topicCost = expectedIngests * avg;
-    const globalCost = GLOBAL_PAGES_COUNT * GLOBAL_PAGE_AVG_USD;
+    const globalCost = expectedGlobalCount(plan.facets) * GLOBAL_PAGE_AVG_USD;
     return {
         expected_ingests: expectedIngests,
         cache_hits: cacheHits,
@@ -396,6 +422,195 @@ export function loadPlanSnapshot(wikiRoot, runId) {
         created_at: typeof rec["created_at"] === "string" ? rec["created_at"] : "",
     };
 }
+/** Builtin connector ids minus `db` — matches the integration-keyword set
+ *  used by `atlas_synthesize.assembleIntegrationsInputs`. Inlined here to
+ *  avoid cross-package coupling between scripts/ and agents/lib/. */
+const _GAP_REPORT_KNOWN_CONNECTORS = [
+    "jira",
+    "confluence",
+    "github",
+    "notion",
+    "gcp",
+    "aws",
+];
+/**
+ * Build a gap report for the given plan. Read-only — does not write
+ * anything. The orchestrator (Phase 8) is responsible for serializing the
+ * returned object to `wiki/outputs/atlas/<run-id>/gap-report.md`.
+ */
+export function assembleGapReport(wikiRoot, plan, gitlog) {
+    const wikiContent = path.join(wikiRoot, "wiki");
+    // 1. Topics whose directory holds no .md page at all.
+    const topicsWithPages = new Set();
+    if (fs.existsSync(wikiContent)) {
+        for (const topic of plan.topics) {
+            const topicDir = path.join(wikiContent, topic);
+            if (!fs.existsSync(topicDir))
+                continue;
+            let entries;
+            try {
+                entries = fs.readdirSync(topicDir, { withFileTypes: true });
+            }
+            catch {
+                continue;
+            }
+            if (entries.some((e) => e.isFile() && e.name.endsWith(".md"))) {
+                topicsWithPages.add(topic);
+            }
+        }
+    }
+    const topicsWithoutPages = plan.topics.filter((t) => !topicsWithPages.has(t));
+    // 2. (topic, facet) pairs whose expected output page is missing.
+    const facetsWithoutCoverage = [];
+    for (const topic of plan.topics) {
+        for (const facet of plan.facets) {
+            const expected = path.join(wikiContent, topic, `${facet}.md`);
+            if (!fs.existsSync(expected)) {
+                facetsWithoutCoverage.push({ topic, facet });
+            }
+        }
+    }
+    // 3. Source paths from plan entries whose output page wasn't produced.
+    const missingSources = new Set();
+    for (const entry of plan.entries) {
+        const outAbs = path.isAbsolute(entry.output)
+            ? entry.output
+            : path.join(wikiRoot, entry.output);
+        if (fs.existsSync(outAbs))
+            continue;
+        for (const src of entry.sources)
+            missingSources.add(src);
+    }
+    const sourceFilesWithNoPage = [...missingSources].sort();
+    // 4. Gitlog uncovered_files — pass through if provided.
+    const uncoveredFiles = gitlog?.uncovered_files ? [...gitlog.uncovered_files] : [];
+    // 5. Connectors mentioned in atlas pages but missing from integrations.md.
+    const externalServicesWithoutDocumentation = [];
+    const integrationsPath = path.join(wikiContent, "integrations.md");
+    let integrationsBody = "";
+    if (fs.existsSync(integrationsPath)) {
+        try {
+            integrationsBody = fs.readFileSync(integrationsPath, "utf-8").toLowerCase();
+        }
+        catch {
+            integrationsBody = "";
+        }
+    }
+    const archMentions = new Set();
+    if (fs.existsSync(wikiContent)) {
+        const walk = (dir) => {
+            let entries;
+            try {
+                entries = fs.readdirSync(dir, { withFileTypes: true });
+            }
+            catch {
+                return;
+            }
+            for (const e of entries) {
+                const full = path.join(dir, e.name);
+                if (e.isDirectory()) {
+                    walk(full);
+                    continue;
+                }
+                if (!e.isFile() || !full.endsWith(".md"))
+                    continue;
+                let body;
+                try {
+                    body = fs.readFileSync(full, "utf-8").toLowerCase();
+                }
+                catch {
+                    continue;
+                }
+                for (const k of _GAP_REPORT_KNOWN_CONNECTORS) {
+                    if (body.includes(k))
+                        archMentions.add(k);
+                }
+            }
+        };
+        walk(wikiContent);
+    }
+    for (const k of archMentions) {
+        if (!integrationsBody.includes(k))
+            externalServicesWithoutDocumentation.push(k);
+    }
+    externalServicesWithoutDocumentation.sort();
+    return {
+        topicsWithoutPages,
+        facetsWithoutCoverage,
+        sourceFilesWithNoPage,
+        uncoveredFiles,
+        externalServicesWithoutDocumentation,
+    };
+}
+/** Render a {@link GapReport} as a Markdown document for `gap-report.md`. */
+export function renderGapReportMarkdown(report, runId) {
+    const lines = [];
+    lines.push(`# Atlas gap report — ${runId}`);
+    lines.push("");
+    lines.push("Items below were in scope for this atlas run but did not land as wiki pages. " +
+        "Use this list to drive a follow-up `--scope` ingest, file a tracking issue, " +
+        "or accept the gap as out-of-scope.");
+    lines.push("");
+    lines.push("## Topics without any pages");
+    if (report.topicsWithoutPages.length === 0) {
+        lines.push("");
+        lines.push("_(none)_");
+    }
+    else {
+        lines.push("");
+        for (const t of report.topicsWithoutPages)
+            lines.push(`- ${t}`);
+    }
+    lines.push("");
+    lines.push("## Facets without coverage");
+    if (report.facetsWithoutCoverage.length === 0) {
+        lines.push("");
+        lines.push("_(none)_");
+    }
+    else {
+        lines.push("");
+        lines.push("| topic | facet |");
+        lines.push("|---|---|");
+        for (const { topic, facet } of report.facetsWithoutCoverage) {
+            lines.push(`| ${topic} | ${facet} |`);
+        }
+    }
+    lines.push("");
+    lines.push("## Source files with no wiki page");
+    if (report.sourceFilesWithNoPage.length === 0) {
+        lines.push("");
+        lines.push("_(none)_");
+    }
+    else {
+        lines.push("");
+        for (const s of report.sourceFilesWithNoPage)
+            lines.push(`- \`${s}\``);
+    }
+    lines.push("");
+    lines.push("## Uncovered files (gitlog)");
+    if (report.uncoveredFiles.length === 0) {
+        lines.push("");
+        lines.push("_(none)_");
+    }
+    else {
+        lines.push("");
+        for (const f of report.uncoveredFiles)
+            lines.push(`- \`${f}\``);
+    }
+    lines.push("");
+    lines.push("## External services mentioned but undocumented");
+    if (report.externalServicesWithoutDocumentation.length === 0) {
+        lines.push("");
+        lines.push("_(none)_");
+    }
+    else {
+        lines.push("");
+        for (const s of report.externalServicesWithoutDocumentation)
+            lines.push(`- ${s}`);
+    }
+    lines.push("");
+    return lines.join("\n");
+}
 // ── CLI ────────────────────────────────────────────────────────────
 const FLAG_SPEC = {
     "--wiki-root": "wikiRoot",
@@ -403,8 +618,9 @@ const FLAG_SPEC = {
     "--run-id": "runId",
     "--sample-size": "sampleSize",
     "--per-ingest-avg-usd": "perIngestAvgUsd",
+    "--gitlog": "gitlog",
 };
-const HELP_TEXT = `usage: atlas_orchestrator.js {detect-state,estimate-cost,save-plan,load-plan,per-ingest-avg} [...]
+const HELP_TEXT = `usage: atlas_orchestrator.js {detect-state,estimate-cost,save-plan,load-plan,per-ingest-avg,gap-report} [...]
 
 Deterministic helpers for the /doc-wiki:atlas orchestrator.
 
@@ -419,6 +635,10 @@ Subcommands:
                     Load a saved snapshot. Stdout: the Plan, or null.
   per-ingest-avg    --wiki-root <p> [--sample-size <n>]
                     Print the rolling per-ingest cost average. Stdout: {avg_usd}.
+  gap-report        --wiki-root <p> --plan '<json>' [--run-id <id>] [--gitlog '<json>']
+                    Build the gap report. With --run-id, also writes
+                    wiki/outputs/atlas/<run-id>/gap-report.md.
+                    Stdout: GapReport JSON (and {written: path} when --run-id is given).
 `;
 export function main(argv = process.argv.slice(2)) {
     if (argv.length === 0 || argv[0] === "-h" || argv[0] === "--help") {
@@ -516,6 +736,45 @@ export function main(argv = process.argv.slice(2)) {
             : undefined;
         const avg = getRollingPerIngestAvg(wikiRoot, sampleSize);
         process.stdout.write(JSON.stringify({ avg_usd: round2(avg) }) + "\n");
+        return 0;
+    }
+    if (sub === "gap-report") {
+        const planRaw = parsed.values["plan"];
+        if (typeof planRaw !== "string" || planRaw.length === 0) {
+            process.stderr.write("--plan is required\n");
+            return 2;
+        }
+        let plan;
+        try {
+            plan = JSON.parse(planRaw);
+        }
+        catch (e) {
+            process.stderr.write(`--plan is not valid JSON: ${e.message}\n`);
+            return 2;
+        }
+        let gitlog;
+        const gitlogRaw = parsed.values["gitlog"];
+        if (typeof gitlogRaw === "string" && gitlogRaw.length > 0) {
+            try {
+                gitlog = JSON.parse(gitlogRaw);
+            }
+            catch (e) {
+                process.stderr.write(`--gitlog is not valid JSON: ${e.message}\n`);
+                return 2;
+            }
+        }
+        const report = assembleGapReport(wikiRoot, plan, gitlog);
+        const runIdRaw = parsed.values["runId"];
+        if (typeof runIdRaw === "string" && runIdRaw.length > 0) {
+            const md = renderGapReportMarkdown(report, runIdRaw);
+            const target = path.join(wikiRoot, "outputs", "atlas", runIdRaw, "gap-report.md");
+            fs.mkdirSync(path.dirname(target), { recursive: true });
+            fs.writeFileSync(target, md);
+            process.stdout.write(JSON.stringify({ ...report, written: target }) + "\n");
+        }
+        else {
+            process.stdout.write(JSON.stringify(report) + "\n");
+        }
         return 0;
     }
     process.stderr.write(`unknown subcommand: ${sub}\n`);

--- a/skills/doc-wiki/scripts/atlas_orchestrator.ts
+++ b/skills/doc-wiki/scripts/atlas_orchestrator.ts
@@ -276,8 +276,35 @@ export function getRollingPerIngestAvg(
 
 // ── Cost estimation ────────────────────────────────────────────────
 
-const GLOBAL_PAGES_COUNT = 3; // overview, integrations, deploy
+/**
+ * Names of every global synthesis page Phase 7 regenerates. Three were
+ * added in the audience-aware coverage tranche (commands, configuration,
+ * getting-started, troubleshooting) on top of the original three
+ * (overview, integrations, deploy). Every entry costs `GLOBAL_PAGE_AVG_USD`
+ * once per atlas run.
+ */
+const STATIC_GLOBAL_PAGES: readonly string[] = [
+  "overview",
+  "integrations",
+  "deploy",
+  "commands",
+  "configuration",
+  "getting-started",
+  "troubleshooting",
+];
 const GLOBAL_PAGE_AVG_USD = 0.20; // synthesis-only, smaller than ingest
+
+/**
+ * Count of global synthesis pages that will be regenerated unconditionally
+ * in Phase 7 for a given plan. The `facets` argument is reserved for
+ * future per-facet-driven globals (e.g., a `data-model-overview` page only
+ * when the `data-model` facet is in scope). Today every global is
+ * unconditional, so the count is fixed regardless of facets.
+ */
+export function expectedGlobalCount(facets?: readonly string[]): number {
+  void facets;
+  return STATIC_GLOBAL_PAGES.length;
+}
 
 /**
  * Estimate the cost of running a plan on a wiki. For each `(topic, facet)`
@@ -310,7 +337,7 @@ export function estimateCost(
   }
 
   const topicCost = expectedIngests * avg;
-  const globalCost = GLOBAL_PAGES_COUNT * GLOBAL_PAGE_AVG_USD;
+  const globalCost = expectedGlobalCount(plan.facets) * GLOBAL_PAGE_AVG_USD;
   return {
     expected_ingests: expectedIngests,
     cache_hits: cacheHits,
@@ -451,6 +478,229 @@ export function loadPlanSnapshot(
   };
 }
 
+// ── Gap report ─────────────────────────────────────────────────────
+
+/**
+ * Optional gitlog-classification input for the gap report. Mirrors the
+ * shape produced by `atlas_gitlog.js classify`: paths the gitlog scan
+ * flagged as already-referenced (stale), needing-coverage (uncovered),
+ * or unrelated to current topics.
+ */
+export interface GitlogClassification {
+  stale_pages?: string[];
+  uncovered_files?: string[];
+  unrelated_files?: string[];
+}
+
+/**
+ * Concrete deliverable describing what the atlas run did NOT manage to
+ * document. An actionable checklist written to
+ * `wiki/outputs/atlas/<run-id>/gap-report.md` by Phase 8.
+ */
+export interface GapReport {
+  /** Topics in the plan that have no `.md` page in `wiki/<topic>/` at all. */
+  topicsWithoutPages: string[];
+  /** (topic, facet) pairs from the plan whose expected `wiki/<topic>/<facet>.md` does not exist. */
+  facetsWithoutCoverage: Array<{ topic: string; facet: string }>;
+  /** Source paths in plan entries whose `output` page does not exist. Deduplicated. */
+  sourceFilesWithNoPage: string[];
+  /** Files the gitlog scan flagged as needing coverage but no atlas page picked them up. */
+  uncoveredFiles: string[];
+  /** Connector ids mentioned in atlas pages whose connector has no surfaced documentation. */
+  externalServicesWithoutDocumentation: string[];
+}
+
+/** Builtin connector ids minus `db` — matches the integration-keyword set
+ *  used by `atlas_synthesize.assembleIntegrationsInputs`. Inlined here to
+ *  avoid cross-package coupling between scripts/ and agents/lib/. */
+const _GAP_REPORT_KNOWN_CONNECTORS: readonly string[] = [
+  "jira",
+  "confluence",
+  "github",
+  "notion",
+  "gcp",
+  "aws",
+];
+
+/**
+ * Build a gap report for the given plan. Read-only — does not write
+ * anything. The orchestrator (Phase 8) is responsible for serializing the
+ * returned object to `wiki/outputs/atlas/<run-id>/gap-report.md`.
+ */
+export function assembleGapReport(
+  wikiRoot: string,
+  plan: Plan,
+  gitlog?: GitlogClassification,
+): GapReport {
+  const wikiContent = path.join(wikiRoot, "wiki");
+
+  // 1. Topics whose directory holds no .md page at all.
+  const topicsWithPages = new Set<string>();
+  if (fs.existsSync(wikiContent)) {
+    for (const topic of plan.topics) {
+      const topicDir = path.join(wikiContent, topic);
+      if (!fs.existsSync(topicDir)) continue;
+      let entries: fs.Dirent[];
+      try {
+        entries = fs.readdirSync(topicDir, { withFileTypes: true });
+      } catch {
+        continue;
+      }
+      if (entries.some((e) => e.isFile() && e.name.endsWith(".md"))) {
+        topicsWithPages.add(topic);
+      }
+    }
+  }
+  const topicsWithoutPages = plan.topics.filter((t) => !topicsWithPages.has(t));
+
+  // 2. (topic, facet) pairs whose expected output page is missing.
+  const facetsWithoutCoverage: Array<{ topic: string; facet: string }> = [];
+  for (const topic of plan.topics) {
+    for (const facet of plan.facets) {
+      const expected = path.join(wikiContent, topic, `${facet}.md`);
+      if (!fs.existsSync(expected)) {
+        facetsWithoutCoverage.push({ topic, facet });
+      }
+    }
+  }
+
+  // 3. Source paths from plan entries whose output page wasn't produced.
+  const missingSources = new Set<string>();
+  for (const entry of plan.entries) {
+    const outAbs = path.isAbsolute(entry.output)
+      ? entry.output
+      : path.join(wikiRoot, entry.output);
+    if (fs.existsSync(outAbs)) continue;
+    for (const src of entry.sources) missingSources.add(src);
+  }
+  const sourceFilesWithNoPage = [...missingSources].sort();
+
+  // 4. Gitlog uncovered_files — pass through if provided.
+  const uncoveredFiles = gitlog?.uncovered_files ? [...gitlog.uncovered_files] : [];
+
+  // 5. Connectors mentioned in atlas pages but missing from integrations.md.
+  const externalServicesWithoutDocumentation: string[] = [];
+  const integrationsPath = path.join(wikiContent, "integrations.md");
+  let integrationsBody = "";
+  if (fs.existsSync(integrationsPath)) {
+    try {
+      integrationsBody = fs.readFileSync(integrationsPath, "utf-8").toLowerCase();
+    } catch {
+      integrationsBody = "";
+    }
+  }
+  const archMentions = new Set<string>();
+  if (fs.existsSync(wikiContent)) {
+    const walk = (dir: string): void => {
+      let entries: fs.Dirent[];
+      try {
+        entries = fs.readdirSync(dir, { withFileTypes: true });
+      } catch {
+        return;
+      }
+      for (const e of entries) {
+        const full = path.join(dir, e.name);
+        if (e.isDirectory()) {
+          walk(full);
+          continue;
+        }
+        if (!e.isFile() || !full.endsWith(".md")) continue;
+        let body: string;
+        try {
+          body = fs.readFileSync(full, "utf-8").toLowerCase();
+        } catch {
+          continue;
+        }
+        for (const k of _GAP_REPORT_KNOWN_CONNECTORS) {
+          if (body.includes(k)) archMentions.add(k);
+        }
+      }
+    };
+    walk(wikiContent);
+  }
+  for (const k of archMentions) {
+    if (!integrationsBody.includes(k)) externalServicesWithoutDocumentation.push(k);
+  }
+  externalServicesWithoutDocumentation.sort();
+
+  return {
+    topicsWithoutPages,
+    facetsWithoutCoverage,
+    sourceFilesWithNoPage,
+    uncoveredFiles,
+    externalServicesWithoutDocumentation,
+  };
+}
+
+/** Render a {@link GapReport} as a Markdown document for `gap-report.md`. */
+export function renderGapReportMarkdown(report: GapReport, runId: string): string {
+  const lines: string[] = [];
+  lines.push(`# Atlas gap report — ${runId}`);
+  lines.push("");
+  lines.push(
+    "Items below were in scope for this atlas run but did not land as wiki pages. " +
+      "Use this list to drive a follow-up `--scope` ingest, file a tracking issue, " +
+      "or accept the gap as out-of-scope.",
+  );
+  lines.push("");
+
+  lines.push("## Topics without any pages");
+  if (report.topicsWithoutPages.length === 0) {
+    lines.push("");
+    lines.push("_(none)_");
+  } else {
+    lines.push("");
+    for (const t of report.topicsWithoutPages) lines.push(`- ${t}`);
+  }
+  lines.push("");
+
+  lines.push("## Facets without coverage");
+  if (report.facetsWithoutCoverage.length === 0) {
+    lines.push("");
+    lines.push("_(none)_");
+  } else {
+    lines.push("");
+    lines.push("| topic | facet |");
+    lines.push("|---|---|");
+    for (const { topic, facet } of report.facetsWithoutCoverage) {
+      lines.push(`| ${topic} | ${facet} |`);
+    }
+  }
+  lines.push("");
+
+  lines.push("## Source files with no wiki page");
+  if (report.sourceFilesWithNoPage.length === 0) {
+    lines.push("");
+    lines.push("_(none)_");
+  } else {
+    lines.push("");
+    for (const s of report.sourceFilesWithNoPage) lines.push(`- \`${s}\``);
+  }
+  lines.push("");
+
+  lines.push("## Uncovered files (gitlog)");
+  if (report.uncoveredFiles.length === 0) {
+    lines.push("");
+    lines.push("_(none)_");
+  } else {
+    lines.push("");
+    for (const f of report.uncoveredFiles) lines.push(`- \`${f}\``);
+  }
+  lines.push("");
+
+  lines.push("## External services mentioned but undocumented");
+  if (report.externalServicesWithoutDocumentation.length === 0) {
+    lines.push("");
+    lines.push("_(none)_");
+  } else {
+    lines.push("");
+    for (const s of report.externalServicesWithoutDocumentation) lines.push(`- ${s}`);
+  }
+  lines.push("");
+
+  return lines.join("\n");
+}
+
 // ── CLI ────────────────────────────────────────────────────────────
 
 const FLAG_SPEC = {
@@ -459,9 +709,10 @@ const FLAG_SPEC = {
   "--run-id": "runId",
   "--sample-size": "sampleSize",
   "--per-ingest-avg-usd": "perIngestAvgUsd",
+  "--gitlog": "gitlog",
 } as const;
 
-const HELP_TEXT = `usage: atlas_orchestrator.js {detect-state,estimate-cost,save-plan,load-plan,per-ingest-avg} [...]
+const HELP_TEXT = `usage: atlas_orchestrator.js {detect-state,estimate-cost,save-plan,load-plan,per-ingest-avg,gap-report} [...]
 
 Deterministic helpers for the /doc-wiki:atlas orchestrator.
 
@@ -476,6 +727,10 @@ Subcommands:
                     Load a saved snapshot. Stdout: the Plan, or null.
   per-ingest-avg    --wiki-root <p> [--sample-size <n>]
                     Print the rolling per-ingest cost average. Stdout: {avg_usd}.
+  gap-report        --wiki-root <p> --plan '<json>' [--run-id <id>] [--gitlog '<json>']
+                    Build the gap report. With --run-id, also writes
+                    wiki/outputs/atlas/<run-id>/gap-report.md.
+                    Stdout: GapReport JSON (and {written: path} when --run-id is given).
 `;
 
 export function main(argv: readonly string[] = process.argv.slice(2)): number {
@@ -580,6 +835,49 @@ export function main(argv: readonly string[] = process.argv.slice(2)): number {
         : undefined;
     const avg = getRollingPerIngestAvg(wikiRoot, sampleSize);
     process.stdout.write(JSON.stringify({ avg_usd: round2(avg) }) + "\n");
+    return 0;
+  }
+
+  if (sub === "gap-report") {
+    const planRaw = parsed.values["plan"];
+    if (typeof planRaw !== "string" || planRaw.length === 0) {
+      process.stderr.write("--plan is required\n");
+      return 2;
+    }
+    let plan: Plan;
+    try {
+      plan = JSON.parse(planRaw) as Plan;
+    } catch (e) {
+      process.stderr.write(`--plan is not valid JSON: ${(e as Error).message}\n`);
+      return 2;
+    }
+    let gitlog: GitlogClassification | undefined;
+    const gitlogRaw = parsed.values["gitlog"];
+    if (typeof gitlogRaw === "string" && gitlogRaw.length > 0) {
+      try {
+        gitlog = JSON.parse(gitlogRaw) as GitlogClassification;
+      } catch (e) {
+        process.stderr.write(`--gitlog is not valid JSON: ${(e as Error).message}\n`);
+        return 2;
+      }
+    }
+    const report = assembleGapReport(wikiRoot, plan, gitlog);
+    const runIdRaw = parsed.values["runId"];
+    if (typeof runIdRaw === "string" && runIdRaw.length > 0) {
+      const md = renderGapReportMarkdown(report, runIdRaw);
+      const target = path.join(
+        wikiRoot,
+        "outputs",
+        "atlas",
+        runIdRaw,
+        "gap-report.md",
+      );
+      fs.mkdirSync(path.dirname(target), { recursive: true });
+      fs.writeFileSync(target, md);
+      process.stdout.write(JSON.stringify({ ...report, written: target }) + "\n");
+    } else {
+      process.stdout.write(JSON.stringify(report) + "\n");
+    }
     return 0;
   }
 

--- a/skills/doc-wiki/scripts/atlas_validate.js
+++ b/skills/doc-wiki/scripts/atlas_validate.js
@@ -29,6 +29,7 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
 import { parseFlags } from "./_cli_args.js";
+import { parseFrontmatter } from "./_frontmatter.js";
 // ── Constants ──────────────────────────────────────────────────────
 export const VALIDATE_CACHE_SUBDIR = path.join(".wiki-cache", "atlas-validate");
 /** Bumped when on-disk format changes; forces auto-invalidation. */
@@ -191,6 +192,116 @@ export function validateStructural(wikiRoot, pageRelPath) {
     }
     return out;
 }
+// ── Cross-doc ownership ────────────────────────────────────────────
+/**
+ * Title of a Mermaid block on an atlas page. Extracted from the
+ * `<!-- wiki-mermaid: <title> start -->` marker that `mermaid_inject.ts`
+ * wraps every spliced diagram in. The trailing ` start` token is stripped.
+ */
+const _MERMAID_TITLE_RE = /<!--\s*wiki-mermaid:\s*(.*?)\s+start\s*-->/g;
+function _scanArchPages(wikiRoot) {
+    const wikiContent = path.join(wikiRoot, "wiki");
+    if (!fs.existsSync(wikiContent))
+        return [];
+    const out = [];
+    const walk = (dir) => {
+        let entries;
+        try {
+            entries = fs.readdirSync(dir, { withFileTypes: true });
+        }
+        catch {
+            return;
+        }
+        for (const e of entries) {
+            const full = path.join(dir, e.name);
+            if (e.isDirectory()) {
+                walk(full);
+                continue;
+            }
+            if (!e.isFile() || !full.endsWith(".md"))
+                continue;
+            let body;
+            try {
+                body = fs.readFileSync(full, "utf-8");
+            }
+            catch {
+                continue;
+            }
+            const { frontmatter, body: pageBody } = parseFrontmatter(body);
+            if (!frontmatter)
+                continue;
+            if (frontmatter["atlas_facet"] !== "architecture")
+                continue;
+            const sources = new Set();
+            const sourcesRaw = frontmatter["sources"];
+            if (Array.isArray(sourcesRaw)) {
+                for (const s of sourcesRaw) {
+                    if (typeof s === "string" && s.length > 0)
+                        sources.add(s);
+                }
+            }
+            const diagramTitles = new Set();
+            _MERMAID_TITLE_RE.lastIndex = 0;
+            let m;
+            while ((m = _MERMAID_TITLE_RE.exec(pageBody)) !== null) {
+                const title = (m[1] ?? "").trim().toLowerCase();
+                if (title.length > 0)
+                    diagramTitles.add(title);
+            }
+            out.push({
+                page: path.relative(wikiRoot, full).split(path.sep).join("/"),
+                sources,
+                diagramTitles,
+            });
+        }
+    };
+    walk(wikiContent);
+    out.sort((a, b) => a.page.localeCompare(b.page));
+    return out;
+}
+/**
+ * Find pairs of architecture-facet atlas pages that likely duplicate each
+ * other's coverage. The heuristic: two pages are flagged when they share
+ * at least one source path AND at least one Mermaid diagram title. Either
+ * signal alone is too noisy (shared-source happens for thin slices that
+ * legitimately overlap; same-title happens for boilerplate "Service
+ * Topology" labels). Both together is a strong signal one page should
+ * own the topic and the other should `[link](../path/to/owner.md)`.
+ *
+ * Mirrors the "Cross-doc concerns" registry pattern from `docs/README.md`.
+ */
+export function findDuplicateDiagrams(wikiRoot) {
+    const arch = _scanArchPages(wikiRoot);
+    const findings = [];
+    for (let i = 0; i < arch.length; i++) {
+        const a = arch[i];
+        if (!a)
+            continue;
+        for (let j = i + 1; j < arch.length; j++) {
+            const b = arch[j];
+            if (!b)
+                continue;
+            const sharedSources = [];
+            for (const s of a.sources)
+                if (b.sources.has(s))
+                    sharedSources.push(s);
+            const sharedTitles = [];
+            for (const t of a.diagramTitles)
+                if (b.diagramTitles.has(t))
+                    sharedTitles.push(t);
+            if (sharedSources.length === 0 || sharedTitles.length === 0)
+                continue;
+            sharedSources.sort();
+            sharedTitles.sort();
+            findings.push({
+                pages: [a.page, b.page],
+                sharedSources,
+                sharedDiagramTitles: sharedTitles,
+            });
+        }
+    }
+    return findings;
+}
 // ── CLI ────────────────────────────────────────────────────────────
 const FLAG_SPEC = {
     "--wiki-root": "wikiRoot",
@@ -199,7 +310,7 @@ const FLAG_SPEC = {
     "--result": "result",
     "--page": "page",
 };
-const HELP_TEXT = `usage: atlas_validate.js {cache-check,cache-store,cache-clear,structural} [...]
+const HELP_TEXT = `usage: atlas_validate.js {cache-check,cache-store,cache-clear,structural,cross-doc} [...]
 
 Validation cache and structural checks for /doc-wiki:atlas Phase 5.
 
@@ -212,6 +323,9 @@ Subcommands:
                  Remove every cached validation entry. Stdout: {removed: N}.
   structural     --wiki-root <p> --page <relpath>
                  Run lint_checks on one page. Stdout: {findings: [...]}.
+  cross-doc      --wiki-root <p>
+                 Find architecture pages with overlapping diagrams + sources.
+                 Stdout: {findings: [{pages, sharedSources, sharedDiagramTitles}]}.
 `;
 export function main(argv = process.argv.slice(2)) {
     if (argv.length === 0 || argv[0] === "-h" || argv[0] === "--help") {
@@ -288,6 +402,11 @@ export function main(argv = process.argv.slice(2)) {
             process.stderr.write(`structural check failed: ${e.message}\n`);
             return 1;
         }
+        process.stdout.write(JSON.stringify({ findings }) + "\n");
+        return 0;
+    }
+    if (sub === "cross-doc") {
+        const findings = findDuplicateDiagrams(wikiRoot);
         process.stdout.write(JSON.stringify({ findings }) + "\n");
         return 0;
     }

--- a/skills/doc-wiki/scripts/atlas_validate.ts
+++ b/skills/doc-wiki/scripts/atlas_validate.ts
@@ -30,6 +30,7 @@ import * as path from "node:path";
 import { fileURLToPath } from "node:url";
 
 import { parseFlags } from "./_cli_args.js";
+import { parseFrontmatter } from "./_frontmatter.js";
 
 // ── Constants ──────────────────────────────────────────────────────
 
@@ -233,6 +234,121 @@ export function validateStructural(
   return out;
 }
 
+// ── Cross-doc ownership ────────────────────────────────────────────
+
+/**
+ * Title of a Mermaid block on an atlas page. Extracted from the
+ * `<!-- wiki-mermaid: <title> start -->` marker that `mermaid_inject.ts`
+ * wraps every spliced diagram in. The trailing ` start` token is stripped.
+ */
+const _MERMAID_TITLE_RE = /<!--\s*wiki-mermaid:\s*(.*?)\s+start\s*-->/g;
+
+/** Pair of atlas pages flagged as covering overlapping ground. */
+export interface DuplicateDiagramFinding {
+  /** Wiki-relative paths of the two pages, sorted lexicographically. */
+  pages: [string, string];
+  /** Source paths both pages declare in their `sources:` frontmatter. */
+  sharedSources: string[];
+  /** Mermaid block titles present on both pages (case-insensitive match). */
+  sharedDiagramTitles: string[];
+}
+
+interface _ArchPageScan {
+  page: string;
+  sources: Set<string>;
+  diagramTitles: Set<string>;
+}
+
+function _scanArchPages(wikiRoot: string): _ArchPageScan[] {
+  const wikiContent = path.join(wikiRoot, "wiki");
+  if (!fs.existsSync(wikiContent)) return [];
+  const out: _ArchPageScan[] = [];
+  const walk = (dir: string): void => {
+    let entries: fs.Dirent[];
+    try {
+      entries = fs.readdirSync(dir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const e of entries) {
+      const full = path.join(dir, e.name);
+      if (e.isDirectory()) {
+        walk(full);
+        continue;
+      }
+      if (!e.isFile() || !full.endsWith(".md")) continue;
+      let body: string;
+      try {
+        body = fs.readFileSync(full, "utf-8");
+      } catch {
+        continue;
+      }
+      const { frontmatter, body: pageBody } = parseFrontmatter(body);
+      if (!frontmatter) continue;
+      if (frontmatter["atlas_facet"] !== "architecture") continue;
+      const sources = new Set<string>();
+      const sourcesRaw = frontmatter["sources"];
+      if (Array.isArray(sourcesRaw)) {
+        for (const s of sourcesRaw) {
+          if (typeof s === "string" && s.length > 0) sources.add(s);
+        }
+      }
+      const diagramTitles = new Set<string>();
+      _MERMAID_TITLE_RE.lastIndex = 0;
+      let m: RegExpExecArray | null;
+      while ((m = _MERMAID_TITLE_RE.exec(pageBody)) !== null) {
+        const title = (m[1] ?? "").trim().toLowerCase();
+        if (title.length > 0) diagramTitles.add(title);
+      }
+      out.push({
+        page: path.relative(wikiRoot, full).split(path.sep).join("/"),
+        sources,
+        diagramTitles,
+      });
+    }
+  };
+  walk(wikiContent);
+  out.sort((a, b) => a.page.localeCompare(b.page));
+  return out;
+}
+
+/**
+ * Find pairs of architecture-facet atlas pages that likely duplicate each
+ * other's coverage. The heuristic: two pages are flagged when they share
+ * at least one source path AND at least one Mermaid diagram title. Either
+ * signal alone is too noisy (shared-source happens for thin slices that
+ * legitimately overlap; same-title happens for boilerplate "Service
+ * Topology" labels). Both together is a strong signal one page should
+ * own the topic and the other should `[link](../path/to/owner.md)`.
+ *
+ * Mirrors the "Cross-doc concerns" registry pattern from `docs/README.md`.
+ */
+export function findDuplicateDiagrams(wikiRoot: string): DuplicateDiagramFinding[] {
+  const arch = _scanArchPages(wikiRoot);
+  const findings: DuplicateDiagramFinding[] = [];
+  for (let i = 0; i < arch.length; i++) {
+    const a = arch[i];
+    if (!a) continue;
+    for (let j = i + 1; j < arch.length; j++) {
+      const b = arch[j];
+      if (!b) continue;
+      const sharedSources: string[] = [];
+      for (const s of a.sources) if (b.sources.has(s)) sharedSources.push(s);
+      const sharedTitles: string[] = [];
+      for (const t of a.diagramTitles) if (b.diagramTitles.has(t)) sharedTitles.push(t);
+      if (sharedSources.length === 0 || sharedTitles.length === 0) continue;
+      sharedSources.sort();
+      sharedTitles.sort();
+      findings.push({
+        pages: [a.page, b.page],
+        sharedSources,
+        sharedDiagramTitles: sharedTitles,
+      });
+    }
+  }
+  return findings;
+}
+
 // ── CLI ────────────────────────────────────────────────────────────
 
 const FLAG_SPEC = {
@@ -243,7 +359,7 @@ const FLAG_SPEC = {
   "--page": "page",
 } as const;
 
-const HELP_TEXT = `usage: atlas_validate.js {cache-check,cache-store,cache-clear,structural} [...]
+const HELP_TEXT = `usage: atlas_validate.js {cache-check,cache-store,cache-clear,structural,cross-doc} [...]
 
 Validation cache and structural checks for /doc-wiki:atlas Phase 5.
 
@@ -256,6 +372,9 @@ Subcommands:
                  Remove every cached validation entry. Stdout: {removed: N}.
   structural     --wiki-root <p> --page <relpath>
                  Run lint_checks on one page. Stdout: {findings: [...]}.
+  cross-doc      --wiki-root <p>
+                 Find architecture pages with overlapping diagrams + sources.
+                 Stdout: {findings: [{pages, sharedSources, sharedDiagramTitles}]}.
 `;
 
 export function main(argv: readonly string[] = process.argv.slice(2)): number {
@@ -338,6 +457,12 @@ export function main(argv: readonly string[] = process.argv.slice(2)): number {
       process.stderr.write(`structural check failed: ${(e as Error).message}\n`);
       return 1;
     }
+    process.stdout.write(JSON.stringify({ findings }) + "\n");
+    return 0;
+  }
+
+  if (sub === "cross-doc") {
+    const findings = findDuplicateDiagrams(wikiRoot);
     process.stdout.write(JSON.stringify({ findings }) + "\n");
     return 0;
   }

--- a/skills/doc-wiki/scripts/init_wiki.js
+++ b/skills/doc-wiki/scripts/init_wiki.js
@@ -40,13 +40,83 @@ const WIKI_IGNORE_DEFAULTS = [
     "node_modules/",
     ".DS_Store",
 ];
-/** Initial seeded pages under wiki/. Insertion order matches Python's dict
- *  literal so `created_files` lists them in the same order. */
-const INITIAL_WIKI_FILES = [
-    ["wiki/index.md", "# Index\n\nWiki entry point.\n"],
-    ["wiki/summaries.md", "# Summaries\n\nHigh-level summaries of wiki topics.\n"],
-    ["wiki/overview.md", "# Overview\n\nOverview of the knowledge domain.\n"],
-];
+/**
+ * Build the YAML frontmatter block + markdown body for one of the three
+ * seeded index pages. The frontmatter is conformant with the schema in
+ * `references/compilation.md` (every required field is populated and
+ * non-empty) so `/doc-wiki:lint` does not flag the stub as
+ * `missing_frontmatter` on a fresh wiki.
+ *
+ * `seedDate` is the ISO-8601 date stamped into `created` and `updated`;
+ * defaults to today, but tests inject a fixed value for byte-stable
+ * snapshot comparisons.
+ */
+function _seedPage(args) {
+    const { title, type, tags, summary, body, seedDate } = args;
+    // Quote the date values so YAML loaders return strings (not `Date`
+    // objects) — matches the convention used by the lint / quality-score
+    // test fixtures and by every hand-authored wiki page.
+    return [
+        "---",
+        `title: ${title}`,
+        `type: ${type}`,
+        `tags: [${tags.join(", ")}]`,
+        "sources:",
+        "  - wiki/",
+        `created: "${seedDate}"`,
+        `updated: "${seedDate}"`,
+        "quality: 0.0",
+        "summary: >",
+        `  ${summary}`,
+        "audience: contributor",
+        "---",
+        "",
+        body,
+    ].join("\n");
+}
+/**
+ * Insertion-ordered list of seeded pages under `wiki/`. Each emits a
+ * frontmatter+body string built by `_seedPage`. The `audience: contributor`
+ * default reflects that these are auto-managed indices read primarily by
+ * agents; humans rarely open them directly.
+ */
+function _initialWikiFiles(seedDate) {
+    return [
+        [
+            "wiki/index.md",
+            _seedPage({
+                title: "Wiki Index",
+                type: "index",
+                tags: ["wiki-meta", "navigation"],
+                summary: "Master catalog of every wiki page. Auto-managed by /doc-wiki:* operations; hand-edits outside the marked regions are preserved on re-runs.",
+                body: "# Index\n\nWiki entry point.\n",
+                seedDate,
+            }),
+        ],
+        [
+            "wiki/summaries.md",
+            _seedPage({
+                title: "Page Summaries",
+                type: "index",
+                tags: ["wiki-meta", "progressive-disclosure"],
+                summary: "Approximately 50-token summary per wiki page. Used by /doc-wiki:query for progressive-disclosure search. Auto-managed by summaries_rebuild.ts.",
+                body: "# Summaries\n\nHigh-level summaries of wiki topics.\n",
+                seedDate,
+            }),
+        ],
+        [
+            "wiki/overview.md",
+            _seedPage({
+                title: "Wiki Overview",
+                type: "concept",
+                tags: ["wiki-meta", "architecture"],
+                summary: "Global architecture narrative. Initially empty; populated by /doc-wiki:atlas Phase 7 from per-topic atlas pages.",
+                body: "# Overview\n\nOverview of the knowledge domain.\n",
+                seedDate,
+            }),
+        ],
+    ];
+}
 // ── Helpers ─────────────────────────────────────────────────────────
 /**
  * Return the default wiki.config.yaml structure. Shape mirrors the v2
@@ -320,8 +390,12 @@ function touchFile(target) {
  * Create the wiki scaffold at `wikiPath`. Idempotent — re-running on an
  * existing wiki leaves user edits intact and returns empty `created_*`
  * arrays for anything that already existed.
+ *
+ * `seedDate` controls the `created`/`updated` value stamped into the
+ * three seeded index pages' frontmatter; defaults to today. Tests inject
+ * a fixed value to keep snapshots byte-stable.
  */
-export function initWiki(wikiPath, domain = "general", name = "My Wiki") {
+export function initWiki(wikiPath, domain = "general", name = "My Wiki", seedDate = new Date().toISOString().slice(0, 10)) {
     const root = pythonResolve(wikiPath);
     const createdDirs = [];
     const createdFiles = [];
@@ -344,7 +418,7 @@ export function initWiki(wikiPath, domain = "general", name = "My Wiki") {
         createdFiles.push("wiki.config.yaml");
     }
     // 3. Create initial wiki files (skip if exists)
-    for (const [relPath, content] of INITIAL_WIKI_FILES) {
+    for (const [relPath, content] of _initialWikiFiles(seedDate)) {
         const target = path.join(root, relPath);
         if (!fs.existsSync(target)) {
             fs.writeFileSync(target, content);

--- a/skills/doc-wiki/scripts/init_wiki.ts
+++ b/skills/doc-wiki/scripts/init_wiki.ts
@@ -44,13 +44,94 @@ const WIKI_IGNORE_DEFAULTS: readonly string[] = [
   ".DS_Store",
 ];
 
-/** Initial seeded pages under wiki/. Insertion order matches Python's dict
- *  literal so `created_files` lists them in the same order. */
-const INITIAL_WIKI_FILES: ReadonlyArray<[string, string]> = [
-  ["wiki/index.md", "# Index\n\nWiki entry point.\n"],
-  ["wiki/summaries.md", "# Summaries\n\nHigh-level summaries of wiki topics.\n"],
-  ["wiki/overview.md", "# Overview\n\nOverview of the knowledge domain.\n"],
-];
+/**
+ * Build the YAML frontmatter block + markdown body for one of the three
+ * seeded index pages. The frontmatter is conformant with the schema in
+ * `references/compilation.md` (every required field is populated and
+ * non-empty) so `/doc-wiki:lint` does not flag the stub as
+ * `missing_frontmatter` on a fresh wiki.
+ *
+ * `seedDate` is the ISO-8601 date stamped into `created` and `updated`;
+ * defaults to today, but tests inject a fixed value for byte-stable
+ * snapshot comparisons.
+ */
+function _seedPage(args: {
+  title: string;
+  type: string;
+  tags: readonly string[];
+  summary: string;
+  body: string;
+  seedDate: string;
+}): string {
+  const { title, type, tags, summary, body, seedDate } = args;
+  // Quote the date values so YAML loaders return strings (not `Date`
+  // objects) — matches the convention used by the lint / quality-score
+  // test fixtures and by every hand-authored wiki page.
+  return [
+    "---",
+    `title: ${title}`,
+    `type: ${type}`,
+    `tags: [${tags.join(", ")}]`,
+    "sources:",
+    "  - wiki/",
+    `created: "${seedDate}"`,
+    `updated: "${seedDate}"`,
+    "quality: 0.0",
+    "summary: >",
+    `  ${summary}`,
+    "audience: contributor",
+    "---",
+    "",
+    body,
+  ].join("\n");
+}
+
+/**
+ * Insertion-ordered list of seeded pages under `wiki/`. Each emits a
+ * frontmatter+body string built by `_seedPage`. The `audience: contributor`
+ * default reflects that these are auto-managed indices read primarily by
+ * agents; humans rarely open them directly.
+ */
+function _initialWikiFiles(seedDate: string): ReadonlyArray<[string, string]> {
+  return [
+    [
+      "wiki/index.md",
+      _seedPage({
+        title: "Wiki Index",
+        type: "index",
+        tags: ["wiki-meta", "navigation"],
+        summary:
+          "Master catalog of every wiki page. Auto-managed by /doc-wiki:* operations; hand-edits outside the marked regions are preserved on re-runs.",
+        body: "# Index\n\nWiki entry point.\n",
+        seedDate,
+      }),
+    ],
+    [
+      "wiki/summaries.md",
+      _seedPage({
+        title: "Page Summaries",
+        type: "index",
+        tags: ["wiki-meta", "progressive-disclosure"],
+        summary:
+          "Approximately 50-token summary per wiki page. Used by /doc-wiki:query for progressive-disclosure search. Auto-managed by summaries_rebuild.ts.",
+        body: "# Summaries\n\nHigh-level summaries of wiki topics.\n",
+        seedDate,
+      }),
+    ],
+    [
+      "wiki/overview.md",
+      _seedPage({
+        title: "Wiki Overview",
+        type: "concept",
+        tags: ["wiki-meta", "architecture"],
+        summary:
+          "Global architecture narrative. Initially empty; populated by /doc-wiki:atlas Phase 7 from per-topic atlas pages.",
+        body: "# Overview\n\nOverview of the knowledge domain.\n",
+        seedDate,
+      }),
+    ],
+  ];
+}
 
 // ── Helpers ─────────────────────────────────────────────────────────
 
@@ -351,11 +432,16 @@ export interface InitResult {
  * Create the wiki scaffold at `wikiPath`. Idempotent — re-running on an
  * existing wiki leaves user edits intact and returns empty `created_*`
  * arrays for anything that already existed.
+ *
+ * `seedDate` controls the `created`/`updated` value stamped into the
+ * three seeded index pages' frontmatter; defaults to today. Tests inject
+ * a fixed value to keep snapshots byte-stable.
  */
 export function initWiki(
   wikiPath: string,
   domain: string = "general",
   name: string = "My Wiki",
+  seedDate: string = new Date().toISOString().slice(0, 10),
 ): InitResult {
   const root = pythonResolve(wikiPath);
 
@@ -386,7 +472,7 @@ export function initWiki(
   }
 
   // 3. Create initial wiki files (skip if exists)
-  for (const [relPath, content] of INITIAL_WIKI_FILES) {
+  for (const [relPath, content] of _initialWikiFiles(seedDate)) {
     const target = path.join(root, relPath);
     if (!fs.existsSync(target)) {
       fs.writeFileSync(target, content);

--- a/skills/doc-wiki/scripts/quality_score.js
+++ b/skills/doc-wiki/scripts/quality_score.js
@@ -45,6 +45,11 @@ const MERMAID_EXPECTED_TAGS = new Set([
     "infrastructure",
     "erd",
     "topology",
+    "troubleshooting",
+    "runbook",
+    "pipeline",
+    "workflow",
+    "commands",
 ]);
 /** Python: `re.compile(r"\[.*?\]\((?!http|#)(.*?\.md)\)")` — global. */
 const _LINK_RE = /\[.*?\]\((?!http|#)(.*?\.md)\)/g;

--- a/skills/doc-wiki/scripts/quality_score.ts
+++ b/skills/doc-wiki/scripts/quality_score.ts
@@ -48,6 +48,11 @@ const MERMAID_EXPECTED_TAGS: ReadonlySet<string> = new Set([
   "infrastructure",
   "erd",
   "topology",
+  "troubleshooting",
+  "runbook",
+  "pipeline",
+  "workflow",
+  "commands",
 ]);
 
 /** Python: `re.compile(r"\[.*?\]\((?!http|#)(.*?\.md)\)")` — global. */

--- a/skills/doc-wiki/scripts/tests/atlas_orchestrator.test.ts
+++ b/skills/doc-wiki/scripts/tests/atlas_orchestrator.test.ts
@@ -14,9 +14,12 @@ import {
   getLastAtlasRunId,
   detectState,
   estimateCost,
+  expectedGlobalCount,
   savePlanSnapshot,
   loadPlanSnapshot,
   getRollingPerIngestAvg,
+  assembleGapReport,
+  renderGapReportMarkdown,
 } from "../atlas_orchestrator.js";
 import {
   makeTmpPath,
@@ -245,8 +248,10 @@ describe("estimateCost", () => {
     expect(est.expected_ingests).toBe(4);
     expect(est.cache_hits).toBe(0);
     expect(est.topic_cost_usd).toBe(0.80); // 4 * 0.20
-    expect(est.global_cost_usd).toBe(0.60); // 3 * 0.20
-    expect(est.total_estimated_usd).toBe(1.40);
+    // 7 globals (overview + integrations + deploy + commands + configuration +
+    // getting-started + troubleshooting) × $0.20 each.
+    expect(est.global_cost_usd).toBe(1.40);
+    expect(est.total_estimated_usd).toBe(2.20);
     expect(est.breakdown).toHaveLength(4);
     for (const b of est.breakdown) {
       expect(b.expected).toBe(true);
@@ -323,6 +328,15 @@ describe("plan snapshot round-trip", () => {
 
 // ── getRollingPerIngestAvg ─────────────────────────────────────────
 
+describe("expectedGlobalCount", () => {
+  it("returns the static count regardless of facets argument", () => {
+    expect(expectedGlobalCount()).toBe(7);
+    expect(expectedGlobalCount([])).toBe(7);
+    expect(expectedGlobalCount(["architecture", "data-model"])).toBe(7);
+    expect(expectedGlobalCount(["architecture"])).toBe(7);
+  });
+});
+
 describe("getRollingPerIngestAvg", () => {
   let tmpPath: string;
   let wikiRoot: string;
@@ -367,5 +381,190 @@ describe("getRollingPerIngestAvg", () => {
     writeEvent(wikiRoot, { op: "ingest", cost_usd: 0.0 });
     // sampleSize=1 → only the most recent event counts
     expect(getRollingPerIngestAvg(wikiRoot, 1)).toBe(0.0);
+  });
+});
+
+// ── assembleGapReport / renderGapReportMarkdown ────────────────────
+
+describe("assembleGapReport", () => {
+  let tmpPath: string;
+  let wikiRoot: string;
+
+  beforeEach(() => {
+    tmpPath = makeTmpPath("atlas-orch-gap-");
+    wikiRoot = makeInitializedWiki(tmpPath);
+    // Drop the starter pages so wiki content reflects only what tests create.
+    for (const f of ["index.md", "summaries.md", "overview.md"]) {
+      const p = path.join(wikiRoot, "wiki", f);
+      if (fs.existsSync(p)) fs.unlinkSync(p);
+    }
+  });
+
+  afterEach(() => {
+    cleanupTmpPath(tmpPath);
+  });
+
+  it("flags topics whose directory has no pages", () => {
+    const plan = {
+      topics: ["auth", "billing"],
+      facets: ["architecture"],
+      entries: [
+        {
+          topic: "auth",
+          facet: "architecture",
+          sources: ["src/auth/"],
+          output: "wiki/auth/architecture.md",
+        },
+        {
+          topic: "billing",
+          facet: "architecture",
+          sources: ["src/billing/"],
+          output: "wiki/billing/architecture.md",
+        },
+      ],
+      created_at: new Date().toISOString(),
+    };
+    // Only auth has a page on disk.
+    writeAtlasPage(wikiRoot, "wiki/auth/architecture.md", "architecture", "r1");
+
+    const report = assembleGapReport(wikiRoot, plan);
+    expect(report.topicsWithoutPages).toEqual(["billing"]);
+    // Auth/architecture is covered, billing/architecture is not.
+    expect(report.facetsWithoutCoverage).toEqual([
+      { topic: "billing", facet: "architecture" },
+    ]);
+    // Billing's source paths are flagged because the output page is missing.
+    expect(report.sourceFilesWithNoPage).toContain("src/billing/");
+    expect(report.sourceFilesWithNoPage).not.toContain("src/auth/");
+  });
+
+  it("dedupes source paths repeated across plan entries", () => {
+    const plan = {
+      topics: ["auth"],
+      facets: ["architecture", "data-model"],
+      entries: [
+        {
+          topic: "auth",
+          facet: "architecture",
+          sources: ["src/auth/", "shared/lib/"],
+          output: "wiki/auth/architecture.md",
+        },
+        {
+          topic: "auth",
+          facet: "data-model",
+          sources: ["src/auth/", "shared/lib/"],
+          output: "wiki/auth/data-model.md",
+        },
+      ],
+      created_at: new Date().toISOString(),
+    };
+    const report = assembleGapReport(wikiRoot, plan);
+    expect(report.sourceFilesWithNoPage).toEqual(["shared/lib/", "src/auth/"]);
+  });
+
+  it("passes through gitlog uncovered_files when provided", () => {
+    const plan = {
+      topics: ["auth"],
+      facets: ["architecture"],
+      entries: [],
+      created_at: new Date().toISOString(),
+    };
+    const report = assembleGapReport(wikiRoot, plan, {
+      uncovered_files: ["src/new-thing.ts", "src/another.ts"],
+      stale_pages: [],
+      unrelated_files: [],
+    });
+    expect(report.uncoveredFiles).toEqual(["src/new-thing.ts", "src/another.ts"]);
+  });
+
+  it("flags connectors mentioned in atlas pages but missing from integrations.md", () => {
+    const plan = {
+      topics: ["auth"],
+      facets: ["architecture"],
+      entries: [],
+      created_at: new Date().toISOString(),
+    };
+    // architecture page mentions jira and github
+    fs.mkdirSync(path.join(wikiRoot, "wiki", "auth"), { recursive: true });
+    fs.writeFileSync(
+      path.join(wikiRoot, "wiki", "auth", "architecture.md"),
+      "---\n" +
+        yaml.dump({ atlas_facet: "architecture", atlas_run_id: "r1" }) +
+        "---\n\nWe sync to JIRA and emit to GitHub Actions.\n",
+    );
+    // integrations.md exists but only documents jira
+    fs.writeFileSync(
+      path.join(wikiRoot, "wiki", "integrations.md"),
+      "---\n" +
+        yaml.dump({ atlas_facet: "integrations", atlas_run_id: "r1" }) +
+        "---\n\nJira sync.\n",
+    );
+
+    const report = assembleGapReport(wikiRoot, plan);
+    expect(report.externalServicesWithoutDocumentation).toContain("github");
+    expect(report.externalServicesWithoutDocumentation).not.toContain("jira");
+  });
+
+  it("returns empty arrays when everything is documented", () => {
+    const plan = {
+      topics: ["auth"],
+      facets: ["architecture"],
+      entries: [
+        {
+          topic: "auth",
+          facet: "architecture",
+          sources: ["src/auth/"],
+          output: "wiki/auth/architecture.md",
+        },
+      ],
+      created_at: new Date().toISOString(),
+    };
+    writeAtlasPage(wikiRoot, "wiki/auth/architecture.md", "architecture", "r1");
+    const report = assembleGapReport(wikiRoot, plan);
+    expect(report.topicsWithoutPages).toEqual([]);
+    expect(report.facetsWithoutCoverage).toEqual([]);
+    expect(report.sourceFilesWithNoPage).toEqual([]);
+    expect(report.uncoveredFiles).toEqual([]);
+  });
+});
+
+describe("renderGapReportMarkdown", () => {
+  it("emits all five sections with placeholder text when empty", () => {
+    const md = renderGapReportMarkdown(
+      {
+        topicsWithoutPages: [],
+        facetsWithoutCoverage: [],
+        sourceFilesWithNoPage: [],
+        uncoveredFiles: [],
+        externalServicesWithoutDocumentation: [],
+      },
+      "2026-04-30T12-00-00",
+    );
+    expect(md).toContain("Atlas gap report — 2026-04-30T12-00-00");
+    expect(md).toContain("## Topics without any pages");
+    expect(md).toContain("## Facets without coverage");
+    expect(md).toContain("## Source files with no wiki page");
+    expect(md).toContain("## Uncovered files (gitlog)");
+    expect(md).toContain("## External services mentioned but undocumented");
+    expect(md.match(/_\(none\)_/g)?.length).toBe(5);
+  });
+
+  it("formats facets-without-coverage as a markdown table", () => {
+    const md = renderGapReportMarkdown(
+      {
+        topicsWithoutPages: [],
+        facetsWithoutCoverage: [
+          { topic: "auth", facet: "data-model" },
+          { topic: "billing", facet: "api" },
+        ],
+        sourceFilesWithNoPage: [],
+        uncoveredFiles: [],
+        externalServicesWithoutDocumentation: [],
+      },
+      "r1",
+    );
+    expect(md).toContain("| topic | facet |");
+    expect(md).toContain("| auth | data-model |");
+    expect(md).toContain("| billing | api |");
   });
 });

--- a/skills/doc-wiki/scripts/tests/atlas_validate.test.ts
+++ b/skills/doc-wiki/scripts/tests/atlas_validate.test.ts
@@ -8,15 +8,18 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import * as fs from "node:fs";
 import * as path from "node:path";
 
+import * as yaml from "js-yaml";
+
 import {
   computeValidationKey,
   checkValidationCache,
   storeValidationCache,
   clearValidationCache,
+  findDuplicateDiagrams,
   VALIDATE_CACHE_SUBDIR,
   VALIDATE_CACHE_VERSION,
 } from "../atlas_validate.js";
-import { makeTmpPath, cleanupTmpPath } from "./fixtures.js";
+import { makeTmpPath, cleanupTmpPath, makeInitializedWiki } from "./fixtures.js";
 
 describe("computeValidationKey", () => {
   it("is deterministic for identical inputs", () => {
@@ -111,5 +114,116 @@ describe("validation cache CRUD", () => {
     storeValidationCache(tmpPath, "p1", "s1", "first");
     storeValidationCache(tmpPath, "p1", "s1", "second");
     expect(checkValidationCache(tmpPath, "p1", "s1")?.result).toBe("second");
+  });
+});
+
+// ── findDuplicateDiagrams (cross-doc ownership) ─────────────────────
+
+function writeArchPage(
+  wikiRoot: string,
+  relPath: string,
+  sources: string[],
+  diagramTitles: string[],
+): void {
+  const full = path.join(wikiRoot, relPath);
+  fs.mkdirSync(path.dirname(full), { recursive: true });
+  const fm = yaml.dump({
+    title: "page",
+    type: "concept",
+    atlas_facet: "architecture",
+    atlas_run_id: "r1",
+    sources,
+  });
+  const diagrams = diagramTitles
+    .map(
+      (t) =>
+        `<!-- wiki-mermaid: ${t} start -->\n\`\`\`mermaid\nflowchart TD\n  A --> B\n\`\`\`\n<!-- wiki-mermaid: ${t} end -->`,
+    )
+    .join("\n\n");
+  fs.writeFileSync(full, "---\n" + fm + "---\n\nbody\n\n" + diagrams + "\n");
+}
+
+describe("findDuplicateDiagrams", () => {
+  let tmpPath: string;
+  let wikiRoot: string;
+
+  beforeEach(() => {
+    tmpPath = makeTmpPath("atlas-validate-cross-");
+    wikiRoot = makeInitializedWiki(tmpPath);
+  });
+
+  afterEach(() => {
+    cleanupTmpPath(tmpPath);
+  });
+
+  it("returns empty when no architecture pages exist", () => {
+    expect(findDuplicateDiagrams(wikiRoot)).toEqual([]);
+  });
+
+  it("does NOT flag pages that share only sources OR only diagram titles", () => {
+    // Same source, different diagram titles → no finding.
+    writeArchPage(wikiRoot, "wiki/auth/architecture.md", ["src/auth/"], ["Auth Topology"]);
+    writeArchPage(wikiRoot, "wiki/billing/architecture.md", ["src/auth/"], ["Billing Topology"]);
+    expect(findDuplicateDiagrams(wikiRoot)).toEqual([]);
+    // Same title, different sources → no finding.
+    writeArchPage(wikiRoot, "wiki/users/architecture.md", ["src/users/"], ["Service Topology"]);
+    writeArchPage(wikiRoot, "wiki/orders/architecture.md", ["src/orders/"], ["Service Topology"]);
+    expect(findDuplicateDiagrams(wikiRoot)).toEqual([]);
+  });
+
+  it("flags pages that share both ≥1 source AND ≥1 diagram title", () => {
+    writeArchPage(
+      wikiRoot,
+      "wiki/auth/architecture.md",
+      ["src/shared/", "src/auth/"],
+      ["Service Topology", "Login Flow"],
+    );
+    writeArchPage(
+      wikiRoot,
+      "wiki/users/architecture.md",
+      ["src/shared/", "src/users/"],
+      ["Service Topology", "User Profile"],
+    );
+    const findings = findDuplicateDiagrams(wikiRoot);
+    expect(findings).toHaveLength(1);
+    expect(findings[0]!.pages).toEqual([
+      "wiki/auth/architecture.md",
+      "wiki/users/architecture.md",
+    ]);
+    expect(findings[0]!.sharedSources).toEqual(["src/shared/"]);
+    expect(findings[0]!.sharedDiagramTitles).toEqual(["service topology"]);
+  });
+
+  it("matches diagram titles case-insensitively", () => {
+    writeArchPage(wikiRoot, "wiki/a/architecture.md", ["src/x/"], ["Service Topology"]);
+    writeArchPage(wikiRoot, "wiki/b/architecture.md", ["src/x/"], ["service topology"]);
+    const findings = findDuplicateDiagrams(wikiRoot);
+    expect(findings).toHaveLength(1);
+    expect(findings[0]!.sharedDiagramTitles).toEqual(["service topology"]);
+  });
+
+  it("only considers architecture-facet pages — ignores data-model, api, etc.", () => {
+    // Two pages with shared source + title but one is api facet → not flagged.
+    writeArchPage(wikiRoot, "wiki/auth/architecture.md", ["src/auth/"], ["Login Flow"]);
+    const apiPage = path.join(wikiRoot, "wiki", "auth", "api.md");
+    fs.writeFileSync(
+      apiPage,
+      "---\n" +
+        yaml.dump({
+          atlas_facet: "api",
+          atlas_run_id: "r1",
+          sources: ["src/auth/"],
+        }) +
+        "---\n\n<!-- wiki-mermaid: Login Flow start -->\n\nbody\n\n<!-- wiki-mermaid: Login Flow end -->\n",
+    );
+    expect(findDuplicateDiagrams(wikiRoot)).toEqual([]);
+  });
+
+  it("flags a triangle as three separate pairs", () => {
+    writeArchPage(wikiRoot, "wiki/a/architecture.md", ["src/shared/"], ["Topology"]);
+    writeArchPage(wikiRoot, "wiki/b/architecture.md", ["src/shared/"], ["Topology"]);
+    writeArchPage(wikiRoot, "wiki/c/architecture.md", ["src/shared/"], ["Topology"]);
+    const findings = findDuplicateDiagrams(wikiRoot);
+    expect(findings).toHaveLength(3); // pairs: (a,b), (a,c), (b,c)
   });
 });

--- a/skills/doc-wiki/scripts/tests/init_wiki.test.ts
+++ b/skills/doc-wiki/scripts/tests/init_wiki.test.ts
@@ -127,9 +127,62 @@ describe("init_wiki — initial files", () => {
     expect(fs.existsSync(summaries)).toBe(true);
     expect(fs.existsSync(overview)).toBe(true);
 
-    expect(fs.readFileSync(index, "utf-8").startsWith("#")).toBe(true);
-    expect(fs.readFileSync(summaries, "utf-8").startsWith("#")).toBe(true);
-    expect(fs.readFileSync(overview, "utf-8").startsWith("#")).toBe(true);
+    // Each seeded page now opens with YAML frontmatter so /doc-wiki:lint
+    // does not flag them as `missing_frontmatter` on a fresh wiki.
+    for (const p of [index, summaries, overview]) {
+      const body = fs.readFileSync(p, "utf-8");
+      expect(body.startsWith("---\n"), `${p} should start with frontmatter`).toBe(true);
+      // Required compilation.md fields plus the audience field added in the
+      // audience-aware-coverage tranche.
+      for (const field of [
+        "title:",
+        "type:",
+        "tags:",
+        "sources:",
+        "created:",
+        "updated:",
+        "quality:",
+        "summary:",
+        "audience:",
+      ]) {
+        expect(body, `${p} should declare ${field}`).toContain(field);
+      }
+      // The body heading is preserved after the closing frontmatter delimiter.
+      expect(body, `${p} should still carry its # heading`).toMatch(/^---\n[\s\S]+?\n---\n\n# /);
+    }
+  });
+
+  it("test_seed_date_param_overrides_today", () => {
+    // initWiki accepts a fixed seedDate so test snapshots are byte-stable.
+    const wiki = tmpWiki(tmpPath);
+    initWiki(wiki, "general", "My Wiki", "2026-01-15");
+    const body = fs.readFileSync(path.join(wiki, "wiki", "index.md"), "utf-8");
+    expect(body).toContain('created: "2026-01-15"');
+    expect(body).toContain('updated: "2026-01-15"');
+  });
+
+  it("test_seeded_frontmatter_parses_to_valid_yaml", () => {
+    const wiki = tmpWiki(tmpPath);
+    runInit(wiki);
+    for (const name of ["index.md", "summaries.md", "overview.md"]) {
+      const body = fs.readFileSync(path.join(wiki, "wiki", name), "utf-8");
+      // Extract the frontmatter block (between the two `---` delimiters)
+      // and verify it parses as a YAML object with the required scalar
+      // and list fields populated.
+      const match = body.match(/^---\n([\s\S]*?)\n---\n/);
+      expect(match, `${name} frontmatter delimiters`).toBeTruthy();
+      const fm = yaml.load(match![1] as string) as Record<string, unknown>;
+      expect(fm["title"]).toBeTypeOf("string");
+      expect(fm["type"]).toBeTypeOf("string");
+      expect(Array.isArray(fm["tags"])).toBe(true);
+      expect(Array.isArray(fm["sources"])).toBe(true);
+      expect((fm["sources"] as string[]).length).toBeGreaterThan(0);
+      expect(fm["created"]).toMatch(/^\d{4}-\d{2}-\d{2}/);
+      expect(fm["updated"]).toMatch(/^\d{4}-\d{2}-\d{2}/);
+      expect(fm["quality"]).toBe(0);
+      expect(fm["summary"]).toBeTypeOf("string");
+      expect(fm["audience"]).toBe("contributor");
+    }
   });
 
   it("test_creates_wiki_ignore", () => {

--- a/skills/doc-wiki/scripts/tests/quality_score.test.ts
+++ b/skills/doc-wiki/scripts/tests/quality_score.test.ts
@@ -361,6 +361,23 @@ describe("TestScorePageStructural", () => {
     expect(signals.has("missing_mermaid")).toBe(true);
     expect(signals.get("missing_mermaid")).toBeCloseTo(-0.1);
   });
+
+  it("missing-mermaid penalty fires for new audience-flavor facet tags", () => {
+    // Each new tag added to MERMAID_EXPECTED_TAGS should fire the penalty
+    // in isolation. Validates the extension to cover audience-flavor facets.
+    for (const tag of ["troubleshooting", "runbook", "pipeline", "workflow", "commands"]) {
+      const fm = fullFrontmatter({
+        type: "concept",
+        tags: [tag, "extra-1", "extra-2", "extra-3"],
+      });
+      const page = path.join(tmpPath, "wiki", "audience", `${tag}.md`);
+      writePage(page, fm, new Array(200).fill("word").join(" "));
+      const result = scorePage(page, edges);
+      const signals = new Map(result.signals.map((s) => [s.signal, s.delta]));
+      expect(signals.has("missing_mermaid"), `missing_mermaid for tag ${tag}`).toBe(true);
+      expect(signals.get("missing_mermaid")).toBeCloseTo(-0.1);
+    }
+  });
 });
 
 // ── Clamping tests ──────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Closes ten content-surface gaps in `/doc-wiki:atlas` surfaced by a dual audit
that compared atlas output against this repo's hand-curated `docs/` baseline
and an external reference corpus. Atlas had best-in-class operational
machinery (cost ceiling, hash-cached drift detection, autonomy gates,
idempotent re-runs, provenance) but its content surface was narrow: five
fixed code-shaped facets, generic page template, connector-only Mermaid
emission, no audience targeting.

## What ships

**Tranche A — audience-aware coverage**
- New `audience` enum frontmatter field (`new-user` / `operator` /
  `contributor` / `integrator` / `debugger`) with facet→audience
  default-inference table (`compilation.md`)
- Phase 7 grows from 3 globals to 7 — adds `commands`, `configuration`,
  `getting-started`, `troubleshooting` bundles in `atlas_synthesize.ts`
  (each with a default audience derived from the slug)
- Page template gains facet-conditional body sections for 12 facets
  (operator pages get args+examples, debugger pages get
  symptom→cause→fix triplets, new-user pages get numbered walkthroughs,
  contributor pages get architecture contracts)
- `assembleOverviewInputs` prepends an audience-routing table mirroring
  `docs/README.md` "Where to start"
- `integrationKeywords` now sourced from `BUILTIN_PATTERNS` via
  `source_registry.builtinConnectorIds()` — data-driven, honors
  architecture invariant #6
- `GLOBAL_PAGES_COUNT` replaced with `expectedGlobalCount(facets)` so
  cost math stays correct as new globals land
- `MERMAID_EXPECTED_TAGS` extended with `troubleshooting`, `runbook`,
  `pipeline`, `workflow`, `commands` so new facets earn the diagram
  penalty/bonus
- New `formatPhaseFlow` builder in `mermaid_format.ts` with classDef
  styling — emits the classDef-styled flowchart pattern from
  `docs/architecture.md` Diagram 4

**Tranche B — gap report + cross-doc ownership**
- `assembleGapReport` + `renderGapReportMarkdown` + `gap-report` CLI
  subcommand. Phase 8 writes
  `wiki/outputs/atlas/<run-id>/gap-report.md` enumerating
  topics-without-pages, facets-without-coverage,
  source-files-with-no-page, gitlog-uncovered-files,
  external-services-without-documentation
- `findDuplicateDiagrams` + `cross-doc` CLI subcommand flags pairs of
  architecture pages sharing both ≥1 source path AND ≥1 Mermaid diagram
  title — cross-doc-ownership scan in Phase 8 (mirrors
  `docs/README.md` "Cross-doc concerns" registry pattern)

**Dogfood follow-ups (after running atlas on this repo)**
- `init_wiki.ts` seeds `wiki/index.md`, `wiki/summaries.md`,
  `wiki/overview.md` with full YAML frontmatter — closes lint
  `missing_frontmatter` errors on fresh wikis. `seedDate` parameter
  added for byte-stable test snapshots
- SKILL.md `configuration` page template now mandates top-level
  `## Credential reference grammar` and `## Resolution order` headings
  (subsections nested inside `.connectors/` no longer satisfy the
  template)
- `assembleCommandsInputs` prepends a deterministic `formatPhaseFlow`
  Mermaid block (User → `/commands` → orchestrator, classDef-styled)
  wrapped in `<!-- mermaid-seed -->` markers so synthesized
  `commands.md` gets a real diagram

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run build` — clean
- [x] `npm test` — **987 passed** (baseline 934, +53 new); 5 skipped
      (live-DB integration, unchanged)
- [x] **Privacy:** `git grep -i 'ideaprojects\|doc-update'` empty across
      all paths including markdown
- [x] **Dogfood:** init wiki at `/tmp/doc-wiki-self-atlas-v2`, generate
      3 globals end-to-end (`commands.md`, `getting-started.md`,
      `configuration.md`); quality scores **1.0**, **0.95**, **0.95**;
      `commands.md` contains the Mermaid `flowchart TD` block;
      `configuration.md` has top-level `## Credential reference grammar`
      and `## Resolution order`; lint shows **0** `missing_frontmatter`
      errors
- [x] **Gap report** persists to
      `wiki/outputs/atlas/<run-id>/gap-report.md` with all five
      sections rendered

## Out of scope (deferred)

Tranche C — pre-phase code-inventory manifest. A new `atlas_inventory.ts`
that runs once at start of Phase 2 and persists
`wiki/outputs/atlas/<run-id>/code-inventory.json` (clients, ORM
entities, REST endpoints, project versions); Phase 4 cost-estimate,
Phase 6 source heuristics, and the new `assembleX` helpers all consume
it instead of re-scanning. Real value but larger surface area —
deserves its own planning round once Tranche A+B has been exercised
by a real `/doc-wiki:atlas` run on this repo.