### PR TITLE
feat(atlas + lint): manifest-driven Phase 6 sources + references-inventory lint check

### DIFF
--- a/agents/lib/atlas_synthesize.js
+++ b/agents/lib/atlas_synthesize.js
@@ -703,6 +703,94 @@ export function assembleTroubleshootingInputs(wikiRoot) {
     }
     return { sources, text: parts.join("\n"), notes };
 }
+/** Directory names that gate a topic-bearing path component. The
+ *  directory IMMEDIATELY following one of these is treated as the
+ *  topic candidate. Curated to match the layouts atlas already
+ *  recognises in topic discovery (Phase 2). */
+const _TOPIC_DIR_PREFIXES = new Set([
+    "src",
+    "app",
+    "apps",
+    "services",
+    "lib",
+    "internal",
+    "pkg",
+    "packages",
+    "modules",
+    "cmd",
+]);
+/**
+ * Canonicalize a topic candidate to match the topic-discovery convention
+ * (SKILL.md Phase 2): lowercase-kebab-case, strip `-service`, `-svc`,
+ * `-module` suffixes.
+ */
+function _canonicalizeTopic(raw) {
+    let s = raw.toLowerCase().replace(/[_\s]+/g, "-");
+    s = s.replace(/-(service|svc|module)$/i, "");
+    return s;
+}
+/**
+ * Extract a topic candidate from a repo-relative source-file path.
+ * Looks for `<prefix>/<topic>/...` where `<prefix>` is one of the
+ * known topic-bearing directories. Returns the canonicalized topic,
+ * or `null` if no recognized topic directory is found or the candidate
+ * is the path's leaf (i.e. a file, not a sub-directory).
+ */
+export function extractTopicFromPath(sourceFile) {
+    const parts = sourceFile.split("/").filter((p) => p.length > 0);
+    // Need at least <prefix>/<topic>/<more> — if `<topic>` is the leaf,
+    // it's likely a file (e.g. `src/utils.ts`), not a topic directory.
+    for (let i = 0; i < parts.length - 2; i++) {
+        if (_TOPIC_DIR_PREFIXES.has(parts[i] ?? "")) {
+            const candidate = parts[i + 1] ?? "";
+            if (candidate.length > 0)
+                return _canonicalizeTopic(candidate);
+        }
+    }
+    return null;
+}
+/**
+ * Build a topic → facet → source-files map for the two manifest-backed
+ * facets — `data-model` (from `inventory.orm_entities`) and `api` (from
+ * `inventory.rest_endpoints`). Topic assignment is path-based via
+ * {@link extractTopicFromPath}; entries whose extracted topic does not
+ * canonicalize to a member of `topics` are dropped.
+ *
+ * Other facets (`architecture`, `environments`, `operations`) are NOT
+ * manifest-backed — the orchestrator continues to use SKILL.md
+ * heuristics for them, merging the two source lists.
+ */
+export function groupManifestByTopicFacet(inventory, topics) {
+    const wantedTopics = new Set(topics.map((t) => _canonicalizeTopic(t)));
+    const out = {};
+    const ensure = (topic) => {
+        const existing = out[topic];
+        if (existing)
+            return existing;
+        const fresh = { "data-model": [], api: [] };
+        out[topic] = fresh;
+        return fresh;
+    };
+    for (const entity of inventory.orm_entities) {
+        const topic = extractTopicFromPath(entity.source_file);
+        if (!topic || !wantedTopics.has(topic))
+            continue;
+        const bucket = ensure(topic);
+        if (!bucket["data-model"].includes(entity.source_file)) {
+            bucket["data-model"].push(entity.source_file);
+        }
+    }
+    for (const endpoint of inventory.rest_endpoints) {
+        const topic = extractTopicFromPath(endpoint.file);
+        if (!topic || !wantedTopics.has(topic))
+            continue;
+        const bucket = ensure(topic);
+        if (!bucket["api"].includes(endpoint.file)) {
+            bucket["api"].push(endpoint.file);
+        }
+    }
+    return out;
+}
 // ── CLI ────────────────────────────────────────────────────────────
 const FLAG_SPEC = {
     "--wiki-root": "wikiRoot",

--- a/agents/lib/atlas_synthesize.ts
+++ b/agents/lib/atlas_synthesize.ts
@@ -27,6 +27,7 @@ import { fileURLToPath } from "node:url";
 
 import { parseFlags } from "../../skills/doc-wiki/scripts/_cli_args.js";
 import { parseFrontmatter } from "../../skills/doc-wiki/scripts/_frontmatter.js";
+import { type CodeInventory } from "./atlas_inventory.js";
 import {
   formatPhaseFlow,
   type ClassDef,
@@ -768,6 +769,109 @@ export function assembleTroubleshootingInputs(wikiRoot: string): SynthesisBundle
   }
 
   return { sources, text: parts.join("\n"), notes };
+}
+
+// ── Manifest-driven source lookups ─────────────────────────────────
+
+/** Per-topic, per-facet source list. Only the manifest-backed facets
+ *  appear here; other facets keep using SKILL.md heuristics. */
+export interface ManifestSourcesByTopic {
+  [topic: string]: { "data-model": string[]; api: string[] };
+}
+
+/** Directory names that gate a topic-bearing path component. The
+ *  directory IMMEDIATELY following one of these is treated as the
+ *  topic candidate. Curated to match the layouts atlas already
+ *  recognises in topic discovery (Phase 2). */
+const _TOPIC_DIR_PREFIXES: ReadonlySet<string> = new Set([
+  "src",
+  "app",
+  "apps",
+  "services",
+  "lib",
+  "internal",
+  "pkg",
+  "packages",
+  "modules",
+  "cmd",
+]);
+
+/**
+ * Canonicalize a topic candidate to match the topic-discovery convention
+ * (SKILL.md Phase 2): lowercase-kebab-case, strip `-service`, `-svc`,
+ * `-module` suffixes.
+ */
+function _canonicalizeTopic(raw: string): string {
+  let s = raw.toLowerCase().replace(/[_\s]+/g, "-");
+  s = s.replace(/-(service|svc|module)$/i, "");
+  return s;
+}
+
+/**
+ * Extract a topic candidate from a repo-relative source-file path.
+ * Looks for `<prefix>/<topic>/...` where `<prefix>` is one of the
+ * known topic-bearing directories. Returns the canonicalized topic,
+ * or `null` if no recognized topic directory is found or the candidate
+ * is the path's leaf (i.e. a file, not a sub-directory).
+ */
+export function extractTopicFromPath(sourceFile: string): string | null {
+  const parts = sourceFile.split("/").filter((p) => p.length > 0);
+  // Need at least <prefix>/<topic>/<more> — if `<topic>` is the leaf,
+  // it's likely a file (e.g. `src/utils.ts`), not a topic directory.
+  for (let i = 0; i < parts.length - 2; i++) {
+    if (_TOPIC_DIR_PREFIXES.has(parts[i] ?? "")) {
+      const candidate = parts[i + 1] ?? "";
+      if (candidate.length > 0) return _canonicalizeTopic(candidate);
+    }
+  }
+  return null;
+}
+
+/**
+ * Build a topic → facet → source-files map for the two manifest-backed
+ * facets — `data-model` (from `inventory.orm_entities`) and `api` (from
+ * `inventory.rest_endpoints`). Topic assignment is path-based via
+ * {@link extractTopicFromPath}; entries whose extracted topic does not
+ * canonicalize to a member of `topics` are dropped.
+ *
+ * Other facets (`architecture`, `environments`, `operations`) are NOT
+ * manifest-backed — the orchestrator continues to use SKILL.md
+ * heuristics for them, merging the two source lists.
+ */
+export function groupManifestByTopicFacet(
+  inventory: CodeInventory,
+  topics: readonly string[],
+): ManifestSourcesByTopic {
+  const wantedTopics = new Set(topics.map((t) => _canonicalizeTopic(t)));
+  const out: ManifestSourcesByTopic = {};
+
+  const ensure = (topic: string): { "data-model": string[]; api: string[] } => {
+    const existing = out[topic];
+    if (existing) return existing;
+    const fresh = { "data-model": [] as string[], api: [] as string[] };
+    out[topic] = fresh;
+    return fresh;
+  };
+
+  for (const entity of inventory.orm_entities) {
+    const topic = extractTopicFromPath(entity.source_file);
+    if (!topic || !wantedTopics.has(topic)) continue;
+    const bucket = ensure(topic);
+    if (!bucket["data-model"].includes(entity.source_file)) {
+      bucket["data-model"].push(entity.source_file);
+    }
+  }
+
+  for (const endpoint of inventory.rest_endpoints) {
+    const topic = extractTopicFromPath(endpoint.file);
+    if (!topic || !wantedTopics.has(topic)) continue;
+    const bucket = ensure(topic);
+    if (!bucket["api"].includes(endpoint.file)) {
+      bucket["api"].push(endpoint.file);
+    }
+  }
+
+  return out;
 }
 
 // ── CLI ────────────────────────────────────────────────────────────

