### PR TITLE
refactor(atlas): consolidate deploy + configuration walkers

### DIFF
--- a/agents/lib/atlas_synthesize.js
+++ b/agents/lib/atlas_synthesize.js
@@ -27,6 +27,7 @@ import { fileURLToPath } from "node:url";
 import { parseFlags } from "../../skills/doc-wiki/scripts/_cli_args.js";
 import { parseFrontmatter } from "../../skills/doc-wiki/scripts/_frontmatter.js";
 import { formatPhaseFlow, } from "./mermaid_format.js";
+import { walkRepoTargets } from "./repo_walker.js";
 import { builtinConnectorIds } from "./source_registry.js";
 /**
  * Walk `<wikiRoot>/wiki/` and yield every `.md` page whose frontmatter has a
@@ -279,63 +280,23 @@ const DEPLOY_DIR_PATTERNS = [
     { dir: "k8s", rx: /\.ya?ml$/ },
 ];
 /**
- * Walk the repo root looking for canonical build/deploy files. Returns the
- * relative paths (sorted) plus a concatenated text bundle the orchestrator
- * passes to `/doc-wiki:ingest --output wiki/deploy.md`.
- *
- * Big files (>200 KB) are truncated with a marker line — full inclusion
- * would blow the synthesis context budget for little additional value.
+ * Body-truncation cap for files inlined into a synthesis bundle. Beyond
+ * this, the file is sliced and a marker line is appended so the LLM sees
+ * the truncation. Tuned to keep a single bundle well under the synthesis
+ * context budget while preserving most real-world config / Dockerfile /
+ * workflow content.
  */
