### PR TITLE
feat(atlas): six new REST profiles — Django / Flask / ASP.NET / Gin / Laravel / Hono

### DIFF
--- a/agents/lib/rest_profiles/aspnet.yaml
+++ b/agents/lib/rest_profiles/aspnet.yaml
@@ -1,0 +1,27 @@
+name: aspnet
+language: csharp
+description: "ASP.NET Core MVC + Web API attribute-routed controllers"
+
+detection:
+  file_patterns:
+    - "**/*.cs"
+  markers:
+    - pattern: "using Microsoft.AspNetCore"
+      type: import
+    - pattern: "[ApiController]"
+      type: attribute
+    - pattern: ": ControllerBase"
+      type: base_class
+    - pattern: ": Controller"
+      type: base_class
+
+# `[HttpGet("/api/users")]`, `[HttpPost("/api/users")]`, etc. The
+# `Http<Verb>` capture group is normalized to the verb; the path is the
+# first quoted string argument. Routes declared via `[Route("...")]`
+# at the controller level are intentionally NOT extracted here — the
+# inventory cares about ENDPOINT routes, not controller prefixes.
+endpoint_extraction:
+  patterns:
+    - regex: "\\[Http(Get|Post|Put|Delete|Patch|Options|Head)\\s*\\(\\s*[\"']([^\"']+)[\"']"
+      method_group: 1
+      path_group: 2

--- a/agents/lib/rest_profiles/django.yaml
+++ b/agents/lib/rest_profiles/django.yaml
@@ -1,0 +1,30 @@
+name: django
+language: python
+description: "Django URLconf routes (path / re_path); DRF ViewSet routers deferred"
+
+detection:
+  file_patterns:
+    - "**/*.py"
+  markers:
+    - pattern: "from django.urls import"
+      type: import
+    - pattern: "from django.conf.urls import"
+      type: import
+    - pattern: "urlpatterns ="
+      type: declaration
+
+# Django URLconf entries follow `path("api/users/", view, name="...")`
+# or `re_path(r"^api/", view)`. The HTTP method is not declared at the
+# URL level — it's enforced inside the view (CBV/FBV/DRF). For the
+# inventory, we record GET as a placeholder so the (file, line, method,
+# path) tuple stays unique; the synthesized api page can refine.
+endpoint_extraction:
+  patterns:
+    # path("api/users/", views.UserList.as_view(), name="user-list")
+    - regex: "(path)\\s*\\(\\s*['\"]([^'\"]+)['\"]"
+      method_group: 1
+      path_group: 2
+    # re_path(r"^api/users/$", views.user_list)
+    - regex: "(re_path)\\s*\\(\\s*r?['\"]([^'\"]+)['\"]"
+      method_group: 1
+      path_group: 2

--- a/agents/lib/rest_profiles/flask.yaml
+++ b/agents/lib/rest_profiles/flask.yaml
@@ -1,0 +1,29 @@
+name: flask
+language: python
+description: "Flask routes (explicit methods= keyword form; default-GET form deferred)"
+
+detection:
+  file_patterns:
+    - "**/*.py"
+  markers:
+    - pattern: "from flask import"
+      type: import
+    - pattern: "import flask"
+      type: import
+    - pattern: "Flask(__name__)"
+      type: instantiation
+
+# `@app.route('/path', methods=['GET'])` — only catches the explicit
+# methods= form. The default-GET case (`@app.route('/x')`) needs a
+# profile-shape extension to support a hardcoded fallback method;
+# tracked as a future enhancement. Capture order is path then method
+# because that's how Flask writes them.
+endpoint_extraction:
+  patterns:
+    - regex: "@(?:app|bp|blueprint)\\.route\\s*\\(\\s*['\"]([^'\"]+)['\"]\\s*,\\s*methods\\s*=\\s*\\[\\s*['\"](GET|POST|PUT|DELETE|PATCH|OPTIONS|HEAD)['\"]"
+      method_group: 2
+      path_group: 1
+    # @app.get("/x"), @app.post("/x") — Flask 2+ shorthand
+    - regex: "@(?:app|bp|blueprint)\\.(get|post|put|delete|patch|options|head)\\s*\\(\\s*['\"]([^'\"]+)['\"]"
+      method_group: 1
+      path_group: 2