--- a/agents/lib/tests/atlas_synthesize.test.ts
+++ b/agents/lib/tests/atlas_synthesize.test.ts
@@ -17,7 +17,10 @@ import {
   assembleIntegrationsInputs,
   assembleOverviewInputs,
   assembleTroubleshootingInputs,
+  extractTopicFromPath,
+  groupManifestByTopicFacet,
 } from "../atlas_synthesize.js";
+import { type CodeInventory } from "../atlas_inventory.js";
 import { makeTmpPath, cleanupTmpPath } from "./fixtures.js";
 
 // ── Helpers ─────────────────────────────────────────────────────────
@@ -491,5 +494,196 @@ describe("assembleTroubleshootingInputs", () => {
     const bundle = assembleTroubleshootingInputs(wikiRoot);
     expect(bundle.text).toContain("NEW DRIFT");
     expect(bundle.text).not.toContain("OLD DRIFT");
+  });
+});
+
+// ── Manifest-driven source lookups ─────────────────────────────────
+
+function emptyInventory(overrides: Partial<CodeInventory> = {}): CodeInventory {
+  return {
+    atlas_run_id: "2026-05-03T00-00-00",
+    generated_at: "2026-05-03T00:00:00.000Z",
+    repo_root: "/repo",
+    project_metadata: {
+      name: "x",
+      version: "0.0.0",
+      language: "unknown",
+      runtime: "",
+      manifests_seen: [],
+    },
+    orm_entities: [],
+    rest_endpoints: [],
+    code_clients: [],
+    stats: { files_walked: 0, files_skipped_for_size: 0, duration_ms: 0 },
+    notes: [],
+    ...overrides,
+  };
+}
+
+describe("extractTopicFromPath", () => {
+  it("extracts topic from src/<topic>/...", () => {
+    expect(extractTopicFromPath("src/auth/models/user.py")).toBe("auth");
+    expect(extractTopicFromPath("src/billing/routes/payments.ts")).toBe("billing");
+  });
+
+  it("works for app, services, lib, internal, pkg, packages, modules, cmd, apps", () => {
+    expect(extractTopicFromPath("app/users/controllers/index.rb")).toBe("users");
+    expect(extractTopicFromPath("services/auth/handler.go")).toBe("auth");
+    expect(extractTopicFromPath("lib/billing/calc.ts")).toBe("billing");
+    expect(extractTopicFromPath("internal/users/store.go")).toBe("users");
+    expect(extractTopicFromPath("pkg/auth/jwt.go")).toBe("auth");
+    expect(extractTopicFromPath("packages/billing/index.ts")).toBe("billing");
+    expect(extractTopicFromPath("modules/users/service.php")).toBe("users");
+    expect(extractTopicFromPath("cmd/server/main.go")).toBe("server");
+    expect(extractTopicFromPath("apps/dashboard/layout.tsx")).toBe("dashboard");
+  });
+
+  it("strips -service / -svc / -module suffixes (matches Phase 2 canonicalization)", () => {
+    expect(extractTopicFromPath("src/auth-service/api.ts")).toBe("auth");
+    expect(extractTopicFromPath("services/billing-svc/index.go")).toBe("billing");
+    expect(extractTopicFromPath("lib/users-module/handler.ts")).toBe("users");
+  });
+
+  it("returns null when no recognized prefix is present", () => {
+    expect(extractTopicFromPath("agents/lib/foo.ts")).toBeNull();
+    expect(extractTopicFromPath("docs/intro.md")).toBeNull();
+    expect(extractTopicFromPath("Makefile")).toBeNull();
+  });
+
+  it("returns null when the topic candidate is the leaf (looks like a file)", () => {
+    // src/utils.ts → no topic; the "candidate" is the file itself.
+    expect(extractTopicFromPath("src/utils.ts")).toBeNull();
+    expect(extractTopicFromPath("lib/index.js")).toBeNull();
+  });
+
+  it("tolerates leading slashes and multiple separators", () => {
+    expect(extractTopicFromPath("/src/auth/foo.py")).toBe("auth");
+    expect(extractTopicFromPath("src//billing//x.ts")).toBe("billing");
+  });
+});
+
+describe("groupManifestByTopicFacet", () => {
+  it("groups orm_entities into data-model and rest_endpoints into api", () => {
+    const inv = emptyInventory({
+      orm_entities: [
+        {
+          profile: "sqlalchemy",
+          class_name: "User",
+          table_name: "users",
+          schema_name: "",
+          source_file: "src/auth/models/user.py",
+          columns: [],
+          relationships: [],
+        },
+        {
+          profile: "sqlalchemy",
+          class_name: "Invoice",
+          table_name: "invoices",
+          schema_name: "",
+          source_file: "src/billing/models/invoice.py",
+          columns: [],
+          relationships: [],
+        },
+      ],
+      rest_endpoints: [
+        {
+          framework: "fastapi",
+          method: "GET",
+          path: "/api/users",
+          file: "src/auth/routes/users.py",
+          line: 10,
+        },
+        {
+          framework: "fastapi",
+          method: "POST",
+          path: "/api/payments",
+          file: "src/billing/routes/payments.py",
+          line: 22,
+        },
+      ],
+    });
+    const grouped = groupManifestByTopicFacet(inv, ["auth", "billing"]);
+    expect(grouped["auth"]).toEqual({
+      "data-model": ["src/auth/models/user.py"],
+      api: ["src/auth/routes/users.py"],
+    });
+    expect(grouped["billing"]).toEqual({
+      "data-model": ["src/billing/models/invoice.py"],
+      api: ["src/billing/routes/payments.py"],
+    });
+  });
+
+  it("drops entries whose extracted topic is not in the wanted list", () => {
+    const inv = emptyInventory({
+      orm_entities: [
+        {
+          profile: "sqlalchemy",
+          class_name: "User",
+          table_name: "users",
+          schema_name: "",
+          source_file: "src/auth/models/user.py",
+          columns: [],
+          relationships: [],
+        },
+        {
+          profile: "sqlalchemy",
+          class_name: "Telemetry",
+          table_name: "telemetry",
+          schema_name: "",
+          source_file: "src/observability/models/event.py",
+          columns: [],
+          relationships: [],
+        },
+      ],
+    });
+    const grouped = groupManifestByTopicFacet(inv, ["auth"]);
+    expect(Object.keys(grouped)).toEqual(["auth"]);
+    expect(grouped["auth"]?.["data-model"]).toEqual(["src/auth/models/user.py"]);
+  });
+
+  it("canonicalizes the wanted-topics list (auth-service ≡ auth)", () => {
+    const inv = emptyInventory({
+      orm_entities: [
+        {
+          profile: "django",
+          class_name: "User",
+          table_name: "users",
+          schema_name: "",
+          source_file: "src/auth/models.py",
+          columns: [],
+          relationships: [],
+        },
+      ],
+    });
+    const grouped = groupManifestByTopicFacet(inv, ["Auth-Service"]);
+    expect(grouped["auth"]?.["data-model"]).toEqual(["src/auth/models.py"]);
+  });
+
+  it("dedupes when multiple endpoints in the same file map to the same topic", () => {
+    const inv = emptyInventory({
+      rest_endpoints: [
+        { framework: "fastapi", method: "GET",  path: "/a", file: "src/auth/routes.py", line: 1 },
+        { framework: "fastapi", method: "POST", path: "/a", file: "src/auth/routes.py", line: 2 },
+      ],
+    });
+    const grouped = groupManifestByTopicFacet(inv, ["auth"]);
+    expect(grouped["auth"]?.["api"]).toEqual(["src/auth/routes.py"]);
+  });
+
+  it("returns empty object when no manifest entry matches a wanted topic", () => {
+    const inv = emptyInventory({
+      orm_entities: [
+        {
+          profile: "django",
+          class_name: "User",
+          table_name: "users",
+          schema_name: "",
+          source_file: "src/auth/models.py",
+          columns: [],
+          relationships: [],
+        },
+      ],
+    });
+    expect(groupManifestByTopicFacet(inv, ["billing"])).toEqual({});
   });
 });