-export function assembleDeployInputs(repoRoot) {
-    const sources = [];
+const _BUNDLE_FILE_TRUNCATE_BYTES = 200 * 1024;
+/**
+ * Read each `paths` entry under `repoRoot`, truncate at
+ * {@link _BUNDLE_FILE_TRUNCATE_BYTES}, and format as a fenced
+ * `## <rel>` section. Per-file read failures append to `notes` and skip
+ * the file. Shared by `assembleDeployInputs` and
+ * `assembleConfigurationInputs`.
+ */
+function _readAndFormatBundleFiles(repoRoot, paths, notes) {
     const parts = [];
-    const notes = [];
-    // Top-level files.
-    let topLevel;
-    try {
-        topLevel = fs.readdirSync(repoRoot, { withFileTypes: true });
-    }
-    catch {
-        notes.push(`could not read repo root: ${repoRoot}`);
-        return { sources, text: "", notes };
-    }
-    for (const e of topLevel) {
-        if (!e.isFile())
-            continue;
-        if (DEPLOY_FILE_GLOBS.some((rx) => rx.test(e.name))) {
-            sources.push(e.name);
-        }
-    }
-    // Directory patterns.
-    for (const { dir, rx } of DEPLOY_DIR_PATTERNS) {
-        const abs = path.join(repoRoot, dir);
-        if (!fs.existsSync(abs))
-            continue;
-        const walk = (d, relBase) => {
-            let entries;
-            try {
-                entries = fs.readdirSync(d, { withFileTypes: true });
-            }
-            catch {
-                return;
-            }
-            for (const e of entries) {
-                const full = path.join(d, e.name);
-                const rel = path.posix.join(relBase, e.name);
-                if (e.isDirectory())
-                    walk(full, rel);
-                else if (e.isFile() && rx.test(e.name))
-                    sources.push(rel);
-            }
-        };
-        walk(abs, dir);
-    }
-    sources.sort();
-    if (sources.length === 0) {
-        notes.push("no build/deploy files matched — wiki/deploy.md will be sparse");
-        return { sources, text: "", notes };
-    }
-    for (const rel of sources) {
+    for (const rel of paths) {
         const abs = path.join(repoRoot, rel);
         let body;
         try {
@@ -345,10 +306,32 @@ export function assembleDeployInputs(repoRoot) {
             notes.push(`could not read ${rel}`);
             continue;
         }
-        const truncated = body.length > 200 * 1024 ? body.slice(0, 200 * 1024) + "\n... [truncated]\n" : body;
+        const truncated = body.length > _BUNDLE_FILE_TRUNCATE_BYTES
+            ? body.slice(0, _BUNDLE_FILE_TRUNCATE_BYTES) + "\n... [truncated]\n"
+            : body;
         parts.push(`## ${rel}\n\n\`\`\`\n${truncated}\n\`\`\`\n`);
     }
-    return { sources, text: parts.join("\n"), notes };
+    return parts;
+}
+/**
+ * Walk the repo root looking for canonical build/deploy files. Returns
+ * the relative paths (sorted) plus a concatenated text bundle the
+ * orchestrator passes to `/doc-wiki:ingest --output wiki/deploy.md`.
+ *
+ * Big files (>200 KB) are truncated with a marker line — full inclusion
+ * would blow the synthesis context budget for little additional value.
+ */
+export function assembleDeployInputs(repoRoot) {
+    const { paths, notes } = walkRepoTargets(repoRoot, {
+        topLevelBasenames: DEPLOY_FILE_GLOBS,
+        subdirPatterns: DEPLOY_DIR_PATTERNS,
+    });
+    if (paths.length === 0) {
+        notes.push("no build/deploy files matched — wiki/deploy.md will be sparse");
+        return { sources: [], text: "", notes };
+    }
+    const parts = _readAndFormatBundleFiles(repoRoot, paths, notes);
+    return { sources: [...paths], text: parts.join("\n"), notes };
 }
 /**
  * Sourced integration-keyword list. Used by `assembleIntegrationsInputs`
@@ -604,70 +587,16 @@ const _CONFIGURATION_DIR_PATTERNS = [
  * inline so the synthesis step can note the truncation when relevant.
  */
 export function assembleConfigurationInputs(repoRoot) {
-    const sources = [];
-    const parts = [];
-    const notes = [];
-    // Top-level files matching configuration globs.
-    let topLevel;
-    try {
-        topLevel = fs.readdirSync(repoRoot, { withFileTypes: true });
-    }
-    catch {
-        notes.push(`could not read repo root: ${repoRoot}`);
-        return { sources, text: "", notes };
-    }
-    for (const e of topLevel) {
-        if (!e.isFile())
-            continue;
-        if (_CONFIGURATION_FILE_GLOBS.some((rx) => rx.test(e.name))) {
-            sources.push(e.name);
-        }
-    }
-    // Directory patterns.
-    for (const { dir, rx } of _CONFIGURATION_DIR_PATTERNS) {
-        const abs = path.join(repoRoot, dir);
-        if (!fs.existsSync(abs))
-            continue;
-        const walk = (d, relBase) => {
-            let entries;
-            try {
-                entries = fs.readdirSync(d, { withFileTypes: true });
-            }
-            catch {
-                return;
-            }
-            for (const e of entries) {
-                const full = path.join(d, e.name);
-                const rel = path.posix.join(relBase, e.name);
-                if (e.isDirectory())
-                    walk(full, rel);
-                else if (e.isFile() && rx.test(e.name))
-                    sources.push(rel);
-            }
-        };
-        walk(abs, dir);
-    }
-    sources.sort();
-    if (sources.length === 0) {
+    const { paths, notes } = walkRepoTargets(repoRoot, {
+        topLevelBasenames: _CONFIGURATION_FILE_GLOBS,
+        subdirPatterns: _CONFIGURATION_DIR_PATTERNS,
+    });
+    if (paths.length === 0) {
         notes.push("no configuration files matched — wiki/configuration.md will be sparse");
-        return { sources, text: "", notes };
+        return { sources: [], text: "", notes };
     }
-    for (const rel of sources) {
-        const abs = path.join(repoRoot, rel);
-        let body;
-        try {
-            body = fs.readFileSync(abs, "utf-8");
-        }
-        catch {
-            notes.push(`could not read ${rel}`);
-            continue;
-        }
-        const truncated = body.length > 200 * 1024
-            ? body.slice(0, 200 * 1024) + "\n... [truncated]\n"
-            : body;
-        parts.push(`## ${rel}\n\n\`\`\`\n${truncated}\n\`\`\`\n`);
-    }
-    return { sources, text: parts.join("\n"), notes };
+    const parts = _readAndFormatBundleFiles(repoRoot, paths, notes);
+    return { sources: [...paths], text: parts.join("\n"), notes };
 }
 // ── Troubleshooting bundle ─────────────────────────────────────────
 const _TROUBLESHOOTING_EVENT_LIMIT = 30;

--- a/agents/lib/atlas_synthesize.ts
+++ b/agents/lib/atlas_synthesize.ts
@@ -33,6 +33,7 @@ import {
   type PhaseEdge,
   type PhaseNode,
 } from "./mermaid_format.js";
+import { walkRepoTargets } from "./repo_walker.js";
 import { builtinConnectorIds } from "./source_registry.js";
 
 // ── Shared types ───────────────────────────────────────────────────
@@ -324,61 +325,28 @@ const DEPLOY_DIR_PATTERNS: ReadonlyArray<{ dir: string; rx: RegExp }> = [
 ];
 
 /**
- * Walk the repo root looking for canonical build/deploy files. Returns the
- * relative paths (sorted) plus a concatenated text bundle the orchestrator
- * passes to `/doc-wiki:ingest --output wiki/deploy.md`.
- *
- * Big files (>200 KB) are truncated with a marker line — full inclusion
- * would blow the synthesis context budget for little additional value.
+ * Body-truncation cap for files inlined into a synthesis bundle. Beyond
+ * this, the file is sliced and a marker line is appended so the LLM sees
+ * the truncation. Tuned to keep a single bundle well under the synthesis
+ * context budget while preserving most real-world config / Dockerfile /
+ * workflow content.
  */
-export function assembleDeployInputs(repoRoot: string): SynthesisBundle {
-  const sources: string[] = [];
+const _BUNDLE_FILE_TRUNCATE_BYTES = 200 * 1024;
+
+/**
+ * Read each `paths` entry under `repoRoot`, truncate at
+ * {@link _BUNDLE_FILE_TRUNCATE_BYTES}, and format as a fenced
+ * `## <rel>` section. Per-file read failures append to `notes` and skip
+ * the file. Shared by `assembleDeployInputs` and
+ * `assembleConfigurationInputs`.
+ */
+function _readAndFormatBundleFiles(
+  repoRoot: string,
+  paths: readonly string[],
+  notes: string[],
+): string[] {
   const parts: string[] = [];
-  const notes: string[] = [];
-
-  // Top-level files.
-  let topLevel: fs.Dirent[];
-  try {
-    topLevel = fs.readdirSync(repoRoot, { withFileTypes: true });
-  } catch {
-    notes.push(`could not read repo root: ${repoRoot}`);
-    return { sources, text: "", notes };
-  }
-  for (const e of topLevel) {
-    if (!e.isFile()) continue;
-    if (DEPLOY_FILE_GLOBS.some((rx) => rx.test(e.name))) {
-      sources.push(e.name);
-    }
-  }
-
-  // Directory patterns.
-  for (const { dir, rx } of DEPLOY_DIR_PATTERNS) {
-    const abs = path.join(repoRoot, dir);
-    if (!fs.existsSync(abs)) continue;
-    const walk = (d: string, relBase: string): void => {
-      let entries: fs.Dirent[];
-      try {
-        entries = fs.readdirSync(d, { withFileTypes: true });
-      } catch {
-        return;
-      }
-      for (const e of entries) {
-        const full = path.join(d, e.name);
-        const rel = path.posix.join(relBase, e.name);
-        if (e.isDirectory()) walk(full, rel);
-        else if (e.isFile() && rx.test(e.name)) sources.push(rel);
-      }
-    };
-    walk(abs, dir);
-  }
-
-  sources.sort();
-  if (sources.length === 0) {
-    notes.push("no build/deploy files matched — wiki/deploy.md will be sparse");
-    return { sources, text: "", notes };
-  }
-
-  for (const rel of sources) {
+  for (const rel of paths) {
     const abs = path.join(repoRoot, rel);
     let body: string;
     try {
@@ -387,10 +355,34 @@ export function assembleDeployInputs(repoRoot: string): SynthesisBundle {
       notes.push(`could not read ${rel}`);
       continue;
     }
-    const truncated = body.length > 200 * 1024 ? body.slice(0, 200 * 1024) + "\n... [truncated]\n" : body;
+    const truncated =
+      body.length > _BUNDLE_FILE_TRUNCATE_BYTES
+        ? body.slice(0, _BUNDLE_FILE_TRUNCATE_BYTES) + "\n... [truncated]\n"
+        : body;
     parts.push(`## ${rel}\n\n\`\`\`\n${truncated}\n\`\`\`\n`);
   }
-  return { sources, text: parts.join("\n"), notes };
+  return parts;
+}
+
+/**
+ * Walk the repo root looking for canonical build/deploy files. Returns
+ * the relative paths (sorted) plus a concatenated text bundle the
+ * orchestrator passes to `/doc-wiki:ingest --output wiki/deploy.md`.
+ *
+ * Big files (>200 KB) are truncated with a marker line — full inclusion
+ * would blow the synthesis context budget for little additional value.
+ */
+export function assembleDeployInputs(repoRoot: string): SynthesisBundle {
+  const { paths, notes } = walkRepoTargets(repoRoot, {
+    topLevelBasenames: DEPLOY_FILE_GLOBS,
+    subdirPatterns: DEPLOY_DIR_PATTERNS,
+  });
+  if (paths.length === 0) {
+    notes.push("no build/deploy files matched — wiki/deploy.md will be sparse");
+    return { sources: [], text: "", notes };
+  }
+  const parts = _readAndFormatBundleFiles(repoRoot, paths, notes);
+  return { sources: [...paths], text: parts.join("\n"), notes };
 }
 
 /**
@@ -657,68 +649,18 @@ const _CONFIGURATION_DIR_PATTERNS: ReadonlyArray<{ dir: string; rx: RegExp }> = 
  * inline so the synthesis step can note the truncation when relevant.
  */
 export function assembleConfigurationInputs(repoRoot: string): SynthesisBundle {
-  const sources: string[] = [];
-  const parts: string[] = [];
-  const notes: string[] = [];
-
-  // Top-level files matching configuration globs.
-  let topLevel: fs.Dirent[];
-  try {
-    topLevel = fs.readdirSync(repoRoot, { withFileTypes: true });
-  } catch {
-    notes.push(`could not read repo root: ${repoRoot}`);
-    return { sources, text: "", notes };
+  const { paths, notes } = walkRepoTargets(repoRoot, {
+    topLevelBasenames: _CONFIGURATION_FILE_GLOBS,
+    subdirPatterns: _CONFIGURATION_DIR_PATTERNS,
+  });
+  if (paths.length === 0) {
+    notes.push(
+      "no configuration files matched — wiki/configuration.md will be sparse",
+    );
+    return { sources: [], text: "", notes };
   }
-  for (const e of topLevel) {
-    if (!e.isFile()) continue;
-    if (_CONFIGURATION_FILE_GLOBS.some((rx) => rx.test(e.name))) {
-      sources.push(e.name);
-    }
-  }
-
-  // Directory patterns.
-  for (const { dir, rx } of _CONFIGURATION_DIR_PATTERNS) {
-    const abs = path.join(repoRoot, dir);
-    if (!fs.existsSync(abs)) continue;
-    const walk = (d: string, relBase: string): void => {
-      let entries: fs.Dirent[];
-      try {
-        entries = fs.readdirSync(d, { withFileTypes: true });
-      } catch {
-        return;
-      }
-      for (const e of entries) {
-        const full = path.join(d, e.name);
-        const rel = path.posix.join(relBase, e.name);
-        if (e.isDirectory()) walk(full, rel);
-        else if (e.isFile() && rx.test(e.name)) sources.push(rel);
-      }
-    };
-    walk(abs, dir);
-  }
-
-  sources.sort();
-  if (sources.length === 0) {
-    notes.push("no configuration files matched — wiki/configuration.md will be sparse");
-    return { sources, text: "", notes };
-  }
-
-  for (const rel of sources) {
-    const abs = path.join(repoRoot, rel);
-    let body: string;
-    try {
-      body = fs.readFileSync(abs, "utf-8");
-    } catch {
-      notes.push(`could not read ${rel}`);
-      continue;
-    }
-    const truncated =
-      body.length > 200 * 1024
-        ? body.slice(0, 200 * 1024) + "\n... [truncated]\n"
-        : body;
-    parts.push(`## ${rel}\n\n\`\`\`\n${truncated}\n\`\`\`\n`);
-  }
-  return { sources, text: parts.join("\n"), notes };
+  const parts = _readAndFormatBundleFiles(repoRoot, paths, notes);
+  return { sources: [...paths], text: parts.join("\n"), notes };
 }
 
 // ── Troubleshooting bundle ─────────────────────────────────────────

--- a/agents/lib/repo_walker.js
+++ b/agents/lib/repo_walker.js
@@ -116,3 +116,64 @@ export function walkCodebase(root, patterns) {
 export function _resetPatternCache() {
     _PATTERN_CACHE.clear();
 }
+/**
+ * Walker variant tailored to the per-facet bundle assemblers in
+ * `atlas_synthesize.ts`: top-level basenames matching one of a fixed
+ * regex set + named subdirectories walked recursively with their own
+ * basename filter. Returns a sorted list of repo-relative POSIX paths.
+ *
+ * Does NOT read file bodies — callers handle truncation, encoding, and
+ * synthesis-text formatting themselves. Stays small, single-purpose,
+ * and reusable.
+ */
+export function walkRepoTargets(repoRoot, spec) {
+    const paths = new Set();
+    const notes = [];
+    // Top-level files.
+    if (spec.topLevelBasenames && spec.topLevelBasenames.length > 0) {
+        let topLevel;
+        try {
+            topLevel = fs.readdirSync(repoRoot, { withFileTypes: true });
+        }
+        catch {
+            notes.push(`could not read repo root: ${repoRoot}`);
+            return { paths: [], notes };
+        }
+        for (const e of topLevel) {
+            if (!e.isFile())
+                continue;
+            if (spec.topLevelBasenames.some((rx) => rx.test(e.name))) {
+                paths.add(e.name);
+            }
+        }
+    }
+    // Subdirectory recursive walks.
+    if (spec.subdirPatterns) {
+        for (const { dir, rx } of spec.subdirPatterns) {
+            const abs = path.join(repoRoot, dir);
+            if (!fs.existsSync(abs))
+                continue;
+            const recurse = (d, relBase) => {
+                let entries;
+                try {
+                    entries = fs.readdirSync(d, { withFileTypes: true });
+                }
+                catch {
+                    return;
+                }
+                for (const entry of entries) {
+                    const full = path.join(d, entry.name);
+                    const rel = path.posix.join(relBase, entry.name);
+                    if (entry.isDirectory()) {
+                        recurse(full, rel);
+                    }
+                    else if (entry.isFile() && rx.test(entry.name)) {
+                        paths.add(rel);
+                    }
+                }
+            };
+            recurse(abs, dir);
+        }
+    }
+    return { paths: [...paths].sort(), notes };
+}

--- a/agents/lib/repo_walker.ts
+++ b/agents/lib/repo_walker.ts
@@ -123,3 +123,94 @@ export function walkCodebase(
 export function _resetPatternCache(): void {
   _PATTERN_CACHE.clear();
 }
+
+/**
+ * Spec for {@link walkRepoTargets}. At least one of `topLevelBasenames`
+ * or `subdirPatterns` should be non-empty — both empty returns an empty
+ * result without error.
+ */
+export interface WalkTargetSpec {
+  /**
+   * RegExps tested against the basename (`fs.Dirent.name`) of every
+   * top-level file under `repoRoot`. A file matches when ANY pattern
+   * matches.
+   */
+  topLevelBasenames?: ReadonlyArray<RegExp>;
+  /**
+   * Subdirectories under `repoRoot` to walk recursively. Each entry's
+   * `rx` is tested against the basename of every file encountered. The
+   * walker silently skips a `dir` that does not exist.
+   */
+  subdirPatterns?: ReadonlyArray<{ dir: string; rx: RegExp }>;
+}
+
+/** Result of {@link walkRepoTargets}. */
+export interface WalkTargetResult {
+  /** Repo-relative POSIX paths discovered, lexicographically sorted. */
+  paths: string[];
+  /** Per-walk notes (e.g. `could not read repo root: <p>`). */
+  notes: string[];
+}
+
+/**
+ * Walker variant tailored to the per-facet bundle assemblers in
+ * `atlas_synthesize.ts`: top-level basenames matching one of a fixed
+ * regex set + named subdirectories walked recursively with their own
+ * basename filter. Returns a sorted list of repo-relative POSIX paths.
+ *
+ * Does NOT read file bodies — callers handle truncation, encoding, and
+ * synthesis-text formatting themselves. Stays small, single-purpose,
+ * and reusable.
+ */
+export function walkRepoTargets(
+  repoRoot: string,
+  spec: WalkTargetSpec,
+): WalkTargetResult {
+  const paths = new Set<string>();
+  const notes: string[] = [];
+
+  // Top-level files.
+  if (spec.topLevelBasenames && spec.topLevelBasenames.length > 0) {
+    let topLevel: fs.Dirent[];
+    try {
+      topLevel = fs.readdirSync(repoRoot, { withFileTypes: true });
+    } catch {
+      notes.push(`could not read repo root: ${repoRoot}`);
+      return { paths: [], notes };
+    }
+    for (const e of topLevel) {
+      if (!e.isFile()) continue;
+      if (spec.topLevelBasenames.some((rx) => rx.test(e.name))) {
+        paths.add(e.name);
+      }
+    }
+  }
+
+  // Subdirectory recursive walks.
+  if (spec.subdirPatterns) {
+    for (const { dir, rx } of spec.subdirPatterns) {
+      const abs = path.join(repoRoot, dir);
+      if (!fs.existsSync(abs)) continue;
+      const recurse = (d: string, relBase: string): void => {
+        let entries: fs.Dirent[];
+        try {
+          entries = fs.readdirSync(d, { withFileTypes: true });
+        } catch {
+          return;
+        }
+        for (const entry of entries) {
+          const full = path.join(d, entry.name);
+          const rel = path.posix.join(relBase, entry.name);
+          if (entry.isDirectory()) {
+            recurse(full, rel);
+          } else if (entry.isFile() && rx.test(entry.name)) {
+            paths.add(rel);
+          }
+        }
+      };
+      recurse(abs, dir);
+    }
+  }
+
+  return { paths: [...paths].sort(), notes };
+}

--- a/agents/lib/tests/repo_walker.test.ts
+++ b/agents/lib/tests/repo_walker.test.ts
@@ -11,6 +11,7 @@ import {
   compileGlob,
   matchesPattern,
   walkCodebase,
+  walkRepoTargets,
   _resetPatternCache,
 } from "../repo_walker.js";
 import { makeTmpPath, cleanupTmpPath } from "./fixtures.js";
@@ -138,5 +139,104 @@ describe("walkCodebase", () => {
 
   it("MAX_FILES is the documented bound", () => {
     expect(MAX_FILES).toBe(2000);
+  });
+});
+
+describe("walkRepoTargets", () => {
+  let tmpPath: string;
+
+  beforeEach(() => {
+    tmpPath = makeTmpPath("repo-walk-targets-");
+  });
+
+  afterEach(() => {
+    cleanupTmpPath(tmpPath);
+  });
+
+  it("returns empty for an empty spec", () => {
+    fs.writeFileSync(path.join(tmpPath, "Dockerfile"), "x");
+    const r = walkRepoTargets(tmpPath, {});
+    expect(r.paths).toEqual([]);
+    expect(r.notes).toEqual([]);
+  });
+
+  it("collects top-level files matching any basename regex", () => {
+    fs.writeFileSync(path.join(tmpPath, "Dockerfile"), "x");
+    fs.writeFileSync(path.join(tmpPath, "Makefile"), "x");
+    fs.writeFileSync(path.join(tmpPath, "README.md"), "x");
+    fs.mkdirSync(path.join(tmpPath, "src"), { recursive: true });
+    fs.writeFileSync(path.join(tmpPath, "src", "Dockerfile"), "x"); // not top-level
+
+    const r = walkRepoTargets(tmpPath, {
+      topLevelBasenames: [/^Dockerfile(\.[^/]+)?$/, /^Makefile$/],
+    });
+    expect(r.paths).toEqual(["Dockerfile", "Makefile"]);
+  });
+
+  it("walks subdir patterns recursively and matches basenames", () => {
+    fs.mkdirSync(path.join(tmpPath, ".github", "workflows"), { recursive: true });
+    fs.writeFileSync(
+      path.join(tmpPath, ".github", "workflows", "ci.yml"),
+      "x",
+    );
+    fs.writeFileSync(
+      path.join(tmpPath, ".github", "workflows", "deploy.yaml"),
+      "x",
+    );
+    fs.writeFileSync(
+      path.join(tmpPath, ".github", "workflows", "notes.txt"),
+      "x",
+    );
+    const r = walkRepoTargets(tmpPath, {
+      subdirPatterns: [{ dir: ".github/workflows", rx: /\.ya?ml$/ }],
+    });
+    expect(r.paths).toEqual([
+      ".github/workflows/ci.yml",
+      ".github/workflows/deploy.yaml",
+    ]);
+  });
+
+  it("silently skips a non-existent subdir", () => {
+    const r = walkRepoTargets(tmpPath, {
+      subdirPatterns: [{ dir: "nope", rx: /\.ya?ml$/ }],
+    });
+    expect(r.paths).toEqual([]);
+    expect(r.notes).toEqual([]);
+  });
+
+  it("combines top-level + subdir results, deduped and sorted", () => {
+    fs.writeFileSync(path.join(tmpPath, "Dockerfile"), "x");
+    fs.mkdirSync(path.join(tmpPath, "deploy"), { recursive: true });
+    fs.writeFileSync(path.join(tmpPath, "deploy", "k8s.yaml"), "x");
+    fs.writeFileSync(path.join(tmpPath, "deploy", "ec2.yml"), "x");
+    const r = walkRepoTargets(tmpPath, {
+      topLevelBasenames: [/^Dockerfile$/],
+      subdirPatterns: [{ dir: "deploy", rx: /\.ya?ml$/ }],
+    });
+    expect(r.paths).toEqual(["Dockerfile", "deploy/ec2.yml", "deploy/k8s.yaml"]);
+  });
+
+  it("emits a note + empty paths when repoRoot is unreadable", () => {
+    const missing = path.join(tmpPath, "does-not-exist");
+    const r = walkRepoTargets(missing, {
+      topLevelBasenames: [/^Dockerfile$/],
+    });
+    expect(r.paths).toEqual([]);
+    expect(r.notes[0]).toMatch(/could not read repo root/);
+  });
+
+  it("returns lexicographically sorted output", () => {
+    fs.mkdirSync(path.join(tmpPath, "config"), { recursive: true });
+    for (const name of ["zeta.yaml", "alpha.yaml", "mu.yaml"]) {
+      fs.writeFileSync(path.join(tmpPath, "config", name), "x");
+    }
+    const r = walkRepoTargets(tmpPath, {
+      subdirPatterns: [{ dir: "config", rx: /\.ya?ml$/ }],
+    });
+    expect(r.paths).toEqual([
+      "config/alpha.yaml",
+      "config/mu.yaml",
+      "config/zeta.yaml",
+    ]);
   });
 });


### PR DESCRIPTION
## Summary

The deploy walker (`assembleDeployInputs`) and configuration walker
(`assembleConfigurationInputs`) in `agents/lib/atlas_synthesize.ts`
had **byte-identical structure** — top-level basename-regex filter +
per-subdir recursive walk + 200KB-truncated body emission. With
`repo_walker.ts` now in place from PR #12, this refactor lifts both
into thin wrappers around a new `walkRepoTargets` primitive plus a
shared `_readAndFormatBundleFiles` helper for the body-formatting step.

## Why

- **Code reduction:** atlas_synthesize.ts shrinks by 58 LOC (117
  deletions vs 59 additions) — the duplicated walker bodies were the
  largest-by-far near-duplicates in the file per PR #12's Explore audit.
- **Reusable primitive:** `walkRepoTargets` is now available for future
  bundle assemblers — additional REST profiles, Phase 6 source-heuristic
  replacement, anything else with a top-level-globs + subdir-recursive
  shape.
- **Test surface:** new primitive has its own focused unit tests; the
  two wrappers' existing integration tests (in `atlas_synthesize.test.ts`)
  pass unmodified, proving byte-equivalent behavior.

## What does NOT change

- Same regex sets (`DEPLOY_FILE_GLOBS`, `DEPLOY_DIR_PATTERNS`,
  `_CONFIGURATION_FILE_GLOBS`, `_CONFIGURATION_DIR_PATTERNS`) feed
  both wrappers
- Same lexicographic sort
- Same per-file read-failure note semantics
- Same 200KB truncation cap with `... [truncated]` marker
- Same `SynthesisBundle` output shape

`assembleCommandsInputs` and `assembleGettingStartedInputs` are
intentionally untouched — they have walker-adjacent logic
(slash-command heading extraction, package.json scripts parsing) that
doesn't fit `walkRepoTargets` cleanly.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run build` — clean
- [x] `npm test` — **1038 passed** (baseline 1031, +7 new
      walkRepoTargets unit tests); 5 skipped (live-DB integration,
      unchanged)
- [x] Existing `atlas_synthesize.test.ts` tests for `assembleDeployInputs`
      and `assembleConfigurationInputs` pass without modification, proving
      behavior is preserved byte-equivalently
- [x] **Privacy:** `git grep -i 'ideaprojects\|doc-update'` empty across
      all paths