### PR TITLE
feat(atlas): eight more REST profiles — Fastify / Koa / Echo / Rocket / Actix / Slim / Phoenix / Vapor

### DIFF
--- a/agents/lib/rest_profiles/actix.yaml
+++ b/agents/lib/rest_profiles/actix.yaml
@@ -1,0 +1,26 @@
+name: actix
+language: rust
+description: "Actix Web (Rust) HTTP routes via .route() registration"
+
+detection:
+  file_patterns:
+    - "**/*.rs"
+  markers:
+    - pattern: "use actix_web"
+      type: import
+    - pattern: "extern crate actix_web"
+      type: import
+    - pattern: "actix_web::"
+      type: usage
+
+# Actix has two routing styles. This profile covers the explicit
+# `.route("/path", web::get().to(handler))` builder form, which puts the
+# path BEFORE the method — hence method_group: 2 / path_group: 1. The
+# attribute-macro form (`#[get("/path")]` on a handler + `cfg.service(...)`)
+# is intentionally deferred: those attribute macros are typed differently
+# than Rocket's and would shadow Rocket's profile on shared `*.rs` files.
+endpoint_extraction:
+  patterns:
+    - regex: "\\.route\\s*\\(\\s*\"([^\"]+)\"\\s*,\\s*web::(get|post|put|delete|patch|options|head)"
+      method_group: 2
+      path_group: 1

--- a/agents/lib/rest_profiles/echo.yaml
+++ b/agents/lib/rest_profiles/echo.yaml
@@ -1,0 +1,23 @@
+name: echo
+language: go
+description: "Echo (Go) HTTP routes"
+
+detection:
+  file_patterns:
+    - "**/*.go"
+  markers:
+    - pattern: "github.com/labstack/echo"
+      type: import
+    - pattern: "echo.New("
+      type: instantiation
+
+# Echo's verb methods are SHOUTING-CASE: `e.GET("/x", h)`, `e.POST(...)`,
+# etc. Common router variable names: e (engine), router, g (group), api,
+# server. Group prefixing — `g := e.Group("/api"); g.GET("/users", ...)`
+# — is intentionally NOT concatenated: the inventory records the literal
+# path argument and leaves prefix synthesis to the future synthesizer.
+endpoint_extraction:
+  patterns:
+    - regex: "(?:e|router|g|api|server)\\.(GET|POST|PUT|DELETE|PATCH|OPTIONS|HEAD)\\s*\\(\\s*\"([^\"]+)\""
+      method_group: 1
+      path_group: 2

--- a/agents/lib/rest_profiles/fastify.yaml
+++ b/agents/lib/rest_profiles/fastify.yaml
@@ -1,0 +1,33 @@
+name: fastify
+language: typescript
+description: "Fastify (Node.js) HTTP routes"
+
+detection:
+  file_patterns:
+    - "**/*.ts"
+    - "**/*.tsx"
+    - "**/*.js"
+    - "**/*.jsx"
+    - "**/*.mjs"
+    - "**/*.cjs"
+  markers:
+    - pattern: "from \"fastify\""
+      type: import
+    - pattern: "from 'fastify'"
+      type: import
+    - pattern: "require('fastify')"
+      type: import
+    - pattern: "require(\"fastify\")"
+      type: import
+    - pattern: "Fastify("
+      type: instantiation
+
+# fastify.get('/path', handler), app.post("/x"), server.put(`/y/:id`).
+# Fastify's plugin/encapsulation system can also expose `instance.get(...)`
+# inside `fastify.register(...)` callbacks; that's deferred to a future
+# pass.
+endpoint_extraction:
+  patterns:
+    - regex: "(?:fastify|app|server)\\.(get|post|put|delete|patch|options|head)\\s*\\(\\s*['\"`]([^'\"`]+)['\"`]"
+      method_group: 1
+      path_group: 2