--- a/skills/doc-wiki/SKILL.md
+++ b/skills/doc-wiki/SKILL.md
@@ -220,7 +220,7 @@ This is **a meta-orchestrator over `/doc-wiki:ingest`**. It does not replace the
 3. **Confirm topics** — present the merged list with provenance (which signals contributed each topic). Under `balanced+`, ask "Generate atlas pages for these topics? [Y/n/edit]". Under `auto`/`autonomous`, proceed silently. With `--yes`, skip the prompt.
 
 4. **Estimate cost**:
-   - Build a `Plan` JSON: `{ topics, facets, entries: [{topic, facet, sources, output}], created_at }`. Source heuristics: `architecture` → `src/<topic>/`; `data-model` → ORM model files; `environments` → `.env*`, `config/<topic>*`; `api` → controllers/routes; `operations` → runbooks if present.
+   - Build a `Plan` JSON: `{ topics, facets, entries: [{topic, facet, sources, output}], created_at }`. **Manifest-backed facets** — populate `entry.sources` for `data-model` and `api` from `node {skill_path}/scripts/atlas_orchestrator.js compute-sources --wiki-root <root> --run-id <id> --topics <csv>`. The CLI returns `{topic: {"data-model": [...], "api": [...]}}` from the Phase 1b inventory; an empty `{}` (manifest missing or no entries match a wanted topic) means fall back to the heuristics for those facets too. **Heuristic facets** — `architecture` → `src/<topic>/`; `environments` → `.env*`, `config/<topic>*`; `operations` → runbooks if present. Always use heuristics when a manifest source is empty for a `(topic, facet)` pair (e.g. ORM not detected, REST disabled, `--enable-rest` was off).
    - `node {skill_path}/scripts/atlas_orchestrator.js estimate-cost --wiki-root <root> --plan '<plan-json>'`.
    - Display the estimate; if `total_estimated_usd > --max-cost`, abort with a clear hint to re-run with a higher `--max-cost`.
 

--- a/skills/doc-wiki/scripts/atlas_orchestrator.js
+++ b/skills/doc-wiki/scripts/atlas_orchestrator.js
@@ -34,6 +34,7 @@ import { parseFlags } from "./_cli_args.js";
 import { parseFrontmatter } from "./_frontmatter.js";
 import { computeHash, checkCache } from "./cache_manager.js";
 import { loadInventory, } from "../../../agents/lib/atlas_inventory.js";
