### PR TITLE
feat(atlas): REST profile correctness fixes — Flask default-GET, ASP.NET prefix concat, Hono .use() defense

### DIFF
--- a/agents/lib/atlas_inventory.js
+++ b/agents/lib/atlas_inventory.js
@@ -392,7 +392,9 @@ export function detectRestEndpoints(repoRoot, profiles) {
                     re.lastIndex = 0;
                     let m;
                     while ((m = re.exec(line)) !== null) {
-                        const method = (m[ext.method_group] ?? "").toUpperCase();
+                        const method = ext.method_group > 0
+                            ? (m[ext.method_group] ?? "").toUpperCase()
+                            : (ext.default_method ?? "").toUpperCase();
                         const apiPath = m[ext.path_group] ?? "";
                         if (method.length > 0 && apiPath.length > 0) {
                             const key = `${relFile}|${lineIdx + 1}|${method}|${apiPath}`;

--- a/agents/lib/atlas_inventory.js
+++ b/agents/lib/atlas_inventory.js
@@ -377,6 +377,9 @@ export function detectRestEndpoints(repoRoot, profiles) {
                 !markerPatterns.some((m) => content.includes(m))) {
                 continue;
             }
+            // Optional per-file prefix (e.g. ASP.NET `[Route("api/users")]`
+            // above the controller class). Captured once per file.
+            const filePrefix = _extractFilePrefix(content, profile.endpoint_extraction.file_prefix);
             const lines = content.split("\n");
             const relFile = _toRepoRelative(repoRoot, absFile);
             for (const ext of profile.endpoint_extraction.patterns) {
@@ -395,7 +398,8 @@ export function detectRestEndpoints(repoRoot, profiles) {
                         const method = ext.method_group > 0
                             ? (m[ext.method_group] ?? "").toUpperCase()
                             : (ext.default_method ?? "").toUpperCase();
-                        const apiPath = m[ext.path_group] ?? "";
+                        const rawPath = m[ext.path_group] ?? "";
+                        const apiPath = _resolvePath(rawPath, filePrefix);
                         if (method.length > 0 && apiPath.length > 0) {
                             const key = `${relFile}|${lineIdx + 1}|${method}|${apiPath}`;
                             if (!seen.has(key)) {
@@ -560,6 +564,50 @@ function _toRepoRelative(repoRoot, absPath) {
         return "";
     const rel = path.relative(repoRoot, absPath);
     return rel.split(path.sep).join("/");
+}
+/**
+ * Run a profile's `file_prefix` regex against the full file content and
+ * return the captured prefix string, or `undefined` if the file declares
+ * no class-level prefix. When the captured prefix contains the
+ * `[controller]` token and the profile asks for it, expand it to the
+ * controller class name (lowercased, `Controller` suffix stripped).
+ */
+function _extractFilePrefix(content, spec) {
+    if (!spec)
+        return undefined;
+    let re;
+    try {
+        re = new RegExp(spec.regex);
+    }
+    catch {
+        return undefined;
+    }
+    const m = re.exec(content);
+    if (!m)
+        return undefined;
+    let prefix = m[spec.prefix_group] ?? "";
+    if (spec.expand_controller_token && prefix.includes("[controller]")) {
+        const classMatch = content.match(/\bpublic\s+(?:abstract\s+|sealed\s+|partial\s+|static\s+)*class\s+(\w+?)Controller\b/);
+        if (classMatch?.[1]) {
+            prefix = prefix.replace(/\[controller\]/g, classMatch[1].toLowerCase());
+        }
+    }
+    return prefix.length > 0 ? prefix : undefined;
+}
+/**
+ * Combine a per-line captured path with the file's class-level prefix.
+ * Absolute paths (starting with `/`) bypass the prefix entirely. When
+ * the regex captured an empty path (e.g. ASP.NET's `[HttpGet]` with no
+ * argument) and a prefix exists, the prefix becomes the full route path.
+ */
+function _resolvePath(rawPath, filePrefix) {
+    if (rawPath.startsWith("/"))
+        return rawPath;
+    if (!filePrefix)
+        return rawPath;
+    if (rawPath.length === 0)
+        return filePrefix;
+    return `${filePrefix.replace(/\/+$/, "")}/${rawPath.replace(/^\/+/, "")}`;
 }
 // ── CLI ────────────────────────────────────────────────────────────
 const FLAG_SPEC = {

--- a/agents/lib/atlas_inventory.ts
+++ b/agents/lib/atlas_inventory.ts
@@ -298,8 +298,13 @@ export interface RestProfile {
   endpoint_extraction: {
     patterns: Array<{
       regex: string;
+      /** 1-indexed offset of the method capture group. `0` = no method
+       *  captured; in that case `default_method` MUST be set. */
       method_group: number;
       path_group: number;
+      /** Hardcoded HTTP verb for path-only patterns (e.g. Flask's
+       *  `@app.route('/x')` defaults to GET). Used when `method_group` is 0. */
+      default_method?: string;
     }>;
   };
 }
@@ -518,7 +523,10 @@ export function detectRestEndpoints(
           re.lastIndex = 0;
           let m: RegExpExecArray | null;
           while ((m = re.exec(line)) !== null) {
-            const method = (m[ext.method_group] ?? "").toUpperCase();
+            const method =
+              ext.method_group > 0
+                ? (m[ext.method_group] ?? "").toUpperCase()
+                : (ext.default_method ?? "").toUpperCase();
             const apiPath = m[ext.path_group] ?? "";
             if (method.length > 0 && apiPath.length > 0) {
               const key = `${relFile}|${lineIdx + 1}|${method}|${apiPath}`;

--- a/agents/lib/atlas_inventory.ts
+++ b/agents/lib/atlas_inventory.ts
@@ -296,6 +296,19 @@ export interface RestProfile {
     markers: Array<{ pattern: string; type?: string }>;
   };
   endpoint_extraction: {
+    /** Optional per-file prefix extracted from a class-level annotation
+     *  (e.g. ASP.NET's `[Route("api/users")]` above the controller class).
+     *  When set, the prefix is prepended to each relative path captured
+     *  by the per-line `patterns` regexes. Paths that start with `/` are
+     *  treated as absolute and bypass the prefix. */
+    file_prefix?: {
+      regex: string;
+      prefix_group: number;
+      /** When the captured prefix contains `[controller]`, replace it
+       *  with the controller class name (lowercased, `Controller`
+       *  suffix stripped). Used by ASP.NET's `[Route("api/[controller]")]`. */
+      expand_controller_token?: boolean;
+    };
     patterns: Array<{
       regex: string;
       /** 1-indexed offset of the method capture group. `0` = no method
@@ -509,6 +522,10 @@ export function detectRestEndpoints(
         continue;
       }
 
+      // Optional per-file prefix (e.g. ASP.NET `[Route("api/users")]`
+      // above the controller class). Captured once per file.
+      const filePrefix = _extractFilePrefix(content, profile.endpoint_extraction.file_prefix);
+
       const lines = content.split("\n");
       const relFile = _toRepoRelative(repoRoot, absFile);
       for (const ext of profile.endpoint_extraction.patterns) {
@@ -527,7 +544,8 @@ export function detectRestEndpoints(
               ext.method_group > 0
                 ? (m[ext.method_group] ?? "").toUpperCase()
                 : (ext.default_method ?? "").toUpperCase();
-            const apiPath = m[ext.path_group] ?? "";
+            const rawPath = m[ext.path_group] ?? "";
+            const apiPath = _resolvePath(rawPath, filePrefix);
             if (method.length > 0 && apiPath.length > 0) {
               const key = `${relFile}|${lineIdx + 1}|${method}|${apiPath}`;
               if (!seen.has(key)) {
@@ -734,6 +752,51 @@ function _toRepoRelative(repoRoot: string, absPath: string): string {
   if (absPath.length === 0) return "";
   const rel = path.relative(repoRoot, absPath);
   return rel.split(path.sep).join("/");
+}
+
+/**
+ * Run a profile's `file_prefix` regex against the full file content and
+ * return the captured prefix string, or `undefined` if the file declares
+ * no class-level prefix. When the captured prefix contains the
+ * `[controller]` token and the profile asks for it, expand it to the
+ * controller class name (lowercased, `Controller` suffix stripped).
+ */
+function _extractFilePrefix(
+  content: string,
+  spec: RestProfile["endpoint_extraction"]["file_prefix"],
+): string | undefined {
+  if (!spec) return undefined;
+  let re: RegExp;
+  try {
+    re = new RegExp(spec.regex);
+  } catch {
+    return undefined;
+  }
+  const m = re.exec(content);
+  if (!m) return undefined;
+  let prefix = m[spec.prefix_group] ?? "";
+  if (spec.expand_controller_token && prefix.includes("[controller]")) {
+    const classMatch = content.match(
+      /\bpublic\s+(?:abstract\s+|sealed\s+|partial\s+|static\s+)*class\s+(\w+?)Controller\b/,
+    );
+    if (classMatch?.[1]) {
+      prefix = prefix.replace(/\[controller\]/g, classMatch[1].toLowerCase());
+    }
+  }
+  return prefix.length > 0 ? prefix : undefined;
+}
+
+/**
+ * Combine a per-line captured path with the file's class-level prefix.
+ * Absolute paths (starting with `/`) bypass the prefix entirely. When
+ * the regex captured an empty path (e.g. ASP.NET's `[HttpGet]` with no
+ * argument) and a prefix exists, the prefix becomes the full route path.
+ */
+function _resolvePath(rawPath: string, filePrefix: string | undefined): string {
+  if (rawPath.startsWith("/")) return rawPath;
+  if (!filePrefix) return rawPath;
+  if (rawPath.length === 0) return filePrefix;
+  return `${filePrefix.replace(/\/+$/, "")}/${rawPath.replace(/^\/+/, "")}`;
 }
 
 // ── CLI ────────────────────────────────────────────────────────────

--- a/agents/lib/rest_profiles/aspnet.yaml
+++ b/agents/lib/rest_profiles/aspnet.yaml
@@ -1,6 +1,6 @@
 name: aspnet
 language: csharp
-description: "ASP.NET Core MVC + Web API attribute-routed controllers"
+description: "ASP.NET Core MVC + Web API attribute-routed controllers (with class-level [Route] prefix concat)"
 
 detection:
   file_patterns:
@@ -15,13 +15,18 @@ detection:
     - pattern: ": Controller"
       type: base_class
 
-# `[HttpGet("/api/users")]`, `[HttpPost("/api/users")]`, etc. The
-# `Http<Verb>` capture group is normalized to the verb; the path is the
-# first quoted string argument. Routes declared via `[Route("...")]`
-# at the controller level are intentionally NOT extracted here — the
-# inventory cares about ENDPOINT routes, not controller prefixes.
+# `[HttpGet("/api/users")]`, `[HttpPost("/api/users")]`, etc. The path
+# argument is optional — `[HttpGet]` alone is valid and inherits the
+# class-level `[Route(...)]` prefix as its full path. Verb attributes
+# whose path starts with `/` are absolute and bypass the prefix; the
+# `[controller]` token in `[Route("api/[controller]")]` expands to the
+# controller class name (lowercased, `Controller` suffix stripped).
 endpoint_extraction:
+  file_prefix:
+    regex: "\\[Route\\s*\\(\\s*[\"']([^\"']+)[\"']\\s*\\)\\s*\\]"
+    prefix_group: 1
+    expand_controller_token: true
   patterns:
-    - regex: "\\[Http(Get|Post|Put|Delete|Patch|Options|Head)\\s*\\(\\s*[\"']([^\"']+)[\"']"
+    - regex: "\\[Http(Get|Post|Put|Delete|Patch|Options|Head)(?:\\s*\\(\\s*[\"']([^\"']+)[\"']\\s*\\))?\\s*\\]"
       method_group: 1
       path_group: 2

--- a/agents/lib/rest_profiles/flask.yaml
+++ b/agents/lib/rest_profiles/flask.yaml
@@ -1,6 +1,6 @@
 name: flask
 language: python
-description: "Flask routes (explicit methods= keyword form; default-GET form deferred)"
+description: "Flask routes (explicit methods=, @app.<verb> shorthand, and bare @app.route default-GET)"
 
 detection:
   file_patterns:
@@ -13,11 +13,10 @@ detection:
     - pattern: "Flask(__name__)"
       type: instantiation
 
-# `@app.route('/path', methods=['GET'])` — only catches the explicit
-# methods= form. The default-GET case (`@app.route('/x')`) needs a
-# profile-shape extension to support a hardcoded fallback method;
-# tracked as a future enhancement. Capture order is path then method
-# because that's how Flask writes them.
+# Three patterns, in priority order. The bare-route pattern is anchored
+# with `\)` after the path so it does not match the explicit-methods=
+# form. Capture order is path then method because that's how Flask
+# writes them.
 endpoint_extraction:
   patterns:
     - regex: "@(?:app|bp|blueprint)\\.route\\s*\\(\\s*['\"]([^'\"]+)['\"]\\s*,\\s*methods\\s*=\\s*\\[\\s*['\"](GET|POST|PUT|DELETE|PATCH|OPTIONS|HEAD)['\"]"
@@ -27,3 +26,9 @@ endpoint_extraction:
     - regex: "@(?:app|bp|blueprint)\\.(get|post|put|delete|patch|options|head)\\s*\\(\\s*['\"]([^'\"]+)['\"]"
       method_group: 1
       path_group: 2
+    # @app.route("/x") — bare form, defaults to GET. The `\)` anchor
+    # keeps this from double-matching lines that also have methods=.
+    - regex: "@(?:app|bp|blueprint)\\.route\\s*\\(\\s*['\"]([^'\"]+)['\"]\\s*\\)"
+      method_group: 0
+      path_group: 1
+      default_method: GET

--- a/agents/lib/tests/atlas_inventory.test.ts
+++ b/agents/lib/tests/atlas_inventory.test.ts
@@ -355,7 +355,7 @@ describe("Flask profile", () => {
     expect(p?.language).toBe("python");
   });
 
-  it("extracts @app.route(methods=) and @app.<verb> shorthand", () => {
+  it("extracts @app.route(methods=), @app.<verb> shorthand, and bare @app.route default-GET", () => {
     fs.writeFileSync(
       path.join(tmpPath, "app.py"),
       `from flask import Flask
@@ -372,6 +372,12 @@ def show(user_id): pass
 
 @app.delete('/api/users/<int:user_id>')
 def remove(user_id): pass
+
+@app.route("/api/health")
+def health(): pass
+
+@app.route('/api/version')
+def version(): pass
 `,
     );
     const profile = loadRestProfile("flask")!;
@@ -381,6 +387,25 @@ def remove(user_id): pass
     expect(tuples).toContain("POST /api/users");
     expect(tuples).toContain("GET /api/users/<int:user_id>");
     expect(tuples).toContain("DELETE /api/users/<int:user_id>");
+    expect(tuples).toContain("GET /api/health");
+    expect(tuples).toContain("GET /api/version");
+  });
+
+  it("does not double-count the explicit-methods= form via the bare-route pattern", () => {
+    fs.writeFileSync(
+      path.join(tmpPath, "app.py"),
+      `from flask import Flask
+app = Flask(__name__)
+
+@app.route("/api/users", methods=["POST"])
+def create_user(): pass
+`,
+    );
+    const profile = loadRestProfile("flask")!;
+    const eps = detectRestEndpoints(tmpPath, [profile]);
+    expect(eps).toHaveLength(1);
+    expect(eps[0]?.method).toBe("POST");
+    expect(eps[0]?.path).toBe("/api/users");
   });
 });
 

--- a/agents/lib/tests/atlas_inventory.test.ts
+++ b/agents/lib/tests/atlas_inventory.test.ts
@@ -565,6 +565,26 @@ app.get('/x', () => {});
     const profile = loadRestProfile("hono")!;
     expect(detectRestEndpoints(tmpPath, [profile])).toEqual([]);
   });
+
+  it("does NOT extract .use() middleware as a route", () => {
+    fs.writeFileSync(
+      path.join(tmpPath, "app.ts"),
+      `import { Hono } from "hono";
+import { logger } from "hono/logger";
+
+const app = new Hono();
+
+app.use('/api/*', logger());
+app.use('*', async (c, next) => { await next(); });
+app.get('/api/users', (c) => c.json([]));
+app.post('/api/users', (c) => c.json({}, 201));
+`,
+    );
+    const profile = loadRestProfile("hono")!;
+    const eps = detectRestEndpoints(tmpPath, [profile]);
+    const tuples = eps.map((e) => `${e.method} ${e.path}`);
+    expect(tuples).toEqual(["GET /api/users", "POST /api/users"]);
+  });
 });
 
 describe("FastAPI profile", () => {

--- a/agents/lib/tests/atlas_inventory.test.ts
+++ b/agents/lib/tests/atlas_inventory.test.ts
@@ -420,7 +420,7 @@ describe("ASP.NET profile", () => {
     expect(p?.language).toBe("csharp");
   });
 
-  it("extracts [HttpVerb] attribute routes", () => {
+  it("extracts [HttpVerb] attribute routes (absolute paths)", () => {
     fs.mkdirSync(path.join(tmpPath, "Controllers"), { recursive: true });
     fs.writeFileSync(
       path.join(tmpPath, "Controllers", "UsersController.cs"),
@@ -447,6 +447,109 @@ public class UsersController : ControllerBase
     expect(tuples).toContain("GET /api/users");
     expect(tuples).toContain("POST /api/users");
     expect(tuples).toContain("DELETE /api/users/{id:int}");
+  });
+
+  it("prepends class-level [Route(...)] prefix to relative paths", () => {
+    fs.mkdirSync(path.join(tmpPath, "Controllers"), { recursive: true });
+    fs.writeFileSync(
+      path.join(tmpPath, "Controllers", "OrdersController.cs"),
+      `using Microsoft.AspNetCore.Mvc;
+
+[ApiController]
+[Route("api/orders")]
+public class OrdersController : ControllerBase
+{
+    [HttpGet]
+    public IActionResult List() => Ok();
+
+    [HttpGet("{id:int}")]
+    public IActionResult Get(int id) => Ok();
+
+    [HttpPost]
+    public IActionResult Create() => Created("/", null);
+
+    [HttpDelete("{id:int}")]
+    public IActionResult Delete(int id) => NoContent();
+}
+`,
+    );
+    const profile = loadRestProfile("aspnet")!;
+    const eps = detectRestEndpoints(tmpPath, [profile]);
+    const tuples = eps.map((e) => `${e.method} ${e.path}`);
+    expect(tuples).toContain("GET api/orders");
+    expect(tuples).toContain("GET api/orders/{id:int}");
+    expect(tuples).toContain("POST api/orders");
+    expect(tuples).toContain("DELETE api/orders/{id:int}");
+  });
+
+  it("expands the [controller] token in the class-level [Route]", () => {
+    fs.mkdirSync(path.join(tmpPath, "Controllers"), { recursive: true });
+    fs.writeFileSync(
+      path.join(tmpPath, "Controllers", "AuthController.cs"),
+      `using Microsoft.AspNetCore.Mvc;
+
+[ApiController]
+[Route("api/[controller]")]
+public class AuthController : ControllerBase
+{
+    [HttpPost("login")]
+    public IActionResult Login() => Ok();
+
+    [HttpPost("logout")]
+    public IActionResult Logout() => Ok();
+}
+`,
+    );
+    const profile = loadRestProfile("aspnet")!;
+    const eps = detectRestEndpoints(tmpPath, [profile]);
+    const tuples = eps.map((e) => `${e.method} ${e.path}`);
+    expect(tuples).toContain("POST api/auth/login");
+    expect(tuples).toContain("POST api/auth/logout");
+  });
+
+  it("absolute paths in [HttpVerb] bypass the class-level prefix", () => {
+    fs.mkdirSync(path.join(tmpPath, "Controllers"), { recursive: true });
+    fs.writeFileSync(
+      path.join(tmpPath, "Controllers", "MixedController.cs"),
+      `using Microsoft.AspNetCore.Mvc;
+
+[ApiController]
+[Route("api/mixed")]
+public class MixedController : ControllerBase
+{
+    [HttpGet]
+    public IActionResult List() => Ok();
+
+    [HttpGet("/healthz")]
+    public IActionResult Health() => Ok();
+}
+`,
+    );
+    const profile = loadRestProfile("aspnet")!;
+    const eps = detectRestEndpoints(tmpPath, [profile]);
+    const tuples = eps.map((e) => `${e.method} ${e.path}`);
+    expect(tuples).toContain("GET api/mixed");
+    expect(tuples).toContain("GET /healthz");
+  });
+
+  it("falls back to relative path when the class has no [Route]", () => {
+    fs.mkdirSync(path.join(tmpPath, "Controllers"), { recursive: true });
+    fs.writeFileSync(
+      path.join(tmpPath, "Controllers", "StatusController.cs"),
+      `using Microsoft.AspNetCore.Mvc;
+
+[ApiController]
+public class StatusController : ControllerBase
+{
+    [HttpGet("/healthz")]
+    public IActionResult Health() => Ok();
+}
+`,
+    );
+    const profile = loadRestProfile("aspnet")!;
+    const eps = detectRestEndpoints(tmpPath, [profile]);
+    const tuples = eps.map((e) => `${e.method} ${e.path}`);
+    expect(tuples).toEqual(["GET /healthz"]);
   });
 });
 


### PR DESCRIPTION
## Summary

Three correctness fixes on shipped REST profiles, completing the **REST profile correctness** sub-section under "Before main release" in [`ROADMAP.md`](https://github.com/narailabs/doc-wiki/blob/main/ROADMAP.md). Each commit is independent and reviewable on its own.

### eda47e7 — Flask default-GET case
- Adds optional `default_method` field on `RestProfile` pattern entries. When `method_group: 0` (no method captured), the engine falls back to `default_method`.
- New `flask.yaml` pattern catches `@app.route('/x')` (no `methods=` keyword), defaults to GET. Anchored with `\)` after the path string so it can't double-match the explicit-methods= form.

### 432516a — Hono `.use()` defensive test
- Test-only commit. Verifies the existing Hono regex correctly excludes `.use()` middleware from extracted routes (the alternation `(get|post|put|delete|patch|options|head|all)` doesn't include `use`).
- Locks the behavior in via a fixture mixing `.use()` middleware with `.get()` / `.post()` routes.

### 8694320 — ASP.NET prefix concat
- Adds optional `file_prefix` block on `RestProfile`. When set, the engine extracts a per-file prefix once and concatenates it with each per-line captured path. Absolute paths (starting `/`) bypass the prefix; empty paths (e.g. `[HttpGet]` no-arg) inherit the prefix as the full route.
- `expand_controller_token: true` flag substitutes `[controller]` with the controller class name (lowercased, `Controller` suffix stripped) — common in `[Route("api/[controller]")]`.
- Updates `aspnet.yaml` and adds 4 new tests: relative paths, `[controller]` expansion, absolute-path bypass, no-Route fallback.

## Engine schema changes

```typescript
endpoint_extraction: {
  // NEW
  file_prefix?: {
    regex: string;
    prefix_group: number;
    expand_controller_token?: boolean;
  };
  patterns: Array<{
    regex: string;
    method_group: number;  // 0 = no method captured; default_method MUST be set
    path_group: number;
    default_method?: string;  // NEW
  }>;
}
```

Both fields are optional and additive — every shipped profile that doesn't declare them keeps its existing behavior.

## Test plan

- [x] `npm test` — 1098 passed, 5 skipped (was 1092, +6: 1 Flask, 1 Hono, 4 ASP.NET)
- [x] `npm run typecheck` — clean
- [x] `npm run build` — clean (committed `.js` updated)
- [ ] Manual: run inventory on a real Flask repo with bare `@app.route('/x')` and confirm GET routes appear
- [ ] Manual: run inventory on a real ASP.NET repo with `[Route("api/[controller]")]` controllers and confirm prefix concat