--- a/agents/lib/rest_profiles/koa.yaml
+++ b/agents/lib/rest_profiles/koa.yaml
@@ -1,0 +1,37 @@
+name: koa
+language: typescript
+description: "Koa (Node.js) routes via @koa/router or koa-router"
+
+detection:
+  file_patterns:
+    - "**/*.ts"
+    - "**/*.tsx"
+    - "**/*.js"
+    - "**/*.jsx"
+    - "**/*.mjs"
+    - "**/*.cjs"
+  markers:
+    - pattern: "from \"@koa/router\""
+      type: import
+    - pattern: "from '@koa/router'"
+      type: import
+    - pattern: "from \"koa-router\""
+      type: import
+    - pattern: "from 'koa-router'"
+      type: import
+    - pattern: "require('@koa/router')"
+      type: import
+    - pattern: "require(\"koa-router\")"
+      type: import
+    - pattern: "new Router("
+      type: instantiation
+
+# Koa itself ships no router — apps almost always use @koa/router (or the
+# legacy koa-router). Routes are declared on a Router instance and then
+# mounted with app.use(router.routes()). Common variable names: router,
+# api, app (when developers reuse the app symbol for a sub-router).
+endpoint_extraction:
+  patterns:
+    - regex: "(?:router|api|app)\\.(get|post|put|delete|patch|options|head)\\s*\\(\\s*['\"`]([^'\"`]+)['\"`]"
+      method_group: 1
+      path_group: 2

--- a/agents/lib/rest_profiles/phoenix.yaml
+++ b/agents/lib/rest_profiles/phoenix.yaml
@@ -1,0 +1,27 @@
+name: phoenix
+language: elixir
+description: "Phoenix (Elixir) router verb declarations"
+
+detection:
+  file_patterns:
+    - "**/*.ex"
+    - "**/*.exs"
+  markers:
+    - pattern: "use Phoenix.Router"
+      type: import
+    - pattern: "Phoenix.Router"
+      type: import
+    - pattern: ":router"
+      type: declaration
+
+# Phoenix routes are declared inside a router module:
+#   get "/users", UserController, :index
+#   post "/users", UserController, :create
+# `pipe_through` blocks scope routes to a pipeline; `scope "/api"` blocks
+# prefix paths. Neither is unwound by the inventory v1 — the literal path
+# argument is recorded as-is.
+endpoint_extraction:
+  patterns:
+    - regex: "(?:^|\\s)(get|post|put|delete|patch|options|head)\\s+\"([^\"]+)\"\\s*,"
+      method_group: 1
+      path_group: 2

--- a/agents/lib/rest_profiles/rocket.yaml
+++ b/agents/lib/rest_profiles/rocket.yaml
@@ -1,0 +1,25 @@
+name: rocket
+language: rust
+description: "Rocket (Rust) HTTP routes via attribute macros"
+
+detection:
+  file_patterns:
+    - "**/*.rs"
+  markers:
+    - pattern: "use rocket"
+      type: import
+    - pattern: "extern crate rocket"
+      type: import
+    - pattern: "#[macro_use] extern crate rocket"
+      type: import
+
+# Rocket's routes are declared via attribute macros: `#[get("/path")]`,
+# `#[post("/path", data = "<body>")]`, etc. on a free function. The
+# extractor captures the verb from the macro name and the path from the
+# first quoted string argument; query / data / format keyword args after
+# the path are ignored (the regex stops at the closing quote).
+endpoint_extraction:
+  patterns:
+    - regex: "#\\[(get|post|put|delete|patch|options|head)\\s*\\(\\s*\"([^\"]+)\""
+      method_group: 1
+      path_group: 2

--- a/agents/lib/rest_profiles/slim.yaml
+++ b/agents/lib/rest_profiles/slim.yaml
@@ -1,0 +1,26 @@
+name: slim
+language: php
+description: "Slim Framework (PHP) HTTP routes"
+
+detection:
+  file_patterns:
+    - "**/*.php"
+  markers:
+    - pattern: "use Slim\\App"
+      type: import
+    - pattern: "Slim\\Factory\\AppFactory"
+      type: import
+    - pattern: "\\Slim\\App"
+      type: usage
+    - pattern: "Slim\\App"
+      type: usage
+
+# Slim's verb methods sit on the App instance: `$app->get('/x', $h)`,
+# `$app->post(...)`, etc. The `any()` helper registers a handler for
+# every verb — it's recorded literally as `ANY` in the inventory so the
+# downstream synthesizer can decide how to render it.
+endpoint_extraction:
+  patterns:
+    - regex: "\\$app->(get|post|put|delete|patch|options|head|any)\\s*\\(\\s*['\"]([^'\"]+)['\"]"
+      method_group: 1
+      path_group: 2