+import { groupManifestByTopicFacet } from "../../../agents/lib/atlas_synthesize.js";
 // ── State detection ────────────────────────────────────────────────
 /**
  * Walk `<wikiRoot>/wiki/` and count `.md` pages whose frontmatter contains
@@ -695,8 +696,9 @@ const FLAG_SPEC = {
     "--sample-size": "sampleSize",
     "--per-ingest-avg-usd": "perIngestAvgUsd",
     "--gitlog": "gitlog",
+    "--topics": "topics",
 };
-const HELP_TEXT = `usage: atlas_orchestrator.js {detect-state,estimate-cost,save-plan,load-plan,per-ingest-avg,gap-report} [...]
+const HELP_TEXT = `usage: atlas_orchestrator.js {detect-state,estimate-cost,save-plan,load-plan,per-ingest-avg,gap-report,compute-sources} [...]
 
 Deterministic helpers for the /doc-wiki:atlas orchestrator.
 
@@ -715,6 +717,12 @@ Subcommands:
                     Build the gap report. With --run-id, also writes
                     wiki/outputs/atlas/<run-id>/gap-report.md.
                     Stdout: GapReport JSON (and {written: path} when --run-id is given).
+  compute-sources   --wiki-root <p> --run-id <id> --topics <csv>
+                    Group the Phase-1b inventory into topic+facet source
+                    lists for the manifest-backed facets (data-model, api).
+                    Use these to populate the Plan instead of glob heuristics.
+                    Stdout: {topic: {"data-model": [...], "api": [...]}}.
+                    Empty {} when the manifest is missing.
 `;
 export function main(argv = process.argv.slice(2)) {
     if (argv.length === 0 || argv[0] === "-h" || argv[0] === "--help") {
@@ -858,6 +866,36 @@ export function main(argv = process.argv.slice(2)) {
         else {
             process.stdout.write(JSON.stringify(report) + "\n");
         }
+        return 0;
+    }
+    if (sub === "compute-sources") {
+        const runIdRaw = parsed.values["runId"];
+        const topicsRaw = parsed.values["topics"];
+        if (typeof runIdRaw !== "string" || runIdRaw.length === 0) {
+            process.stderr.write("--run-id is required\n");
+            return 2;
+        }
+        if (typeof topicsRaw !== "string" || topicsRaw.length === 0) {
+            process.stderr.write("--topics is required (comma-separated)\n");
+            return 2;
+        }
+        const topics = topicsRaw
+            .split(",")
+            .map((s) => s.trim())
+            .filter((s) => s.length > 0);
+        if (topics.length === 0) {
+            process.stderr.write("--topics produced an empty list\n");
+            return 2;
+        }
+        const inventory = loadInventory(wikiRoot, runIdRaw);
+        if (!inventory) {
+            // Missing manifest is non-fatal — emit empty map so the orchestrator
+            // falls back to SKILL.md heuristic sources for every topic+facet.
+            process.stdout.write(JSON.stringify({}) + "\n");
+            return 0;
+        }
+        const grouped = groupManifestByTopicFacet(inventory, topics);
+        process.stdout.write(JSON.stringify(grouped) + "\n");
         return 0;
     }
     process.stderr.write(`unknown subcommand: ${sub}\n`);

--- a/skills/doc-wiki/scripts/atlas_orchestrator.ts
+++ b/skills/doc-wiki/scripts/atlas_orchestrator.ts
@@ -38,6 +38,7 @@ import {
   loadInventory,
   type CodeInventory,
 } from "../../../agents/lib/atlas_inventory.js";
+import { groupManifestByTopicFacet } from "../../../agents/lib/atlas_synthesize.js";
 
 // ── Types ───────────────────────────────────────────────────────────
 
@@ -799,9 +800,10 @@ const FLAG_SPEC = {
   "--sample-size": "sampleSize",
   "--per-ingest-avg-usd": "perIngestAvgUsd",
   "--gitlog": "gitlog",
+  "--topics": "topics",
 } as const;
 
-const HELP_TEXT = `usage: atlas_orchestrator.js {detect-state,estimate-cost,save-plan,load-plan,per-ingest-avg,gap-report} [...]
+const HELP_TEXT = `usage: atlas_orchestrator.js {detect-state,estimate-cost,save-plan,load-plan,per-ingest-avg,gap-report,compute-sources} [...]
 
 Deterministic helpers for the /doc-wiki:atlas orchestrator.
 
@@ -820,6 +822,12 @@ Subcommands:
                     Build the gap report. With --run-id, also writes
                     wiki/outputs/atlas/<run-id>/gap-report.md.
                     Stdout: GapReport JSON (and {written: path} when --run-id is given).
+  compute-sources   --wiki-root <p> --run-id <id> --topics <csv>
+                    Group the Phase-1b inventory into topic+facet source
+                    lists for the manifest-backed facets (data-model, api).
+                    Use these to populate the Plan instead of glob heuristics.
+                    Stdout: {topic: {"data-model": [...], "api": [...]}}.
+                    Empty {} when the manifest is missing.
 `;
 
 export function main(argv: readonly string[] = process.argv.slice(2)): number {
@@ -974,6 +982,37 @@ export function main(argv: readonly string[] = process.argv.slice(2)): number {
     } else {
       process.stdout.write(JSON.stringify(report) + "\n");
     }
+    return 0;
+  }
+
+  if (sub === "compute-sources") {
+    const runIdRaw = parsed.values["runId"];
+    const topicsRaw = parsed.values["topics"];
+    if (typeof runIdRaw !== "string" || runIdRaw.length === 0) {
+      process.stderr.write("--run-id is required\n");
+      return 2;
+    }
+    if (typeof topicsRaw !== "string" || topicsRaw.length === 0) {
+      process.stderr.write("--topics is required (comma-separated)\n");
+      return 2;
+    }
+    const topics = topicsRaw
+      .split(",")
+      .map((s) => s.trim())
+      .filter((s) => s.length > 0);
+    if (topics.length === 0) {
+      process.stderr.write("--topics produced an empty list\n");
+      return 2;
+    }
+    const inventory = loadInventory(wikiRoot, runIdRaw);
+    if (!inventory) {
+      // Missing manifest is non-fatal — emit empty map so the orchestrator
+      // falls back to SKILL.md heuristic sources for every topic+facet.
+      process.stdout.write(JSON.stringify({}) + "\n");
+      return 0;
+    }
+    const grouped = groupManifestByTopicFacet(inventory, topics);
+    process.stdout.write(JSON.stringify(grouped) + "\n");
     return 0;
   }
 

--- a/skills/doc-wiki/scripts/lint_checks.js
+++ b/skills/doc-wiki/scripts/lint_checks.js
@@ -28,6 +28,8 @@ import { parseFlags } from "./_cli_args.js";
 import { parseFrontmatter as parseFrontmatterRaw } from "./_frontmatter.js";
 import { wikiPages } from "./_wiki_fs.js";
 import { loadAllProfiles, detectOrm, } from "../../../agents/lib/wiki_orm/index.js";
+import { loadInventory, } from "../../../agents/lib/atlas_inventory.js";
+import { getLastAtlasRunId } from "./atlas_orchestrator.js";
 // ── Constants ───────────────────────────────────────────────────────
 const REQUIRED_FIELDS = new Set([
     "title",
@@ -225,6 +227,55 @@ export function checkCodeRefDrift(wikiRoot, cache) {
             if (actualHash !== storedHash) {
                 issues.push(makeIssue("warning", "code_ref_drift", page, `content_hash mismatch for ${refPath}`));
             }
+        }
+    }
+    return issues;
+}
+/**
+ * Flag `references:` entries whose path is not present anywhere in the
+ * atlas Phase-1b inventory snapshot — neither as an ORM-entity source,
+ * REST endpoint file, code-client file, nor as one of the parsed
+ * project manifests. Skips silently when no inventory is loaded so lint
+ * remains usable in CI gates that do not run atlas.
+ *
+ * Complements {@link checkCodeRefDrift} (which is about hash drift
+ * against the file on disk): this check is about whether the manifest
+ * has *seen* the file at all. A real-but-unseen file usually means the
+ * walker missed it (excluded path / size limit) or the user hasn't
+ * re-run atlas since adding the file.
+ */
+export function checkReferencesInventory(wikiRoot, cache, inventory) {
+    if (!inventory)
+        return [];
+    const knownFiles = new Set();
+    for (const e of inventory.orm_entities)
+        knownFiles.add(e.source_file);
+    for (const r of inventory.rest_endpoints)
+        knownFiles.add(r.file);
+    for (const c of inventory.code_clients)
+        knownFiles.add(c.file);
+    for (const m of inventory.project_metadata.manifests_seen)
+        knownFiles.add(m);
+    const issues = [];
+    const pages = cache ?? buildPageCache(wikiRoot);
+    for (const [page, { frontmatter: fm }] of pages) {
+        const refs = fm["references"];
+        if (!Array.isArray(refs))
+            continue;
+        for (const refEntry of refs) {
+            if (refEntry === null ||
+                typeof refEntry !== "object" ||
+                Array.isArray(refEntry)) {
+                continue;
+            }
+            const ref = refEntry;
+            const refPathVal = ref["path"];
+            const refPath = typeof refPathVal === "string" ? refPathVal : "";
+            if (!refPath)
+                continue;
+            if (knownFiles.has(refPath))
+                continue;
+            issues.push(makeIssue("warning", "references_inventory", page, `Referenced file ${refPath} is not in the atlas inventory snapshot`));
         }
     }
     return issues;
@@ -705,10 +756,11 @@ export function checkDeprecatedClaims(wikiRoot, cache) {
 /**
  * Registry of check functions, matching the Python dict insertion order.
  *
- * Every check accepts an optional `cache` so `lintWiki` can amortize the
- * page-read I/O across the whole run. Checks that don't read pages
+ * Every check accepts the wiki root, an optional `cache` (so `lintWiki`
+ * can amortize page-read I/O across the whole run), and an optional
+ * `inventory` snapshot. Checks that don't read pages or the inventory
  * (provenance / ambiguity_rate / isolated_nodes / orm_mapping_freshness /
- * thin_clusters) just ignore the cache.
+ * thin_clusters) ignore both extras.
  */
 const CHECK_FUNCTIONS = [
     ["broken_links", checkBrokenLinks],
@@ -716,6 +768,7 @@ const CHECK_FUNCTIONS = [
     ["orphans", checkOrphans],
     ["isolated_nodes", checkIsolatedNodes],
     ["code_ref_drift", checkCodeRefDrift],
+    ["references_inventory", checkReferencesInventory],
     ["provenance", checkProvenanceCompleteness],
     ["ambiguity_rate", checkHighAmbiguityRate],
     ["deprecated_claims", checkDeprecatedClaims],
@@ -785,9 +838,11 @@ function issueMatchesPage(issue, pageFilter) {
  *
  * When `pageFilter` is set, only issues whose `page` field matches the
  * filter (exact path, suffix path, or `*`/`**` glob) are returned. The
- * `summary` counters reflect the post-filter list.
+ * `summary` counters reflect the post-filter list. Pass `inventory`
+ * (the Phase-1b atlas manifest) to enable the `references_inventory`
+ * check; when it's `null` / `undefined`, that check silently skips.
  */
-export function lintWiki(wikiRoot, category = null, pageFilter = null) {
+export function lintWiki(wikiRoot, category = null, pageFilter = null, inventory = null) {
     let issues = [];
     // Build the page cache once for the whole run so checks don't each
     // re-readFileSync every wiki page. Was 13× I/O amplification.
@@ -795,12 +850,12 @@ export function lintWiki(wikiRoot, category = null, pageFilter = null) {
     if (category) {
         const found = CHECK_FUNCTIONS.find(([k]) => k === category);
         if (found) {
-            issues = found[1](wikiRoot, cache);
+            issues = found[1](wikiRoot, cache, inventory);
         }
     }
     else {
         for (const [, fn] of CHECK_FUNCTIONS) {
-            issues.push(...fn(wikiRoot, cache));
+            issues.push(...fn(wikiRoot, cache, inventory));
         }
     }
     if (pageFilter !== null && pageFilter !== "") {
@@ -823,22 +878,29 @@ const FLAG_SPEC = {
     "--wiki-root": "wikiRoot",
     "--category": "category",
     "--page": "page",
+    "--inventory-run-id": "inventoryRunId",
 };
-const HELP_TEXT = `usage: lint_checks.js [-h] --wiki-root WIKI_ROOT [--category CATEGORY] [--page PAGE]
+const HELP_TEXT = `usage: lint_checks.js [-h] --wiki-root WIKI_ROOT [--category CATEGORY] [--page PAGE] [--inventory-run-id RUN_ID]
 
 Wiki structural lint checks.
 
 options:
-  -h, --help            show this help message and exit
-  --wiki-root WIKI_ROOT Wiki root path
-  --category CATEGORY   Run only a specific check category
-  --page PAGE           Scope the report to a single page. Accepts an
-                        absolute path, a wiki-relative path
-                        (e.g. wiki/auth/session.md), or a glob with
-                        * / ** segments. All check functions still run
-                        (so orphan/isolated/coverage issues that name the
-                        page survive the filter); only the issues whose
-                        \`page\` field matches PAGE are reported.
+  -h, --help               show this help message and exit
+  --wiki-root WIKI_ROOT    Wiki root path
+  --category CATEGORY      Run only a specific check category
+  --page PAGE              Scope the report to a single page. Accepts an
+                           absolute path, a wiki-relative path
+                           (e.g. wiki/auth/session.md), or a glob with
+                           * / ** segments. All check functions still run
+                           (so orphan/isolated/coverage issues that name the
+                           page survive the filter); only the issues whose
+                           \`page\` field matches PAGE are reported.
+  --inventory-run-id RUN_ID
+                           Atlas run id (YYYY-MM-DDTHH-MM-SS) whose Phase-1b
+                           inventory should drive the references_inventory
+                           check. When omitted, the latest atlas run from
+                           log/events.jsonl is used. The check no-ops when
+                           no inventory is available.
 `;
 export function main(argv = process.argv.slice(2)) {
     let parsed;
@@ -867,7 +929,21 @@ export function main(argv = process.argv.slice(2)) {
     }
     const pageRaw = parsed.values["page"];
     const pageFilter = typeof pageRaw === "string" && pageRaw ? pageRaw : null;
-    const result = lintWiki(wikiRoot, category, pageFilter);
+    // Resolve the inventory snapshot: explicit --inventory-run-id wins;
+    // otherwise auto-discover the latest atlas run from events.jsonl.
+    // A missing/empty/zero-length run id is treated as "no inventory" —
+    // the references_inventory check silently no-ops in that case.
+    const explicitRunIdRaw = parsed.values["inventoryRunId"];
+    const explicitRunId = typeof explicitRunIdRaw === "string" && explicitRunIdRaw.length > 0
+        ? explicitRunIdRaw
+        : null;
+    const inventoryRunId = explicitRunId !== null
+        ? explicitRunId
+        : getLastAtlasRunId(wikiRoot) || null;
+    const inventory = inventoryRunId !== null && inventoryRunId.length > 0
+        ? loadInventory(wikiRoot, inventoryRunId)
+        : null;
+    const result = lintWiki(wikiRoot, category, pageFilter, inventory);
     process.stdout.write(JSON.stringify(result, null, 2) + "\n");
     return 0;
 }

--- a/skills/doc-wiki/scripts/lint_checks.ts
+++ b/skills/doc-wiki/scripts/lint_checks.ts
@@ -32,6 +32,11 @@ import {
   detectOrm,
   type OrmProfile,
 } from "../../../agents/lib/wiki_orm/index.js";
+import {
+  loadInventory,
+  type CodeInventory,
+} from "../../../agents/lib/atlas_inventory.js";
+import { getLastAtlasRunId } from "./atlas_orchestrator.js";
 
 // ── Constants ───────────────────────────────────────────────────────
 
@@ -334,6 +339,62 @@ export function checkCodeRefDrift(wikiRoot: string, cache?: PageCache): Issue[] 
           ),
         );
       }
+    }
+  }
+  return issues;
+}
+
+/**
+ * Flag `references:` entries whose path is not present anywhere in the
+ * atlas Phase-1b inventory snapshot — neither as an ORM-entity source,
+ * REST endpoint file, code-client file, nor as one of the parsed
+ * project manifests. Skips silently when no inventory is loaded so lint
+ * remains usable in CI gates that do not run atlas.
+ *
+ * Complements {@link checkCodeRefDrift} (which is about hash drift
+ * against the file on disk): this check is about whether the manifest
+ * has *seen* the file at all. A real-but-unseen file usually means the
+ * walker missed it (excluded path / size limit) or the user hasn't
+ * re-run atlas since adding the file.
+ */
+export function checkReferencesInventory(
+  wikiRoot: string,
+  cache?: PageCache,
+  inventory?: CodeInventory | null,
+): Issue[] {
+  if (!inventory) return [];
+  const knownFiles = new Set<string>();
+  for (const e of inventory.orm_entities) knownFiles.add(e.source_file);
+  for (const r of inventory.rest_endpoints) knownFiles.add(r.file);
+  for (const c of inventory.code_clients) knownFiles.add(c.file);
+  for (const m of inventory.project_metadata.manifests_seen) knownFiles.add(m);
+
+  const issues: Issue[] = [];
+  const pages = cache ?? buildPageCache(wikiRoot);
+  for (const [page, { frontmatter: fm }] of pages) {
+    const refs = fm["references"];
+    if (!Array.isArray(refs)) continue;
+    for (const refEntry of refs) {
+      if (
+        refEntry === null ||
+        typeof refEntry !== "object" ||
+        Array.isArray(refEntry)
+      ) {
+        continue;
+      }
+      const ref = refEntry as Record<string, unknown>;
+      const refPathVal = ref["path"];
+      const refPath = typeof refPathVal === "string" ? refPathVal : "";
+      if (!refPath) continue;
+      if (knownFiles.has(refPath)) continue;
+      issues.push(
+        makeIssue(
+          "warning",
+          "references_inventory",
+          page,
+          `Referenced file ${refPath} is not in the atlas inventory snapshot`,
+        ),
+      );
     }
   }
   return issues;
@@ -930,19 +991,28 @@ export function checkDeprecatedClaims(wikiRoot: string, cache?: PageCache): Issu
 /**
  * Registry of check functions, matching the Python dict insertion order.
  *
- * Every check accepts an optional `cache` so `lintWiki` can amortize the
- * page-read I/O across the whole run. Checks that don't read pages
+ * Every check accepts the wiki root, an optional `cache` (so `lintWiki`
+ * can amortize page-read I/O across the whole run), and an optional
+ * `inventory` snapshot. Checks that don't read pages or the inventory
  * (provenance / ambiguity_rate / isolated_nodes / orm_mapping_freshness /
- * thin_clusters) just ignore the cache.
+ * thin_clusters) ignore both extras.
  */
 const CHECK_FUNCTIONS: ReadonlyArray<
-  [string, (wikiRoot: string, cache?: PageCache) => Issue[]]
+  [
+    string,
+    (
+      wikiRoot: string,
+      cache?: PageCache,
+      inventory?: CodeInventory | null,
+    ) => Issue[],
+  ]
 > = [
   ["broken_links", checkBrokenLinks],
   ["frontmatter", checkFrontmatter],
   ["orphans", checkOrphans],
   ["isolated_nodes", checkIsolatedNodes],
   ["code_ref_drift", checkCodeRefDrift],
+  ["references_inventory", checkReferencesInventory],
   ["provenance", checkProvenanceCompleteness],
   ["ambiguity_rate", checkHighAmbiguityRate],
   ["deprecated_claims", checkDeprecatedClaims],
@@ -1018,12 +1088,15 @@ function issueMatchesPage(issue: Issue, pageFilter: string): boolean {
  *
  * When `pageFilter` is set, only issues whose `page` field matches the
  * filter (exact path, suffix path, or `*`/`**` glob) are returned. The
- * `summary` counters reflect the post-filter list.
+ * `summary` counters reflect the post-filter list. Pass `inventory`
+ * (the Phase-1b atlas manifest) to enable the `references_inventory`
+ * check; when it's `null` / `undefined`, that check silently skips.
  */
 export function lintWiki(
   wikiRoot: string,
   category: string | null = null,
   pageFilter: string | null = null,
+  inventory: CodeInventory | null = null,
 ): LintResult {
   let issues: Issue[] = [];
   // Build the page cache once for the whole run so checks don't each
@@ -1032,11 +1105,11 @@ export function lintWiki(
   if (category) {
     const found = CHECK_FUNCTIONS.find(([k]) => k === category);
     if (found) {
-      issues = found[1](wikiRoot, cache);
+      issues = found[1](wikiRoot, cache, inventory);
     }
   } else {
     for (const [, fn] of CHECK_FUNCTIONS) {
-      issues.push(...fn(wikiRoot, cache));
+      issues.push(...fn(wikiRoot, cache, inventory));
     }
   }
 
@@ -1061,23 +1134,30 @@ const FLAG_SPEC = {
   "--wiki-root": "wikiRoot",
   "--category": "category",
   "--page": "page",
+  "--inventory-run-id": "inventoryRunId",
 } as const;
 
-const HELP_TEXT = `usage: lint_checks.js [-h] --wiki-root WIKI_ROOT [--category CATEGORY] [--page PAGE]
+const HELP_TEXT = `usage: lint_checks.js [-h] --wiki-root WIKI_ROOT [--category CATEGORY] [--page PAGE] [--inventory-run-id RUN_ID]
 
 Wiki structural lint checks.
 
 options:
-  -h, --help            show this help message and exit
-  --wiki-root WIKI_ROOT Wiki root path
-  --category CATEGORY   Run only a specific check category
-  --page PAGE           Scope the report to a single page. Accepts an
-                        absolute path, a wiki-relative path
-                        (e.g. wiki/auth/session.md), or a glob with
-                        * / ** segments. All check functions still run
-                        (so orphan/isolated/coverage issues that name the
-                        page survive the filter); only the issues whose
-                        \`page\` field matches PAGE are reported.
+  -h, --help               show this help message and exit
+  --wiki-root WIKI_ROOT    Wiki root path
+  --category CATEGORY      Run only a specific check category
+  --page PAGE              Scope the report to a single page. Accepts an
+                           absolute path, a wiki-relative path
+                           (e.g. wiki/auth/session.md), or a glob with
+                           * / ** segments. All check functions still run
+                           (so orphan/isolated/coverage issues that name the
+                           page survive the filter); only the issues whose
+                           \`page\` field matches PAGE are reported.
+  --inventory-run-id RUN_ID
+                           Atlas run id (YYYY-MM-DDTHH-MM-SS) whose Phase-1b
+                           inventory should drive the references_inventory
+                           check. When omitted, the latest atlas run from
+                           log/events.jsonl is used. The check no-ops when
+                           no inventory is available.
 `;
 
 export function main(
@@ -1116,7 +1196,25 @@ export function main(
   const pageRaw = parsed.values["page"];
   const pageFilter = typeof pageRaw === "string" && pageRaw ? pageRaw : null;
 
-  const result = lintWiki(wikiRoot, category, pageFilter);
+  // Resolve the inventory snapshot: explicit --inventory-run-id wins;
+  // otherwise auto-discover the latest atlas run from events.jsonl.
+  // A missing/empty/zero-length run id is treated as "no inventory" —
+  // the references_inventory check silently no-ops in that case.
+  const explicitRunIdRaw = parsed.values["inventoryRunId"];
+  const explicitRunId =
+    typeof explicitRunIdRaw === "string" && explicitRunIdRaw.length > 0
+      ? explicitRunIdRaw
+      : null;
+  const inventoryRunId =
+    explicitRunId !== null
+      ? explicitRunId
+      : getLastAtlasRunId(wikiRoot) || null;
+  const inventory =
+    inventoryRunId !== null && inventoryRunId.length > 0
+      ? loadInventory(wikiRoot, inventoryRunId)
+      : null;
+
+  const result = lintWiki(wikiRoot, category, pageFilter, inventory);
   process.stdout.write(JSON.stringify(result, null, 2) + "\n");
   return 0;
 }

--- a/skills/doc-wiki/scripts/tests/atlas_orchestrator.test.ts
+++ b/skills/doc-wiki/scripts/tests/atlas_orchestrator.test.ts
@@ -3,7 +3,7 @@
  * `/doc-wiki:atlas` skill orchestrator. State detection, page counting,
  * cost estimation, and plan-snapshot persistence.
  */
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import * as yaml from "js-yaml";
@@ -20,7 +20,12 @@ import {
   getRollingPerIngestAvg,
   assembleGapReport,
   renderGapReportMarkdown,
+  main,
 } from "../atlas_orchestrator.js";
+import {
+  generateInventory,
+  persistInventory,
+} from "../../../../agents/lib/atlas_inventory.js";
 import {
   makeTmpPath,
   cleanupTmpPath,
@@ -733,5 +738,109 @@ describe("renderGapReportMarkdown", () => {
     );
     expect(md).toContain("- GET /api/users (src/routes/users.ts:42)");
     expect(md).toContain("- gather() at src/orchestrator.ts:18");
+  });
+});
+
+describe("main() compute-sources subcommand", () => {
+  let tmpPath: string;
+  let wikiRoot: string;
+  let stdoutChunks: string[];
+  let stderrChunks: string[];
+  let stdoutSpy: ReturnType<typeof vi.spyOn>;
+  let stderrSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    tmpPath = makeTmpPath("atlas-orch-cs-");
+    wikiRoot = makeInitializedWiki(tmpPath);
+    stdoutChunks = [];
+    stderrChunks = [];
+    stdoutSpy = vi.spyOn(process.stdout, "write").mockImplementation((chunk) => {
+      stdoutChunks.push(chunk.toString());
+      return true;
+    });
+    stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation((chunk) => {
+      stderrChunks.push(chunk.toString());
+      return true;
+    });
+  });
+  afterEach(() => {
+    stdoutSpy.mockRestore();
+    stderrSpy.mockRestore();
+    cleanupTmpPath(tmpPath);
+  });
+
+  function persistInventoryWith(overrides: {
+    runId: string;
+    orm?: Array<{ class_name: string; source_file: string }>;
+    rest?: Array<{ method: string; path: string; file: string }>;
+  }): void {
+    const inv = generateInventory(wikiRoot, overrides.runId);
+    inv.orm_entities = (overrides.orm ?? []).map((e) => ({
+      profile: "sqlalchemy",
+      class_name: e.class_name,
+      table_name: e.class_name.toLowerCase(),
+      schema_name: "",
+      source_file: e.source_file,
+      columns: [],
+      relationships: [],
+    }));
+    inv.rest_endpoints = (overrides.rest ?? []).map((r) => ({
+      framework: "fastapi",
+      method: r.method,
+      path: r.path,
+      file: r.file,
+      line: 1,
+    }));
+    persistInventory(wikiRoot, inv);
+  }
+
+  it("groups orm and rest entries by topic+facet", () => {
+    persistInventoryWith({
+      runId: "2026-05-03T00-00-00",
+      orm: [{ class_name: "User", source_file: "src/auth/models.py" }],
+      rest: [{ method: "GET", path: "/x", file: "src/billing/api.ts" }],
+    });
+    const exit = main([
+      "compute-sources",
+      "--wiki-root", wikiRoot,
+      "--run-id", "2026-05-03T00-00-00",
+      "--topics", "auth,billing",
+    ]);
+    expect(exit).toBe(0);
+    const out = JSON.parse(stdoutChunks.join("").trim()) as Record<string, unknown>;
+    expect(out["auth"]).toEqual({ "data-model": ["src/auth/models.py"], api: [] });
+    expect(out["billing"]).toEqual({ "data-model": [], api: ["src/billing/api.ts"] });
+  });
+
+  it("emits empty {} when the manifest is missing (non-fatal fallback)", () => {
+    const exit = main([
+      "compute-sources",
+      "--wiki-root", wikiRoot,
+      "--run-id", "2026-05-03T99-99-99",
+      "--topics", "auth",
+    ]);
+    expect(exit).toBe(0);
+    expect(stdoutChunks.join("").trim()).toBe("{}");
+  });
+
+  it("rejects missing --topics", () => {
+    persistInventoryWith({ runId: "2026-05-03T00-00-00" });
+    const exit = main([
+      "compute-sources",
+      "--wiki-root", wikiRoot,
+      "--run-id", "2026-05-03T00-00-00",
+    ]);
+    expect(exit).toBe(2);
+    expect(stderrChunks.join("")).toContain("--topics is required");
+  });
+
+  it("rejects missing --run-id", () => {
+    const exit = main([
+      "compute-sources",
+      "--wiki-root", wikiRoot,
+      "--topics", "auth",
+    ]);
+    expect(exit).toBe(2);
+    expect(stderrChunks.join("")).toContain("--run-id is required");
   });
 });

--- a/skills/doc-wiki/scripts/tests/lint_checks.test.ts
+++ b/skills/doc-wiki/scripts/tests/lint_checks.test.ts
@@ -22,11 +22,13 @@ import {
   checkOrmMappingFreshness,
   checkOrphans,
   checkProvenanceCompleteness,
+  checkReferencesInventory,
   checkStaleContent,
   checkSummariesSync,
   checkThinClusters,
   lintWiki,
 } from "../lint_checks.js";
+import { type CodeInventory } from "../../../../agents/lib/atlas_inventory.js";
 import {
   SCRIPTS_DIR,
   makeInitializedWiki,
@@ -307,6 +309,140 @@ describe("TestCheckCodeRefDrift", () => {
     const issues = checkCodeRefDrift(wiki);
     const refIssues = issues.filter((i) => i.page.includes("ref.md"));
     expect(refIssues).toEqual([]);
+  });
+});
+
+describe("TestCheckReferencesInventory", () => {
+  let tmpPath: string;
+  let wiki: string;
+
+  beforeEach(() => {
+    tmpPath = makeTmpPath("lint-refs-inv-");
+    wiki = makeInitializedWiki(tmpPath);
+  });
+  afterEach(() => {
+    cleanupTmpPath(tmpPath);
+  });
+
+  function makeInventory(overrides: {
+    orm?: string[];
+    rest?: string[];
+    clients?: string[];
+    manifests?: string[];
+  } = {}): CodeInventory {
+    return {
+      atlas_run_id: "2026-05-03T00-00-00",
+      generated_at: "2026-05-03T00:00:00.000Z",
+      repo_root: wiki,
+      project_metadata: {
+        name: "x",
+        version: "0.0.0",
+        language: "unknown",
+        runtime: "",
+        manifests_seen: overrides.manifests ?? [],
+      },
+      orm_entities: (overrides.orm ?? []).map((source_file) => ({
+        profile: "sqlalchemy",
+        class_name: "X",
+        table_name: "x",
+        schema_name: "",
+        source_file,
+        columns: [],
+        relationships: [],
+      })),
+      rest_endpoints: (overrides.rest ?? []).map((file) => ({
+        framework: "fastapi",
+        method: "GET",
+        path: "/x",
+        file,
+        line: 1,
+      })),
+      code_clients: (overrides.clients ?? []).map((file) => ({
+        kind: "gather",
+        file,
+        line: 1,
+      })),
+      stats: { files_walked: 0, files_skipped_for_size: 0, duration_ms: 0 },
+      notes: [],
+    };
+  }
+
+  function pageWithRefs(name: string, refs: Array<{ path: string }>): void {
+    const fm = fullFm({ references: refs });
+    writePage(path.join(wiki, "wiki", name), fm, "body\n");
+  }
+
+  it("flags references whose path is absent from every inventory bucket", () => {
+    pageWithRefs("ref.md", [{ path: "src/missing.py" }]);
+    const inv = makeInventory({ orm: ["src/auth.py"] });
+    const issues = checkReferencesInventory(wiki, undefined, inv);
+    expect(issues).toHaveLength(1);
+    expect(issues[0]?.severity).toBe("warning");
+    expect(issues[0]?.category).toBe("references_inventory");
+    expect(issues[0]?.detail).toContain("src/missing.py");
+  });
+
+  it("accepts paths in orm_entities, rest_endpoints, code_clients, and manifests_seen", () => {
+    pageWithRefs("p1.md", [{ path: "src/auth/models.py" }]);
+    pageWithRefs("p2.md", [{ path: "src/billing/api.ts" }]);
+    pageWithRefs("p3.md", [{ path: "src/orchestrator.ts" }]);
+    pageWithRefs("p4.md", [{ path: "package.json" }]);
+    const inv = makeInventory({
+      orm: ["src/auth/models.py"],
+      rest: ["src/billing/api.ts"],
+      clients: ["src/orchestrator.ts"],
+      manifests: ["package.json"],
+    });
+    const issues = checkReferencesInventory(wiki, undefined, inv);
+    expect(issues).toEqual([]);
+  });
+
+  it("returns no issues when no inventory is provided", () => {
+    pageWithRefs("ref.md", [{ path: "src/missing.py" }]);
+    expect(checkReferencesInventory(wiki, undefined, null)).toEqual([]);
+    expect(checkReferencesInventory(wiki)).toEqual([]);
+  });
+
+  it("flags only the offending refs when a page mixes valid and invalid", () => {
+    pageWithRefs("ref.md", [
+      { path: "src/auth/models.py" },
+      { path: "src/missing.py" },
+      { path: "src/also-missing.py" },
+    ]);
+    const inv = makeInventory({ orm: ["src/auth/models.py"] });
+    const issues = checkReferencesInventory(wiki, undefined, inv);
+    expect(issues).toHaveLength(2);
+    const detailJoined = issues.map((i) => i.detail).join("|");
+    expect(detailJoined).toContain("src/missing.py");
+    expect(detailJoined).toContain("src/also-missing.py");
+    expect(detailJoined).not.toContain("src/auth/models.py");
+  });
+
+  it("ignores pages without a references field", () => {
+    writePage(
+      path.join(wiki, "wiki", "plain.md"),
+      fullFm(),
+      "no references frontmatter\n",
+    );
+    const inv = makeInventory();
+    expect(checkReferencesInventory(wiki, undefined, inv)).toEqual([]);
+  });
+
+  it("skips malformed references entries silently", () => {
+    pageWithRefs("ref.md", [
+      { path: "src/missing.py" },
+    ]);
+    // Append a non-object entry directly so YAML preserves the malformed shape.
+    const refsManual = path.join(wiki, "wiki", "weird.md");
+    const fm = fullFm({ references: [null, "string-not-object", { other: "no-path" }] });
+    writePage(refsManual, fm, "weird refs\n");
+
+    const inv = makeInventory();
+    const issues = checkReferencesInventory(wiki, undefined, inv);
+    // Only ref.md's missing.py should fire; weird.md's malformed entries
+    // are silently skipped (no path field, no string entry, no null entry).
+    expect(issues).toHaveLength(1);
+    expect(issues[0]?.page.endsWith("ref.md")).toBe(true);
   });
 });
 
@@ -869,6 +1005,72 @@ describe("TestLintChecksCLI", () => {
     const result = runCli(CLI, ["--help"]);
     expect(result.status).toBe(0);
     expect(result.stdout).toContain("--page PAGE");
+  });
+
+  it("test_cli_inventory_run_id_drives_references_inventory_check", () => {
+    // Persist a manifest at <wiki>/outputs/atlas/<run-id>/code-inventory.json
+    // that knows about src/auth/models.py. Then write a wiki page that
+    // references both that file (valid) and src/missing.py (invalid).
+    const runId = "2026-05-03T00-00-00";
+    const inv = {
+      atlas_run_id: runId,
+      generated_at: "2026-05-03T00:00:00.000Z",
+      repo_root: wiki,
+      project_metadata: {
+        name: "x",
+        version: "0.0.0",
+        language: "unknown",
+        runtime: "",
+        manifests_seen: ["package.json"],
+      },
+      orm_entities: [
+        {
+          profile: "sqlalchemy",
+          class_name: "User",
+          table_name: "users",
+          schema_name: "",
+          source_file: "src/auth/models.py",
+          columns: [],
+          relationships: [],
+        },
+      ],
+      rest_endpoints: [],
+      code_clients: [],
+      stats: { files_walked: 0, files_skipped_for_size: 0, duration_ms: 0 },
+      notes: [],
+    };
+    const manifestPath = path.join(
+      wiki,
+      "outputs",
+      "atlas",
+      runId,
+      "code-inventory.json",
+    );
+    fs.mkdirSync(path.dirname(manifestPath), { recursive: true });
+    fs.writeFileSync(manifestPath, JSON.stringify(inv));
+
+    const fm = fullFm({
+      references: [
+        { path: "src/auth/models.py" },
+        { path: "src/missing.py" },
+      ],
+    });
+    writePage(path.join(wiki, "wiki", "ref.md"), fm, "body\n");
+
+    const result = runCli(CLI, [
+      "--wiki-root", wiki,
+      "--category", "references_inventory",
+      "--inventory-run-id", runId,
+    ]);
+    expect(result.status).toBe(0);
+    const data = JSON.parse(result.stdout) as {
+      issues: Array<{ category: string; detail: string }>;
+    };
+    const refIssues = data.issues.filter(
+      (i) => i.category === "references_inventory",
+    );
+    expect(refIssues).toHaveLength(1);
+    expect(refIssues[0]?.detail).toContain("src/missing.py");
   });
 
 });


### PR DESCRIPTION
## Summary

Closes the **Atlas — manifest consumers (quality)** sub-section in [`ROADMAP.md`](https://github.com/narailabs/doc-wiki/blob/main/ROADMAP.md)'s "Before main release" milestone. Two cohesive items, two commits.

### 53bb229 — Phase 6 manifest-driven sources

The "Phase 6 source heuristics" exist today only as prose in `SKILL.md:223` — the LLM orchestrator hand-builds the per-`(topic, facet)` source list. For the two facets that the Phase-1b inventory already models structurally (`data-model` and `api`), this commit replaces the LLM glob with deterministic manifest lookups.

- New helper `groupManifestByTopicFacet(inventory, topics)` in `agents/lib/atlas_synthesize.ts`. Path-based topic extraction recognises `src` / `app` / `apps` / `services` / `lib` / `internal` / `pkg` / `packages` / `modules` / `cmd` (matching Phase 2 topic discovery) and applies the same `-service` / `-svc` / `-module` suffix-strip canonicalization.
- New `atlas_orchestrator.js compute-sources --wiki-root --run-id --topics <csv>` subcommand so the LLM orchestrator can call the helper during Phase 4 plan-building.
- SKILL.md Phase 4 prose updated. The other three facets (`architecture`, `environments`, `operations`) keep the existing heuristics — the manifest doesn't model them today; that's v2.

### c978f78 — Lint references-inventory check

A page's `references:` frontmatter is supposed to point to code files the inventory has walked. When it doesn't, the code-locality reference is silently stale.

- New `references_inventory` lint check (`warning`-severity) flags entries whose `path` isn't in the union of `inventory.orm_entities[].source_file` / `rest_endpoints[].file` / `code_clients[].file` / `project_metadata.manifests_seen`.
- `lintWiki()` gains an optional `inventory` parameter; `lint_checks.js` gains an `--inventory-run-id <id>` CLI flag. When absent, the latest atlas run is auto-resolved via the existing `getLastAtlasRunId` helper in `atlas_orchestrator.ts`. With no inventory available at all, the check silently no-ops — lint stays usable in CI gates that don't run atlas.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run build` — clean (`.js` files updated)
- [x] `npm test` — 1129 passed, 5 skipped (was 1107, +22: 11 helper tests for the topic grouper, 4 CLI tests for `compute-sources`, 6 unit tests for the lint check, 1 CLI smoke test)