--- a/agents/lib/rest_profiles/gin.yaml
+++ b/agents/lib/rest_profiles/gin.yaml
@@ -1,0 +1,22 @@
+name: gin
+language: go
+description: "Gin (Go) HTTP routes"
+
+detection:
+  file_patterns:
+    - "**/*.go"
+  markers:
+    - pattern: "github.com/gin-gonic/gin"
+      type: import
+    - pattern: "gin.Default()"
+      type: instantiation
+    - pattern: "gin.New()"
+      type: instantiation
+
+# Gin's verb methods are SHOUTING-CASE: `r.GET("/x", h)`, `r.POST(...)`,
+# etc. Common router variable names: r, router, group, api, e (engine).
+endpoint_extraction:
+  patterns:
+    - regex: "(?:r|router|group|api|e|engine)\\.(GET|POST|PUT|DELETE|PATCH|OPTIONS|HEAD)\\s*\\(\\s*\"([^\"]+)\""
+      method_group: 1
+      path_group: 2

--- a/agents/lib/rest_profiles/hono.yaml
+++ b/agents/lib/rest_profiles/hono.yaml
@@ -1,0 +1,33 @@
+name: hono
+language: typescript
+description: "Hono (Cloudflare Workers / Deno / Bun / Node) HTTP routes"
+
+detection:
+  file_patterns:
+    - "**/*.ts"
+    - "**/*.tsx"
+    - "**/*.js"
+    - "**/*.jsx"
+    - "**/*.mjs"
+  markers:
+    - pattern: "from \"hono\""
+      type: import
+    - pattern: "from 'hono'"
+      type: import
+    - pattern: "from \"hono/"
+      type: import
+    - pattern: "from 'hono/"
+      type: import
+    - pattern: "new Hono("
+      type: instantiation
+
+# Hono's surface is intentionally Express-like: `app.get('/x', c => ...)`
+# and chainable `.get()`/`.post()` etc. The marker check disambiguates
+# from Express: the inventory dedup keeps the first-matched profile's
+# framework field, so on a true Hono file (with `from "hono"` but not
+# `from "express"`), the framework correctly reads `hono`.
+endpoint_extraction:
+  patterns:
+    - regex: "(?:app|router|api|hono)\\.(get|post|put|delete|patch|options|head|all)\\s*\\(\\s*['\"`]([^'\"`]+)['\"`]"
+      method_group: 1
+      path_group: 2

--- a/agents/lib/rest_profiles/laravel.yaml
+++ b/agents/lib/rest_profiles/laravel.yaml
@@ -1,0 +1,29 @@
+name: laravel
+language: php
+description: "Laravel routes (routes/*.php Route::verb declarations)"
+
+detection:
+  # Laravel routes live in routes/api.php, routes/web.php; the matcher
+  # walks any *.php just in case routes are split. Markers confine the
+  # scan to files that look Laravel-shaped.
+  file_patterns:
+    - "**/*.php"
+  markers:
+    - pattern: "use Illuminate\\Support\\Facades\\Route"
+      type: import
+    - pattern: "Route::"
+      type: facade_call
+    - pattern: "Illuminate\\Routing"
+      type: import
+
+endpoint_extraction:
+  patterns:
+    # Route::get('/api/users', [UserController::class, 'index'])
+    # Route::post('/x', fn () => 'ok')
+    - regex: "Route::(get|post|put|delete|patch|options|head|any)\\s*\\(\\s*['\"]([^'\"]+)['\"]"
+      method_group: 1
+      path_group: 2
+    # $router->get('/x', '...') — older middleware-group style
+    - regex: "\\$router->(get|post|put|delete|patch|options|head|any)\\s*\\(\\s*['\"]([^'\"]+)['\"]"
+      method_group: 1
+      path_group: 2