--- a/agents/lib/rest_profiles/vapor.yaml
+++ b/agents/lib/rest_profiles/vapor.yaml
@@ -1,0 +1,26 @@
+name: vapor
+language: swift
+description: "Vapor (Swift) HTTP routes"
+
+detection:
+  file_patterns:
+    - "**/*.swift"
+  markers:
+    - pattern: "import Vapor"
+      type: import
+    - pattern: "app.routes"
+      type: usage
+    - pattern: "app.group("
+      type: usage
+
+# Vapor verb methods accept either a single path string or a sequence of
+# `PathComponent` arguments — `app.get("api", "users") { req in ... }`.
+# The inventory captures only the FIRST path argument; multi-component
+# concatenation (e.g. `["api", "users"]` -> `/api/users`) and route
+# groups (`app.grouped("api").get("users", ...)`) are deferred. Common
+# router variables: `app`, `routes`, `grouped`.
+endpoint_extraction:
+  patterns:
+    - regex: "(?:app|routes|grouped)\\.(get|post|put|delete|patch|options|head)\\s*\\(\\s*\"([^\"]+)\""
+      method_group: 1
+      path_group: 2

--- a/agents/lib/tests/atlas_inventory.test.ts
+++ b/agents/lib/tests/atlas_inventory.test.ts
@@ -277,19 +277,27 @@ const ignored = "app.delete('/x')"; // string literal, but still matches by rege
 // ── discoverShippedRestProfiles + per-profile fixtures ─────────────
 
 describe("discoverShippedRestProfiles", () => {
-  it("returns all ten shipped profiles, sorted", () => {
+  it("returns all eighteen shipped profiles, sorted", () => {
     const names = discoverShippedRestProfiles();
     expect(names).toEqual([
+      "actix",
       "aspnet",
       "django",
+      "echo",
       "express",
       "fastapi",
+      "fastify",
       "flask",
       "gin",
       "hono",
+      "koa",
       "laravel",
+      "phoenix",
       "rails",
+      "rocket",
+      "slim",
       "spring",
+      "vapor",
     ]);
   });
 });
@@ -674,6 +682,343 @@ end
   });
 });
 
