### PR TITLE
docs(roadmap): split into pre-main-release vs v2; promote PR #17 to shipped

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -112,7 +112,7 @@ straight-line profiles, expand router patterns post-launch.
 
 Original framing from PR #14: doc-wiki should learn with the code, not
 just match shipped profiles. With 18 profiles shipped (10 from PRs
-#14+#15, 8 from PR #16), the major frameworks are covered; the
+#14+#15, 8 from PR #17), the major frameworks are covered; the
 learning loop is a substantial new feature, not a main-release blocker.
 
 - **Heuristic regex fallback** — catch HTTP-route-shaped patterns
@@ -181,7 +181,7 @@ These have come up but aren't recommended without more design.
 | #13 | refactor(atlas): consolidate deploy + configuration walkers | 2026-05-01 |
 | #14 | feat(atlas): REST profile expansion + custom profiles | 2026-05-02 |
 | #15 | feat(atlas): six new REST profiles (Django / Flask / ASP.NET / Gin / Laravel / Hono) | 2026-05-02 |
-| #16 | feat(atlas): eight more REST profiles (Fastify / Koa / Echo / Rocket / Actix / Slim / Phoenix / Vapor) | 2026-05-02 |
+| #17 | feat(atlas): eight more REST profiles (Fastify / Koa / Echo / Rocket / Actix / Slim / Phoenix / Vapor) | 2026-05-02 |
 
 These six PRs took atlas from a five-facet code-shaped pipeline to an
 audience-aware, manifest-driven, eighteen-REST-profile pipeline with

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,8 +1,17 @@
 # Roadmap
 
 doc-wiki's deferred work tracker. Each entry is one well-scoped PR or task.
-Categories are loose; within each, items are roughly priority-ordered (top
-= most leverage).
+Items are grouped by milestone (**Before main release** vs **v2**); within
+each sub-section, items are roughly priority-ordered (top = most leverage).
+
+**Milestones:**
+
+- **Before main release** — must land before doc-wiki is "tested and
+  ready to start making content about it." Bar: stable enough to
+  dogfood publicly, demos won't embarrass us, end-to-end runs on real
+  repos without surprises.
+- **v2 (post-main-release)** — additive features, optimizations,
+  speculative items. Not blocking.
 
 **Status legend:**
 
@@ -17,14 +26,40 @@ design round before prioritization.
 
 ---
 
-## Atlas — manifest consumers
+## Before main release
 
-The Phase 1b code-inventory manifest landed in PR #12. More atlas phases
-and adjacent commands could read it instead of re-walking the repo.
+### Atlas — pipeline validation
 
-- **Phase 4 cost-estimate consumes manifest** — skip cache lookups for
-  files already in the manifest. Performance win, no behavior change.
-  _proposed_
+- **Real `/doc-wiki:atlas` dogfood** — full pipeline (Phase 6 included),
+  not partial globals. Costs ~$3-10 of LLM time. Only way to validate
+  the audience-aware + manifest-driven changes hold up end-to-end. _proposed_
+- **`ecosystem.rest.enabled` orchestrator wiring** — atlas skill reads
+  the flag and passes `--enable-rest` accordingly. Closes a loose end
+  from PR #14 (currently the orchestrator-prompt has to know to read
+  this flag). _proposed_
+
+### Atlas — REST profile correctness
+
+Bug fixes on already-shipped profiles. Each affects real-world code
+in ways that would show up in any honest demo.
+
+- **Flask default-GET case** — `@app.route('/x')` without `methods=`
+  defaults to GET. Needs a profile-shape extension to support a
+  hardcoded fallback method when no method group captures. ~10 LOC. _proposed_
+- **ASP.NET controller-level `[Route("...")]` prefix concatenation** —
+  currently each `[HttpGet("/x")]` is taken as the full path; should
+  prepend the class-level `[Route(...)]` prefix. _proposed_
+- **Hono `.use()` middleware vs `.get()` route disambiguation** —
+  current regex catches both; should distinguish (middleware ≠ route). _proposed_
+
+### Atlas — manifest consumers (quality)
+
+The Phase 1b code-inventory manifest landed in PR #12. These two
+consumers improve *output quality* — Phase 6 surfaces ORM entities the
+current heuristics miss; lint catches broken code-locality refs early.
+(The two perf-only consumers — Phase 4, query scoping — are deferred
+to v2.)
+
 - **Phase 6 source-heuristic replacement** — `data-model` facet sources
   from `manifest.orm_entities`; `api` from `manifest.rest_endpoints`.
   Replaces glob heuristics with deterministic lookups; surfaces ORM