--- a/agents/lib/tests/atlas_inventory.test.ts
+++ b/agents/lib/tests/atlas_inventory.test.ts
@@ -277,9 +277,260 @@ const ignored = "app.delete('/x')"; // string literal, but still matches by rege
 // ── discoverShippedRestProfiles + per-profile fixtures ─────────────
 
 describe("discoverShippedRestProfiles", () => {
-  it("returns the four shipped profiles, sorted", () => {
+  it("returns all ten shipped profiles, sorted", () => {
     const names = discoverShippedRestProfiles();
-    expect(names).toEqual(["express", "fastapi", "rails", "spring"]);
+    expect(names).toEqual([
+      "aspnet",
+      "django",
+      "express",
+      "fastapi",
+      "flask",
+      "gin",
+      "hono",
+      "laravel",
+      "rails",
+      "spring",
+    ]);
+  });
+});
+
+describe("Django profile", () => {
+  let tmpPath: string;
+  beforeEach(() => { tmpPath = makeTmpPath("atlas-inv-django-"); });
+  afterEach(() => { cleanupTmpPath(tmpPath); });
+
+  it("loads cleanly from disk", () => {
+    const p = loadRestProfile("django");
+    expect(p).not.toBeNull();
+    expect(p?.language).toBe("python");
+  });
+
+  it("extracts URLconf entries (path / re_path)", () => {
+    fs.writeFileSync(
+      path.join(tmpPath, "urls.py"),
+      `from django.urls import path, re_path
+from . import views
+
+urlpatterns = [
+    path("api/users/", views.UserList.as_view(), name="user-list"),
+    path("api/users/<int:pk>/", views.UserDetail.as_view()),
+    re_path(r"^api/legacy/$", views.legacy_handler),
+]
+`,
+    );
+    const profile = loadRestProfile("django")!;
+    const eps = detectRestEndpoints(tmpPath, [profile]);
+    const urls = eps.map((e) => e.path).sort();
+    expect(urls).toContain("api/users/");
+    expect(urls).toContain("api/users/<int:pk>/");
+    expect(urls).toContain("^api/legacy/$");
+  });
+
+  it("skips Python files without a django.urls import", () => {
+    fs.writeFileSync(
+      path.join(tmpPath, "tasks.py"),
+      `path("/internal/", lambda: None)\n`,
+    );
+    const profile = loadRestProfile("django")!;
+    expect(detectRestEndpoints(tmpPath, [profile])).toEqual([]);
+  });
+});
+
+describe("Flask profile", () => {
+  let tmpPath: string;
+  beforeEach(() => { tmpPath = makeTmpPath("atlas-inv-flask-"); });
+  afterEach(() => { cleanupTmpPath(tmpPath); });
+
+  it("loads cleanly from disk", () => {
+    const p = loadRestProfile("flask");
+    expect(p).not.toBeNull();
+    expect(p?.language).toBe("python");
+  });
+
+  it("extracts @app.route(methods=) and @app.<verb> shorthand", () => {
+    fs.writeFileSync(
+      path.join(tmpPath, "app.py"),
+      `from flask import Flask
+app = Flask(__name__)
+
+@app.route("/api/users", methods=["GET"])
+def list_users(): pass
+
+@app.route('/api/users', methods=['POST'])
+def create_user(): pass
+
+@app.get("/api/users/<int:user_id>")
+def show(user_id): pass
+
+@app.delete('/api/users/<int:user_id>')
+def remove(user_id): pass
+`,
+    );
+    const profile = loadRestProfile("flask")!;
+    const eps = detectRestEndpoints(tmpPath, [profile]);
+    const tuples = eps.map((e) => `${e.method} ${e.path}`);
+    expect(tuples).toContain("GET /api/users");
+    expect(tuples).toContain("POST /api/users");
+    expect(tuples).toContain("GET /api/users/<int:user_id>");
+    expect(tuples).toContain("DELETE /api/users/<int:user_id>");
+  });
+});
+
+describe("ASP.NET profile", () => {
+  let tmpPath: string;
+  beforeEach(() => { tmpPath = makeTmpPath("atlas-inv-aspnet-"); });
+  afterEach(() => { cleanupTmpPath(tmpPath); });
+
+  it("loads cleanly from disk", () => {
+    const p = loadRestProfile("aspnet");
+    expect(p).not.toBeNull();
+    expect(p?.language).toBe("csharp");
+  });
+
+  it("extracts [HttpVerb] attribute routes", () => {
+    fs.mkdirSync(path.join(tmpPath, "Controllers"), { recursive: true });
+    fs.writeFileSync(
+      path.join(tmpPath, "Controllers", "UsersController.cs"),
+      `using Microsoft.AspNetCore.Mvc;
+
+[ApiController]
+[Route("api/[controller]")]
+public class UsersController : ControllerBase
+{
+    [HttpGet("/api/users")]
+    public IActionResult List() => Ok();
+
+    [HttpPost("/api/users")]
+    public IActionResult Create() => Created("/", null);
+
+    [HttpDelete("/api/users/{id:int}")]
+    public IActionResult Delete(int id) => NoContent();
+}
+`,
+    );
+    const profile = loadRestProfile("aspnet")!;
+    const eps = detectRestEndpoints(tmpPath, [profile]);
+    const tuples = eps.map((e) => `${e.method} ${e.path}`);
+    expect(tuples).toContain("GET /api/users");
+    expect(tuples).toContain("POST /api/users");
+    expect(tuples).toContain("DELETE /api/users/{id:int}");
+  });
+});
+
+describe("Gin profile", () => {
+  let tmpPath: string;
+  beforeEach(() => { tmpPath = makeTmpPath("atlas-inv-gin-"); });
+  afterEach(() => { cleanupTmpPath(tmpPath); });
+
+  it("loads cleanly from disk", () => {
+    const p = loadRestProfile("gin");
+    expect(p).not.toBeNull();
+    expect(p?.language).toBe("go");
+  });
+
+  it("extracts r.GET / r.POST etc. routes", () => {
+    fs.writeFileSync(
+      path.join(tmpPath, "main.go"),
+      `package main
+
+import "github.com/gin-gonic/gin"
+
+func main() {
+    r := gin.Default()
+    r.GET("/api/users", listUsers)
+    r.POST("/api/users", createUser)
+    r.PUT("/api/users/:id", updateUser)
+    api := r.Group("/v2")
+    api.DELETE("/api/users/:id", deleteUser)
+    r.Run()
+}
+`,
+    );
+    const profile = loadRestProfile("gin")!;
+    const eps = detectRestEndpoints(tmpPath, [profile]);
+    const tuples = eps.map((e) => `${e.method} ${e.path}`);
+    expect(tuples).toContain("GET /api/users");
+    expect(tuples).toContain("POST /api/users");
+    expect(tuples).toContain("PUT /api/users/:id");
+    expect(tuples).toContain("DELETE /api/users/:id");
+  });
+});
+
+describe("Laravel profile", () => {
+  let tmpPath: string;
+  beforeEach(() => { tmpPath = makeTmpPath("atlas-inv-laravel-"); });
+  afterEach(() => { cleanupTmpPath(tmpPath); });
+
+  it("loads cleanly from disk", () => {
+    const p = loadRestProfile("laravel");
+    expect(p).not.toBeNull();
+    expect(p?.language).toBe("php");
+  });
+
+  it("extracts Route::verb declarations", () => {
+    fs.mkdirSync(path.join(tmpPath, "routes"), { recursive: true });
+    fs.writeFileSync(
+      path.join(tmpPath, "routes", "api.php"),
+      `<?php
+use Illuminate\\Support\\Facades\\Route;
+
+Route::get('/api/users', [UserController::class, 'index']);
+Route::post("/api/users", [UserController::class, 'store']);
+Route::put('/api/users/{user}', [UserController::class, 'update']);
+Route::delete("/api/users/{user}", [UserController::class, 'destroy']);
+`,
+    );
+    const profile = loadRestProfile("laravel")!;
+    const eps = detectRestEndpoints(tmpPath, [profile]);
+    const tuples = eps.map((e) => `${e.method} ${e.path}`);
+    expect(tuples).toContain("GET /api/users");
+    expect(tuples).toContain("POST /api/users");
+    expect(tuples).toContain("PUT /api/users/{user}");
+    expect(tuples).toContain("DELETE /api/users/{user}");
+  });
+});
+
+describe("Hono profile", () => {
+  let tmpPath: string;
+  beforeEach(() => { tmpPath = makeTmpPath("atlas-inv-hono-"); });
+  afterEach(() => { cleanupTmpPath(tmpPath); });
+
+  it("loads cleanly from disk", () => {
+    const p = loadRestProfile("hono");
+    expect(p).not.toBeNull();
+    expect(p?.language).toBe("typescript");
+  });
+
+  it("extracts Hono routes from a file with the hono import", () => {
+    fs.writeFileSync(
+      path.join(tmpPath, "app.ts"),
+      `import { Hono } from "hono";
+
+const app = new Hono();
+
+app.get('/api/users', (c) => c.json([]));
+app.post("/api/users", (c) => c.json({}, 201));
+app.delete(\`/api/users/:id\`, (c) => c.text(""));
+`,
+    );
+    const profile = loadRestProfile("hono")!;
+    const eps = detectRestEndpoints(tmpPath, [profile]);
+    const tuples = eps.map((e) => `${e.method} ${e.path}`);
+    expect(tuples).toContain("GET /api/users");
+    expect(tuples).toContain("POST /api/users");
+    expect(tuples).toContain("DELETE /api/users/:id");
+  });
+
+  it("does NOT match files that import express, not hono", () => {
+    fs.writeFileSync(
+      path.join(tmpPath, "app.ts"),
+      `import express from "express";
+const app = express();
+app.get('/x', () => {});
+`,
+    );
+    const profile = loadRestProfile("hono")!;
+    expect(detectRestEndpoints(tmpPath, [profile])).toEqual([]);
   });
 });
 
@@ -438,10 +689,21 @@ describe("resolveRestProfiles", () => {
     cleanupTmpPath(tmpPath);
   });
 
-  it("returns all four shipped profiles when no name list is given", () => {
+  it("returns all ten shipped profiles when no name list is given", () => {
     const out = resolveRestProfiles({});
     const names = out.map((p) => p.name).sort();
-    expect(names).toEqual(["express", "fastapi", "rails", "spring"]);
+    expect(names).toEqual([
+      "aspnet",
+      "django",
+      "express",
+      "fastapi",
+      "flask",
+      "gin",
+      "hono",
+      "laravel",
+      "rails",
+      "spring",
+    ]);
   });
 
   it("filters to the named subset when profileNames is given", () => {
@@ -514,8 +776,14 @@ ecosystem:
     fs.writeFileSync(configPath, `wiki:\n  name: x\n`);
     const out = resolveRestProfiles({ wikiConfigPath: configPath });
     expect(out.map((p) => p.name).sort()).toEqual([
+      "aspnet",
+      "django",
       "express",
       "fastapi",
+      "flask",
+      "gin",
+      "hono",
+      "laravel",
       "rails",
       "spring",
     ]);


### PR DESCRIPTION
## Summary

Doubles the shipped REST profile set (was 4, now **10**) so the
`rest_endpoints` inventory bucket covers five additional ecosystems:
Python full-stack (Django), Python micro (Flask), .NET (ASP.NET Core),
Go (Gin), PHP (Laravel), plus a Node-alternative (Hono).

Each is an independent ~30-50 LOC YAML profile + tests, additive over
PRs #12 and #14. Custom profiles + multi-profile dispatch + dedup all
work the same way they did before — these new profiles just plug into
the existing dispatcher.

## Profiles authored

| Profile | Language | Pattern | Notes |
|---|---|---|---|
| `django` | Python | `path("/x", view)` / `re_path(r"^api/$", view)` | URLconf only; DRF ViewSet routers deferred |
| `flask` | Python | `@app.route("/x", methods=["GET"])` + `@app.<verb>("/x")` shorthand | Default-GET case deferred (needs profile-shape extension) |
| `aspnet` | C# | `[HttpGet("/x")]` / `[HttpPost(...)]` | Controller-level `[Route("...")]` prefix not concatenated |
| `gin` | Go | `r.GET("/x", h)` / `r.POST(...)` | Common router var names: r, router, group, api, e, engine |
| `laravel` | PHP | `Route::get('/x', ...)` | `$router->verb()` middleware-group form also caught |
| `hono` | TypeScript | `app.METHOD('/x', ...)` | Marker check + first-profile-wins dedup disambiguates from Express |

## What does NOT change

- Public API (`detectRestEndpoints`, `resolveRestProfiles`, `loadRestProfile`,
  `loadCustomRestProfiles`, `discoverShippedRestProfiles`) — same as
  PR #14
- Custom-profile loading from `wiki.config.yaml` — unchanged
- Multi-profile dispatch + `(file, line, method, path)` dedup — unchanged
- CLI flags (`--rest-profiles <csv>`, `--rest-profile <name>`) — unchanged
- SKILL.md Phase 1b prose — already documents the four-profile state in
  general terms; no edit needed

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run build` — clean
- [x] `npm test` — **1071 passed** (baseline 1057, +14 new); 5 skipped
      (live-DB integration, unchanged)
- [x] **Privacy:** `git grep -i 'ideaprojects\|doc-update'` empty across
      all paths
- [x] **Dogfood on this repo with `--enable-rest`:** 16 endpoints, all
      `framework: express` (the new test fixtures added 5 Express-shaped
      routes; markers for the 6 new profiles are absent on this
      Node-only repo, as expected)
- [x] **Per-profile fixture tests** verify detection of conventional
      patterns + negative cases (skips files without the marker)
- [x] **`discoverShippedRestProfiles()`** now returns all 10 profile
      names sorted: aspnet, django, express, fastapi, flask, gin, hono,
      laravel, rails, spring

## Deferred to follow-ups

- **Heuristic "unknown framework" fallback** — the "learning" angle:
  catches HTTP-route-shaped patterns even when no profile marker
  matches; emitted as `framework: "unknown"` / `confidence: low`. Its
  own design round (autonomy-mode-aware loop)
- **Flask default-GET case** — `@app.route('/x')` without `methods=`.
  Needs profile-shape extension to support a hardcoded fallback method
  when no method group captures. ~10 LOC extension
- **Django DRF ViewSet routers** — `router.register(r'users', UserViewSet)`
  expands to multiple endpoints via the DRF router. Needs a route-tree
  walker
- **Rails `resources :foo` blocks** — same — DSL expansion needed
- **ASP.NET controller-level `[Route("...")]` prefix concatenation** —
  currently each `[HttpGet("/x")]` is taken as the full path, ignoring
  any class-level `[Route("api/[controller]")]` prefix