+describe("Fastify profile", () => {
+  let tmpPath: string;
+  beforeEach(() => { tmpPath = makeTmpPath("atlas-inv-fastify-"); });
+  afterEach(() => { cleanupTmpPath(tmpPath); });
+
+  it("loads cleanly from disk", () => {
+    const p = loadRestProfile("fastify");
+    expect(p).not.toBeNull();
+    expect(p?.language).toBe("typescript");
+  });
+
+  it("extracts fastify.* / app.* / server.* verb routes", () => {
+    fs.writeFileSync(
+      path.join(tmpPath, "server.ts"),
+      `import Fastify from 'fastify';
+const fastify = Fastify();
+fastify.get('/api/users', async () => []);
+fastify.post("/api/users", async () => ({}));
+app.put(\`/api/users/:id\`, async () => ({}));
+server.delete('/api/users/:id', async () => undefined);
+`,
+    );
+    const profile = loadRestProfile("fastify")!;
+    const eps = detectRestEndpoints(tmpPath, [profile]);
+    const tuples = eps.map((e) => `${e.method} ${e.path}`);
+    expect(tuples).toContain("GET /api/users");
+    expect(tuples).toContain("POST /api/users");
+    expect(tuples).toContain("PUT /api/users/:id");
+    expect(tuples).toContain("DELETE /api/users/:id");
+    const get = eps.find((e) => e.method === "GET")!;
+    expect(get.line).toBe(3);
+  });
+
+  it("skips files without a fastify import", () => {
+    fs.writeFileSync(
+      path.join(tmpPath, "x.ts"),
+      `app.get('/api/users', async () => []);\n`,
+    );
+    const profile = loadRestProfile("fastify")!;
+    expect(detectRestEndpoints(tmpPath, [profile])).toEqual([]);
+  });
+});
+
+describe("Koa profile", () => {
+  let tmpPath: string;
+  beforeEach(() => { tmpPath = makeTmpPath("atlas-inv-koa-"); });
+  afterEach(() => { cleanupTmpPath(tmpPath); });
+
+  it("loads cleanly from disk", () => {
+    const p = loadRestProfile("koa");
+    expect(p).not.toBeNull();
+    expect(p?.language).toBe("typescript");
+  });
+
+  it("extracts router.* / api.* / app.* verb routes", () => {
+    fs.writeFileSync(
+      path.join(tmpPath, "routes.ts"),
+      `import Router from "@koa/router";
+const router = new Router();
+router.get('/api/users', (ctx) => {});
+router.post("/api/users", (ctx) => {});
+api.put(\`/api/users/:id\`, (ctx) => {});
+app.delete('/api/users/:id', (ctx) => {});
+`,
+    );
+    const profile = loadRestProfile("koa")!;
+    const eps = detectRestEndpoints(tmpPath, [profile]);
+    const tuples = eps.map((e) => `${e.method} ${e.path}`);
+    expect(tuples).toContain("GET /api/users");
+    expect(tuples).toContain("POST /api/users");
+    expect(tuples).toContain("PUT /api/users/:id");
+    expect(tuples).toContain("DELETE /api/users/:id");
+    const get = eps.find((e) => e.method === "GET")!;
+    expect(get.line).toBe(3);
+  });
+
+  it("skips files without a koa-router import", () => {
+    fs.writeFileSync(
+      path.join(tmpPath, "x.ts"),
+      `router.get('/api/users', (ctx) => {});\n`,
+    );
+    const profile = loadRestProfile("koa")!;
+    expect(detectRestEndpoints(tmpPath, [profile])).toEqual([]);
+  });
+});
+
+describe("Echo profile", () => {
+  let tmpPath: string;
+  beforeEach(() => { tmpPath = makeTmpPath("atlas-inv-echo-"); });
+  afterEach(() => { cleanupTmpPath(tmpPath); });
+
+  it("loads cleanly from disk", () => {
+    const p = loadRestProfile("echo");
+    expect(p).not.toBeNull();
+    expect(p?.language).toBe("go");
+  });
+
+  it("extracts e.* / g.* SHOUTING-CASE verb routes", () => {
+    fs.writeFileSync(
+      path.join(tmpPath, "main.go"),
+      `package main
+
+import "github.com/labstack/echo/v4"
+
+func main() {
+    e := echo.New()
+    e.GET("/api/users", listUsers)
+    e.POST("/api/users", createUser)
+    g := e.Group("/v2")
+    g.PUT("/api/users/:id", updateUser)
+    api.DELETE("/api/users/:id", deleteUser)
+    e.Start(":8080")
+}
+`,
+    );
+    const profile = loadRestProfile("echo")!;
+    const eps = detectRestEndpoints(tmpPath, [profile]);
+    const tuples = eps.map((e) => `${e.method} ${e.path}`);
+    expect(tuples).toContain("GET /api/users");
+    expect(tuples).toContain("POST /api/users");
+    expect(tuples).toContain("PUT /api/users/:id");
+    expect(tuples).toContain("DELETE /api/users/:id");
+  });
+});
+
+describe("Rocket profile", () => {
+  let tmpPath: string;
+  beforeEach(() => { tmpPath = makeTmpPath("atlas-inv-rocket-"); });
+  afterEach(() => { cleanupTmpPath(tmpPath); });
+
+  it("loads cleanly from disk", () => {
+    const p = loadRestProfile("rocket");
+    expect(p).not.toBeNull();
+    expect(p?.language).toBe("rust");
+  });
+
+  it("extracts #[verb(\"/path\")] attribute-macro routes", () => {
+    fs.writeFileSync(
+      path.join(tmpPath, "main.rs"),
+      `#[macro_use] extern crate rocket;
+use rocket::*;
+
+#[get("/api/users")]
+fn list() -> &'static str { "" }
+
+#[post("/api/users")]
+fn create() {}
+
+#[put("/api/users/<id>")]
+fn update() {}
+
+#[delete("/api/users/<id>")]
+fn destroy() {}
+`,
+    );
+    const profile = loadRestProfile("rocket")!;
+    const eps = detectRestEndpoints(tmpPath, [profile]);
+    const tuples = eps.map((e) => `${e.method} ${e.path}`);
+    expect(tuples).toContain("GET /api/users");
+    expect(tuples).toContain("POST /api/users");
+    expect(tuples).toContain("PUT /api/users/<id>");
+    expect(tuples).toContain("DELETE /api/users/<id>");
+    const get = eps.find((e) => e.method === "GET")!;
+    expect(get.line).toBe(4);
+  });
+});
+
+describe("Actix profile", () => {
+  let tmpPath: string;
+  beforeEach(() => { tmpPath = makeTmpPath("atlas-inv-actix-"); });
+  afterEach(() => { cleanupTmpPath(tmpPath); });
+
+  it("loads cleanly from disk", () => {
+    const p = loadRestProfile("actix");
+    expect(p).not.toBeNull();
+    expect(p?.language).toBe("rust");
+  });
+
+  it("extracts .route(\"/path\", web::verb()) registration routes", () => {
+    fs.writeFileSync(
+      path.join(tmpPath, "main.rs"),
+      `use actix_web::{web, App, HttpServer};
+
+fn main() {
+    let app = App::new()
+        .route("/api/users", web::get().to(list_users))
+        .route("/api/users", web::post().to(create_user))
+        .route("/api/users/{id}", web::put().to(update_user))
+        .route("/api/users/{id}", web::delete().to(delete_user));
+}
+`,
+    );
+    const profile = loadRestProfile("actix")!;
+    const eps = detectRestEndpoints(tmpPath, [profile]);
+    const tuples = eps.map((e) => `${e.method} ${e.path}`);
+    expect(tuples).toContain("GET /api/users");
+    expect(tuples).toContain("POST /api/users");
+    expect(tuples).toContain("PUT /api/users/{id}");
+    expect(tuples).toContain("DELETE /api/users/{id}");
+  });
+
+  it("skips Rust files without an actix_web import", () => {
+    fs.writeFileSync(
+      path.join(tmpPath, "x.rs"),
+      `app.route("/x", web::get().to(h));\n`,
+    );
+    const profile = loadRestProfile("actix")!;
+    expect(detectRestEndpoints(tmpPath, [profile])).toEqual([]);
+  });
+});
+
+describe("Slim profile", () => {
+  let tmpPath: string;
+  beforeEach(() => { tmpPath = makeTmpPath("atlas-inv-slim-"); });
+  afterEach(() => { cleanupTmpPath(tmpPath); });
+
+  it("loads cleanly from disk", () => {
+    const p = loadRestProfile("slim");
+    expect(p).not.toBeNull();
+    expect(p?.language).toBe("php");
+  });
+
+  it("extracts $app->verb('/path') routes", () => {
+    fs.writeFileSync(
+      path.join(tmpPath, "index.php"),
+      `<?php
+use Slim\\App;
+use Slim\\Factory\\AppFactory;
+
+$app = AppFactory::create();
+$app->get('/api/users', function ($req, $res) {});
+$app->post("/api/users", function ($req, $res) {});
+$app->put('/api/users/{id}', function ($req, $res) {});
+$app->delete("/api/users/{id}", function ($req, $res) {});
+`,
+    );
+    const profile = loadRestProfile("slim")!;
+    const eps = detectRestEndpoints(tmpPath, [profile]);
+    const tuples = eps.map((e) => `${e.method} ${e.path}`);
+    expect(tuples).toContain("GET /api/users");
+    expect(tuples).toContain("POST /api/users");
+    expect(tuples).toContain("PUT /api/users/{id}");
+    expect(tuples).toContain("DELETE /api/users/{id}");
+    const get = eps.find((e) => e.method === "GET")!;
+    expect(get.line).toBe(6);
+  });
+});
+
+describe("Phoenix profile", () => {
+  let tmpPath: string;
+  beforeEach(() => { tmpPath = makeTmpPath("atlas-inv-phoenix-"); });
+  afterEach(() => { cleanupTmpPath(tmpPath); });
+
+  it("loads cleanly from disk", () => {
+    const p = loadRestProfile("phoenix");
+    expect(p).not.toBeNull();
+    expect(p?.language).toBe("elixir");
+  });
+
+  it("extracts router-block verb declarations", () => {
+    fs.writeFileSync(
+      path.join(tmpPath, "router.ex"),
+      `defmodule MyAppWeb.Router do
+  use Phoenix.Router
+
+  scope "/api", MyAppWeb do
+    get "/users", UserController, :index
+    post "/users", UserController, :create
+    put "/users/:id", UserController, :update
+    delete "/users/:id", UserController, :delete
+  end
+end
+`,
+    );
+    const profile = loadRestProfile("phoenix")!;
+    const eps = detectRestEndpoints(tmpPath, [profile]);
+    const tuples = eps.map((e) => `${e.method} ${e.path}`);
+    expect(tuples).toContain("GET /users");
+    expect(tuples).toContain("POST /users");
+    expect(tuples).toContain("PUT /users/:id");
+    expect(tuples).toContain("DELETE /users/:id");
+  });
+
+  it("skips Elixir files without a Phoenix.Router marker", () => {
+    fs.writeFileSync(
+      path.join(tmpPath, "x.ex"),
+      `get "/internal", Handler, :run\n`,
+    );
+    const profile = loadRestProfile("phoenix")!;
+    expect(detectRestEndpoints(tmpPath, [profile])).toEqual([]);
+  });
+});
+
+describe("Vapor profile", () => {
+  let tmpPath: string;
+  beforeEach(() => { tmpPath = makeTmpPath("atlas-inv-vapor-"); });
+  afterEach(() => { cleanupTmpPath(tmpPath); });
+
+  it("loads cleanly from disk", () => {
+    const p = loadRestProfile("vapor");
+    expect(p).not.toBeNull();
+    expect(p?.language).toBe("swift");
+  });
+
+  it("extracts app.* / routes.* / grouped.* verb routes", () => {
+    fs.writeFileSync(
+      path.join(tmpPath, "routes.swift"),
+      `import Vapor
+
+func routes(_ app: Application) throws {
+    app.get("users") { req in [] }
+    app.post("users") { req in "" }
+    routes.put("users/:id") { req in "" }
+    let grouped = app.grouped("v2")
+    grouped.delete("users/:id") { req in "" }
+}
+`,
+    );
+    const profile = loadRestProfile("vapor")!;
+    const eps = detectRestEndpoints(tmpPath, [profile]);
+    const tuples = eps.map((e) => `${e.method} ${e.path}`);
+    expect(tuples).toContain("GET users");
+    expect(tuples).toContain("POST users");
+    expect(tuples).toContain("PUT users/:id");
+    expect(tuples).toContain("DELETE users/:id");
+  });
+
+  it("skips Swift files without a Vapor marker", () => {
+    fs.writeFileSync(
+      path.join(tmpPath, "x.swift"),
+      `app.get("internal") { req in [] }\n`,
+    );
+    const profile = loadRestProfile("vapor")!;
+    expect(detectRestEndpoints(tmpPath, [profile])).toEqual([]);
+  });
+});
+
 // ── resolveRestProfiles ─────────────────────────────────────────────
 
 describe("resolveRestProfiles", () => {
@@ -689,20 +1034,28 @@ describe("resolveRestProfiles", () => {
     cleanupTmpPath(tmpPath);
   });
 
-  it("returns all ten shipped profiles when no name list is given", () => {
+  it("returns all eighteen shipped profiles when no name list is given", () => {
     const out = resolveRestProfiles({});
     const names = out.map((p) => p.name).sort();
     expect(names).toEqual([
+      "actix",
       "aspnet",
       "django",
+      "echo",
       "express",
       "fastapi",
+      "fastify",
       "flask",
       "gin",
       "hono",
+      "koa",
       "laravel",
+      "phoenix",
       "rails",
+      "rocket",
+      "slim",
       "spring",
+      "vapor",
     ]);
   });
 
@@ -776,16 +1129,24 @@ ecosystem:
     fs.writeFileSync(configPath, `wiki:\n  name: x\n`);
     const out = resolveRestProfiles({ wikiConfigPath: configPath });
     expect(out.map((p) => p.name).sort()).toEqual([
+      "actix",
       "aspnet",
       "django",
+      "echo",
       "express",
       "fastapi",
+      "fastify",
       "flask",
       "gin",
       "hono",
+      "koa",
       "laravel",
+      "phoenix",
       "rails",
+      "rocket",
+      "slim",
       "spring",
+      "vapor",
     ]);
   });
 


### PR DESCRIPTION
Closes the **"More frameworks (additive YAMLs)"** item from `ROADMAP.md`'s
*"Atlas — REST profile coverage"* section. Brings the shipped REST-profile
count from **10 → 18**.

## Summary

| Profile | Lang | Marker (substring) | Pattern shape |
|---|---|---|---|
| `fastify` | typescript | `from "fastify"`, `Fastify(` | `(?:fastify\|app\|server)\.(verb)\(['"`+"`"+`]path` |
| `koa` | typescript | `from "@koa/router"`, `new Router(` | `(?:router\|api\|app)\.(verb)\(['"`+"`"+`]path` |
| `echo` | go | `github.com/labstack/echo`, `echo.New(` | `(?:e\|router\|g\|api\|server)\.(VERB)\("path` |
| `rocket` | rust | `use rocket`, `extern crate rocket` | `#\[(verb)\("path` |
| `actix` | rust | `use actix_web`, `actix_web::` | `\.route\("path", web::(verb)` (groups reversed) |
| `slim` | php | `use Slim\App`, `Slim\Factory\AppFactory` | `\$app->(verb)\(['"]path` |
| `phoenix` | elixir | `use Phoenix.Router` | `(?:^\|\s)(verb)\s+"path",` |
| `vapor` | swift | `import Vapor`, `app.routes`, `app.group(` | `(?:app\|routes\|grouped)\.(verb)\("path` |

All eight profiles dogfood-verified end-to-end: `loadRestProfile(name)`
+ `detectRestEndpoints(tmp, [profile])` produces 4/4 expected
`(method, path)` tuples on each fixture.

## Test plan

- [x] `npm run typecheck` — silent
- [x] `npm run build` — silent
- [x] `npm test` — **1092 passed**, 5 skipped (baseline 1071, +21 net new
      across the 8 per-profile describes; the three updated assertion
      tests already counted in baseline)
- [x] `git grep -in 'ideaprojects\|doc-update' -- ':!*.md' ':!.claude/'`
      — empty (privacy clean)
- [x] Per-profile dogfood: each fixture produces the expected route
      count (4/4) and the right line numbers

## Deferred per profile

Items intentionally NOT covered in this batch — recorded so we can
revisit them in a future profile pass:

- **Fastify** — `fastify.register(plugin)` callbacks where routes are
  declared on the inner `instance` rather than the outer `fastify` /
  `app` / `server` symbol.
- **Koa** — Custom router-variable names beyond `router` / `api` / `app`
  (some teams use `r` or `v1Router`).
- **Echo** — `e.Group("/api")` prefix concatenation; only the literal
  path argument is captured today, so a route declared as
  `g.GET("/users")` records as `/users` rather than `/api/users`.
- **Rocket** — Module-level mount prefixes (`rocket::build().mount("/api", routes![...])`)
  are not unwound; declared paths are recorded as-is.
- **Actix** — The attribute-macro form (`#[get("/path")]` on a handler +
  `cfg.service(...)`) is intentionally deferred to avoid shadowing
  Rocket's profile on shared `*.rs` files. Only the explicit
  `.route("/path", web::verb()...)` builder form is matched.
- **Slim** — Slim's group blocks (`$app->group('/api', fn ($g) => ...)`)
  are not unwound; nested routes record their literal path argument.
- **Phoenix** — `pipe_through` blocks and `scope "/api", ...` prefix
  blocks are not unwound; declared paths are recorded as-is.
- **Vapor** — Multi-`PathComponent` calls (`app.get("api", "users")`)
  capture only the FIRST string argument; route groups
  (`app.grouped("api").get("users", ...)`) and route-collection helpers
  (`app.routes.add(...)`) are deferred.

## Commit

`feat(atlas): eight more REST profiles — Fastify / Koa / Echo / Rocket / Actix / Slim / Phoenix / Vapor`