@@ -32,14 +67,53 @@ and adjacent commands could read it instead of re-walking the repo.
 - **`/doc-wiki:lint` references-frontmatter validation** — flag pages
   whose `references:` points to source files the inventory has never
   seen. Catches broken code-locality refs early. _proposed_
+
+### Documentation
+
+- **`docs/atlas.md`** — full Phase 1-8 walkthrough including the
+  Phase 1b inventory step. The atlas command is the tentpole; deserves
+  its own doc beyond the existing `docs/architecture.md` Diagram 4. _proposed_
+- **`docs/configuration.md` `ecosystem.rest` section** — deferred from
+  PR #14. Describe the block (enabled flag, custom_profiles slot,
+  example custom YAML). _proposed_
+- **Custom REST profile authoring guide** — example YAMLs + how to
+  test. Probably belongs as a new file under `docs/` or a section in
+  `docs/architecture.md`. _proposed_
+
+---
+
+## v2 (post-main-release)
+
+### Atlas — manifest consumers (perf)
+
+Performance / precision wins on top of the Phase 1b manifest. No
+behavior change visible in output; defer until after main release.
+
+- **Phase 4 cost-estimate consumes manifest** — skip cache lookups for
+  files already in the manifest. Performance win, no behavior change.
+  _proposed_
 - **`/doc-wiki:query` manifest scoping** — when the question is about
   an API surface, scope link-following to known endpoints. Reduces
   synthesis cost; improves precision. _proposed_
 
-## Atlas — heuristic discovery / "learning"
+### Atlas — REST profile router/DSL expansions
+
+Common in real Django/Rails apps but each needs a route-tree / DSL
+expansion walker. Substantial work; ship main release with the
+straight-line profiles, expand router patterns post-launch.
+
+- **Django DRF ViewSet routers** — `router.register(r'users', UserViewSet)`
+  expands to multiple endpoints via the DRF router. Needs a route-tree
+  walker. _proposed_
+- **Rails `resources :foo` blocks** — DSL expansion (`resources :users`
+  → 7 RESTful routes). _proposed_
+
+### Atlas — heuristic discovery / "learning loop"
 
 Original framing from PR #14: doc-wiki should learn with the code, not
-just match shipped profiles.
+just match shipped profiles. With 18 profiles shipped (10 from PRs
+#14+#15, 8 from PR #16), the major frameworks are covered; the
+learning loop is a substantial new feature, not a main-release blocker.
 
 - **Heuristic regex fallback** — catch HTTP-route-shaped patterns
   (`(?:get|post|put|delete)\s*\(\s*['"\`][/]`) even when no profile
@@ -56,43 +130,10 @@ just match shipped profiles.
   `RestProfile` YAML the user can refine. Closes the loop on
   customization. _proposed_
 
-## Atlas — REST profile coverage
-
-Ten profiles ship today (PRs #14 + #15). Long tail remaining.
-
-### More frameworks (additive YAMLs)
-
-| Profile | Language | Notes |
-|---|---|---|
-| Fastify | TypeScript | Common Express alternative |
-| Koa | TypeScript | Older but still used |
-| Echo | Go | Alternative to Gin |
-| Rocket | Rust | Macro-driven attribute style |
-| Actix | Rust | `App::new().route(...)` style |
-| Slim | PHP | Micro alternative to Laravel |
-| Phoenix | Elixir | Channels + REST routes |
-| Vapor | Swift | iOS/server-side ecosystem |
-
-### Existing-profile shape enhancements
-
-- **Flask default-GET case** — `@app.route('/x')` without `methods=`
-  defaults to GET. Needs a profile-shape extension to support a
-  hardcoded fallback method when no method group captures. ~10 LOC. _proposed_
-- **Django DRF ViewSet routers** — `router.register(r'users', UserViewSet)`
-  expands to multiple endpoints via the DRF router. Needs a route-tree
-  walker. _proposed_
-- **Rails `resources :foo` blocks** — DSL expansion (`resources :users`
-  → 7 RESTful routes). _proposed_
-- **ASP.NET controller-level `[Route("...")]` prefix concatenation** —
-  currently each `[HttpGet("/x")]` is taken as the full path; should
-  prepend the class-level `[Route(...)]` prefix. _proposed_
-- **Hono `.use()` middleware vs `.get()` route disambiguation** —
-  current regex catches both; should distinguish (middleware ≠ route). _proposed_
-
-## Atlas — other detection bucket types
+### Atlas — other detection bucket types
 
 Beyond REST endpoints + code clients, more structural code can be
-inventoried.
+inventoried. All purely additive — nothing blocks main release.
 
 - **GraphQL schema introspection** — `*.graphql`, code-first SDL
   (`gql`-tagged template literals) → type+field inventory. _proposed_
@@ -104,29 +145,7 @@ inventoried.
 - **CLI command inventory** — argparse / click / yargs / clap / cobra
   command trees. _proposed_
 
-## Atlas — pipeline validation
-
-- **Real `/doc-wiki:atlas` dogfood** — full pipeline (Phase 6 included),
-  not partial globals. Costs ~$3-10 of LLM time. Only way to validate
-  the audience-aware + manifest-driven changes hold up end-to-end. _proposed_
-- **`ecosystem.rest.enabled` orchestrator wiring** — atlas skill reads
-  the flag and passes `--enable-rest` accordingly. Closes a loose end
-  from PR #14 (currently the orchestrator-prompt has to know to read
-  this flag). _proposed_
-
-## Documentation
-
-- **`docs/configuration.md` `ecosystem.rest` section** — deferred from
-  PR #14. Describe the block (enabled flag, custom_profiles slot,
-  example custom YAML). _proposed_
-- **Custom REST profile authoring guide** — example YAMLs + how to
-  test. Probably belongs as a new file under `docs/` or a section in
-  `docs/architecture.md`. _proposed_
-- **`docs/atlas.md`** — full Phase 1-8 walkthrough including the
-  Phase 1b inventory step. The atlas command is the tentpole; deserves
-  its own doc beyond the existing `docs/architecture.md` Diagram 4. _proposed_
-
-## Speculative (lower confidence)
+### Speculative (lower confidence)
 
 These have come up but aren't recommended without more design.
 
@@ -162,8 +181,9 @@ These have come up but aren't recommended without more design.
 | #13 | refactor(atlas): consolidate deploy + configuration walkers | 2026-05-01 |
 | #14 | feat(atlas): REST profile expansion + custom profiles | 2026-05-02 |
 | #15 | feat(atlas): six new REST profiles (Django / Flask / ASP.NET / Gin / Laravel / Hono) | 2026-05-02 |
+| #16 | feat(atlas): eight more REST profiles (Fastify / Koa / Echo / Rocket / Actix / Slim / Phoenix / Vapor) | 2026-05-02 |
 
-These five PRs took atlas from a five-facet code-shaped pipeline to an
-audience-aware, manifest-driven, ten-REST-profile pipeline with custom
-profile loading. The roadmap above tracks what was deliberately
+These six PRs took atlas from a five-facet code-shaped pipeline to an
+audience-aware, manifest-driven, eighteen-REST-profile pipeline with
+custom profile loading. The roadmap above tracks what was deliberately
 deferred during that series.


### PR DESCRIPTION
## Summary

- Reorganize `ROADMAP.md` into two top-level milestones — **Before main release** and **v2 (post-main-release)** — so blockers vs parking-lot are visible at a glance.
- Move the eight REST profiles from PR #17 (Fastify / Koa / Echo / Rocket / Actix / Slim / Phoenix / Vapor) out of the proposed list into "Recently shipped".
- Within each milestone, items are sub-grouped by topic and roughly priority-ordered.

The "main release" bar (per the user's definition) is *"tested and ready to start making content about it"* — not full 1.0 OSS feature-completeness. So 1.0-bound items are the ones whose absence would either kill demos (REST profile correctness, pipeline validation) or stop content writers from linking somewhere canonical (docs).

## Final structure

**Before main release** (10 items)
- Atlas — pipeline validation (2)
- Atlas — REST profile correctness (3) — Flask GET, ASP.NET prefix, Hono middleware
- Atlas — manifest consumers (quality) (2) — Phase 6 source-heuristic, lint refs
- Documentation (3) — `docs/atlas.md`, `ecosystem.rest` config section, custom-profile guide

**v2 (post-main-release)** (20 items)
- Atlas — manifest consumers (perf) (2) — Phase 4, query scoping
- Atlas — REST profile router/DSL expansions (2) — DRF ViewSet, Rails `resources`
- Atlas — heuristic discovery / "learning loop" (4)
- Atlas — other detection bucket types (5) — GraphQL, gRPC, MQ, WebSocket, CLI
- Speculative (7)

Item count check: original 38 (= 30 bullets + 8 framework table) − 8 shipped in PR #17 = **30** in body. ✓

## Test plan

- [ ] Markdown renders cleanly on GitHub (headings parse, no broken refs)
- [ ] Every item from the original `ROADMAP.md` appears exactly once in the new structure (verified locally with grep — each unique phrase matches `count == 1`)
- [ ] PR #17 row present in shipped table; the 8-row "More frameworks" sub-section is removed from the body