### PR TITLE
docs: atlas walkthrough + ecosystem.rest config + custom REST profile guide

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -13,6 +13,7 @@ This directory holds the public-facing documentation for doc-wiki. The internal 
 | Configure `wiki.config.yaml` or connector access | [`configuration.md`](configuration.md) |
 | Understand how doc-wiki is built | [`architecture.md`](architecture.md) |
 | Understand how doc-wiki talks to external services | [`connectors.md`](connectors.md) |
+| Author a custom REST profile for atlas inventory | [`rest-profiles.md`](rest-profiles.md) |
 | Diagnose a failure | [`troubleshooting.md`](troubleshooting.md) |
 
 ## Documents
@@ -23,6 +24,7 @@ This directory holds the public-facing documentation for doc-wiki. The internal 
 | [`commands.md`](commands.md) | Operators | All 10 `/doc-wiki:*` commands with synopsis, args, examples, and links to the orchestrator skill |
 | [`atlas.md`](atlas.md) | Operators | The eight-phase `/doc-wiki:atlas` walkthrough — what each phase does, what it writes, how to resume |
 | [`configuration.md`](configuration.md) | Operators / contributors | Schema reference for `wiki.config.yaml` and `.connectors/config.yaml`, plus credential-ref grammar |
+| [`rest-profiles.md`](rest-profiles.md) | Contributors / integrators | How to author a custom REST profile — schema, regex grouping, `default_method`, `file_prefix`, with worked examples |
 | [`architecture.md`](architecture.md) | Contributors / integrators | Three-layer model, ingest pipeline, scripts/agents/libraries inventory, Mermaid diagrams, architecture contracts |
 | [`connectors.md`](connectors.md) | Contributors / integrators | The `narai-primitives` stack — hub, toolkit, config, 7 connectors, `@narai/credential-providers` |
 | [`troubleshooting.md`](troubleshooting.md) | Anyone hitting an error | Common failures and how to fix them |

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,6 +9,7 @@ This directory holds the public-facing documentation for doc-wiki. The internal 
 | Run through the full lifecycle on a new codebase, step by step | [`../WALKTHROUGH.md`](../WALKTHROUGH.md) |
 | Install doc-wiki and run your first command | [`getting-started.md`](getting-started.md) |
 | Look up what a `/doc-wiki:*` command does | [`commands.md`](commands.md) |
+| Document an entire codebase in one pass | [`atlas.md`](atlas.md) |
 | Configure `wiki.config.yaml` or connector access | [`configuration.md`](configuration.md) |
 | Understand how doc-wiki is built | [`architecture.md`](architecture.md) |
 | Understand how doc-wiki talks to external services | [`connectors.md`](connectors.md) |
@@ -20,6 +21,7 @@ This directory holds the public-facing documentation for doc-wiki. The internal 
 |---|---|---|
 | [`getting-started.md`](getting-started.md) | New users | Prereqs, install, `/doc-wiki:init`, `/doc-wiki:onboard`, first `/doc-wiki:ingest`, verifying it worked |
 | [`commands.md`](commands.md) | Operators | All 10 `/doc-wiki:*` commands with synopsis, args, examples, and links to the orchestrator skill |
+| [`atlas.md`](atlas.md) | Operators | The eight-phase `/doc-wiki:atlas` walkthrough — what each phase does, what it writes, how to resume |
 | [`configuration.md`](configuration.md) | Operators / contributors | Schema reference for `wiki.config.yaml` and `.connectors/config.yaml`, plus credential-ref grammar |
 | [`architecture.md`](architecture.md) | Contributors / integrators | Three-layer model, ingest pipeline, scripts/agents/libraries inventory, Mermaid diagrams, architecture contracts |
 | [`connectors.md`](connectors.md) | Contributors / integrators | The `narai-primitives` stack — hub, toolkit, config, 7 connectors, `@narai/credential-providers` |

--- a/docs/atlas.md
+++ b/docs/atlas.md
@@ -1,0 +1,255 @@
+# `/doc-wiki:atlas`
+
+`/doc-wiki:atlas` is the meta-orchestrator that documents an entire codebase in one phased pass. It does not replace [`/doc-wiki:ingest`](commands.md#doc-wikiingest--fetch-extract-compile) — it batches it across discovered topics and facets, then synthesizes global aggregation pages on top.
+
+This document is the operator-facing walkthrough of the eight phases. The architectural overview (with a Mermaid pipeline diagram) lives in [`architecture.md` § Diagram 4](architecture.md#diagram-4-doc-wikiatlas-pipeline); the orchestrator's full prose prompt is the canonical reference at [`SKILL.md` § /doc-wiki:atlas](../skills/doc-wiki/SKILL.md). Use this doc when you want to know what each phase does, what it writes to disk, and how to reason about cost and resumption.
+
+## Table of contents
+
+- [What it does](#what-it-does)
+- [Prerequisites](#prerequisites)
+- [Quickstart](#quickstart)
+- [The eight phases](#the-eight-phases)
+  - [Phase 1 — Detect state](#phase-1--detect-state)
+  - [Phase 1b — Inventory the repo](#phase-1b--inventory-the-repo)
+  - [Phase 2 — Discover topics](#phase-2--discover-topics)
+  - [Phase 3 — Confirm topics](#phase-3--confirm-topics)
+  - [Phase 4 — Estimate cost](#phase-4--estimate-cost)
+  - [Phase 5 — Validate existing](#phase-5--validate-existing)
+  - [Phase 6 — Bootstrap / refresh](#phase-6--bootstrap--refresh)
+  - [Phase 7 — Synthesize globals](#phase-7--synthesize-globals)
+  - [Phase 8 — Finalize](#phase-8--finalize)
+- [Configuration](#configuration)
+- [Output structure](#output-structure)
+- [Resuming a partial run](#resuming-a-partial-run)
+- [Cost and cap](#cost-and-cap)
+- [Related commands](#related-commands)
+
+## What it does
+
+A single `/doc-wiki:atlas` invocation runs eight serial phases. The first four prepare a plan; the next three execute it; the last finalizes outputs and emits drift / cost reports.
+
+| # | Phase | Driver | Output |
+|---|---|---|---|
+| 1 | Detect state | `atlas_orchestrator.js detect-state` | wiki state (`fresh` / `existing` / `hybrid`) |
+| 1b | Inventory the repo | `atlas_inventory.js generate` | `wiki/outputs/atlas/<run-id>/code-inventory.json` |
+| 2 | Discover topics | LLM (orchestrator skill) | merged topic list |
+| 3 | Confirm topics | LLM, autonomy-gated | committed topic list |
+| 4 | Estimate cost | `atlas_orchestrator.js estimate-cost` + `compute-sources` | `Plan` JSON + `CostEstimate` |
+| 5 | Validate existing | LLM + `atlas_validate.js` + `atlas_gitlog.js` | drift report |
+| 6 | Bootstrap / refresh | per-topic-facet `/doc-wiki:ingest` and `/doc-wiki:refresh` | per-topic atlas pages |
+| 7 | Synthesize globals | LLM over `atlas_synthesize.js` bundles | `wiki/overview.md`, `integrations.md`, `deploy.md`, etc. |
+| 8 | Finalize | `lint_checks.js` + index update + crosslink + `op: atlas` event | gap report, drift report, cost report |
+
+Per-topic ingests in Phase 6 may run in parallel within the phase boundary (default concurrency 3). Everything else is serial.
+
+## Prerequisites
+
+Before `/doc-wiki:atlas` can run productively:
+
+- The wiki has been initialized — [`/doc-wiki:init`](commands.md#doc-wikiinit--bootstrap-a-wiki) has populated `wiki.config.yaml`.
+- Connectors are configured if you intend to ingest from external services — [`/doc-wiki:onboard`](commands.md#doc-wikionboard--interactive-onboarding) has written `~/.connectors/config.yaml` (see [`configuration.md`](configuration.md) and [`connectors.md`](connectors.md)).
+- The repo is at the ref you want to document. Atlas does not reset or stash; uncommitted edits are inventoried as-is.
+
+For real LLM-driven runs, your Anthropic credentials must be available to Claude Code. `--dry-run` skips every LLM call.
+
+## Quickstart
+
+The default invocation is the right one for a fresh wiki:
+
+```bash
+/doc-wiki:atlas
+```
+
+Atlas will detect that the wiki is `fresh`, walk you through topic discovery (Phase 3 prompts unless `autonomy.mode` is `auto` or you pass `--yes`), display a cost estimate, and run the full pipeline.
+
+For an iteration on an existing wiki:
+
+```bash
+/doc-wiki:atlas --since 7d
+```
+
+This looks at gitlog churn since seven days ago to scope which topics need refreshing, then re-runs Phases 4–8 with that narrower scope. The full synopsis and flag reference is in [`commands.md` § /doc-wiki:atlas](commands.md#doc-wikiatlas--full-application-documentation).
+
+## The eight phases
+
+### Phase 1 — Detect state
+
+Decides what mode atlas runs in:
+
+- **fresh** — the wiki has fewer than three pages tagged `atlas: true` AND no prior `op: atlas` event in `log/events.jsonl`. Phase 5 is skipped; everything is bootstrapped.
+- **existing** — at least three atlas pages AND a prior atlas event. Run the full pipeline including Phase 5 validation.
+- **hybrid** — pages exist but no prior atlas event (manual ingests only). Phase 5 runs but skips semantic checks on pages without `atlas_run_id` frontmatter.
+
+The `atlas_run_id` (format `YYYY-MM-DDTHH-MM-SS`) is minted at the end of Phase 1 and reused across every artifact below — inventory, plan snapshot, drift report, cost report, gap report.
+
+Driver: [`skills/doc-wiki/scripts/atlas_orchestrator.ts`](../skills/doc-wiki/scripts/atlas_orchestrator.ts) `detect-state`.
+
+### Phase 1b — Inventory the repo
+
+Walks the repo once and emits a four-bucket manifest at `wiki/outputs/atlas/<run-id>/code-inventory.json`:
+
+- `project_metadata` — name / version / language / runtime parsed from `package.json`, `pyproject.toml`, `go.mod`, `Cargo.toml`.
+- `orm_entities` — every entity discovered by the [`wiki_orm` library](architecture.md#3c-shared-libraries) (seven shipped profiles: SQLAlchemy, Django, JPA, Prisma, TypeORM, ActiveRecord, Entity Framework).
+- `rest_endpoints` — HTTP routes from eighteen shipped REST profiles spanning Python / TypeScript / Java / Ruby / Go / PHP / C# / Rust / Elixir / Swift. Opt-in via `ecosystem.rest.enabled: true` in `wiki.config.yaml` (see [`configuration.md`](configuration.md#ecosystem-section)).
+- `code_clients` — `gather()` and `fetchWithCaps()` callsites — anywhere doc-wiki's connector primitives are invoked.
+
+Custom REST profiles authored inline under `ecosystem.rest.custom_profiles` are loaded automatically — see the [REST profile authoring guide](rest-profiles.md). Endpoints from overlapping profiles are deduplicated by `(file, line, method, path)`.
+
+The manifest feeds:
+
+- **Phase 4** cost estimate, where `data-model` and `api` facet sources come from `compute-sources` (manifest lookups) instead of glob heuristics. Other facets stay on heuristics; the manifest doesn't model them.
+- **Phase 8** gap report, which lists endpoints and code-client callsites without documentation.
+- **`/doc-wiki:lint`**'s `references_inventory` check, which flags page `references:` entries that point to files the manifest never saw.
+
+Driver: [`agents/lib/atlas_inventory.ts`](../agents/lib/atlas_inventory.ts) `generate`.
+
+A missing manifest is non-fatal — every consumer falls back to its pre-inventory behavior, so an interrupted Phase 1b just means Phase 4/6 use heuristic source lists for that run.
+
+### Phase 2 — Discover topics
+
+The orchestrator skill unions five signals into one deduplicated list:
+
+- **Code dirs** — top-level subdirectories of `src/`, `app/`, `services/`, etc., minus vendored / `node_modules` / `.git`.
+- **ORM domains** — entities from the inventory, grouped into topic candidates by name (e.g. `User` → `auth`, `Invoice` → `billing`).
+- **Existing wiki dirs** — `wiki/<topic>/` subdirectories already on disk.
+- **Gitlog churn** — `atlas_gitlog.js classify` flags paths whose changes haven't propagated to documentation.
+- **Tooling / CLI repos** — when `domain: tooling` is set in `wiki.config.yaml` AND the repo has a top-level `commands/` directory, every `commands/*.md` slug becomes a topic candidate so each slash command can have its own architecture page.
+
+Each candidate is canonicalized: lowercase-kebab-case, with `-service`, `-svc`, `-module` suffixes stripped. Deduplication is on the canonical name.
+
+### Phase 3 — Confirm topics
+
+The merged list is presented with provenance — which signals contributed each topic. Behavior depends on autonomy:
+
+- `balanced` and stricter — prompt `Generate atlas pages for these topics? [Y/n/edit]`.
+- `auto` / `autonomous` — proceed silently.
+- `--yes` flag — skip the prompt regardless of mode.
+
+The confirmed list becomes the canonical topic set for the rest of the run.
+
+### Phase 4 — Estimate cost
+
+Two sub-steps:
+
+1. **Build the plan.** The orchestrator constructs a `Plan` JSON: `{ topics, facets, entries: [{topic, facet, sources, output}], created_at }`. For the manifest-backed facets (`data-model` and `api`), `entry.sources` is populated by `atlas_orchestrator.js compute-sources --wiki-root <p> --run-id <id> --topics <csv>`, which returns a `topic → facet → file[]` map drawn from the Phase 1b inventory. For `architecture`, `environments`, and `operations`, sources come from glob heuristics (`src/<topic>/`, `.env*`/`config/<topic>*`, runbook directories) — the manifest doesn't model them yet.
+2. **Estimate.** `atlas_orchestrator.js estimate-cost --wiki-root <p> --plan '<json>'` rolls a per-ingest average over recent `op: ingest` events in `log/events.jsonl` and multiplies it by the entry count, plus a fixed allowance for Phase 7 globals.
+
+If `total_estimated_usd > --max-cost`, the run aborts with a hint to re-invoke at a higher cap. Default `--max-cost` is conservative (see [`commands.md`](commands.md#doc-wikiatlas--full-application-documentation)).
+
+The plan is also persisted at `wiki/outputs/atlas/<run-id>/plan.json` so `--resume` can pick up where Phase 6 left off without re-discovering topics.
+
+### Phase 5 — Validate existing
+
+Skipped when state is `fresh`. Otherwise:
+
+- **Structural** — for each existing atlas page, `atlas_validate.js structural` runs the lint subset relevant to atlas frontmatter (atlas tag, run id, facet, sources). Failures surface in the drift report.
+- **Gitlog drift** — `atlas_gitlog.js classify` returns `{stale_pages, uncovered_files, unrelated_files}` since `--since`. Stale = page references a file that has changed; uncovered = file is under a current-run topic but no atlas page exists yet; unrelated = neither.
+- **Semantic check** — when state is `existing` or `hybrid`, the orchestrator compares each page's content to its current sources. The `(page-hash, source-hash)` cache in `atlas_validate.js` skips pages whose inputs haven't moved.
+
+The drift report is written at `wiki/outputs/atlas/<run-id>/drift-report.md`.
+
+### Phase 6 — Bootstrap / refresh
+
+For each `(topic, facet)` entry in the plan:
+
+- `state == fresh` or no existing page for the entry — dispatch `/doc-wiki:ingest` against the entry's sources, with `--output wiki/<topic>/<facet>.md` so the destination is pinned.
+- Existing page that is stale or under-covered — dispatch `/doc-wiki:refresh --source <ref>`.
+
+Per-entry ingests honor `--scope <topic>` and `--facets <list>`; out-of-scope work is simply not iterated. Default concurrency is 3 — three entries run in parallel, balancing throughput against connector rate limits.
+
+If an entry fails (connector error, ingest error, LLM timeout), atlas logs the error to `wiki/outputs/atlas/<run-id>/errors.jsonl` and continues. Disk and permission errors hard-abort with a checkpoint save (see [Resuming a partial run](#resuming-a-partial-run)).
+
+### Phase 7 — Synthesize globals
+
+Three to seven global pages are regenerated every time, regardless of `--facets` and `--scope` — reading already-on-disk topic pages is cheap (~$0.30 total). The bundles are assembled by [`agents/lib/atlas_synthesize.ts`](../agents/lib/atlas_synthesize.ts):
+
+| Global page | Bundle | What it summarises |
+|---|---|---|
+| `wiki/overview.md` | `assembleOverviewInputs` | One-page architecture + audience-aware TL;DRs per facet |
+| `wiki/integrations.md` | `assembleIntegrationsInputs` | API pages + external-service mentions + connector config |
+| `wiki/deploy.md` | `assembleDeployInputs` | Dockerfile, compose, workflows, terraform |
+| `wiki/commands.md` | `assembleCommandsInputs` | Per-command lifecycle (only when the repo has a `commands/` directory) |
+| `wiki/getting-started.md` | `assembleGettingStartedInputs` | First-run install / quickstart |
+| `wiki/configuration.md` | `assembleConfigurationInputs` | Top-level config files |
+| `wiki/troubleshooting.md` | `assembleTroubleshootingInputs` | Recent error events + drift highlights |
+
+Each bundle is read-only — the assembly walks the wiki and the repo for inputs, hands them to the LLM, and writes the synthesized page back. Source paths are recorded in each global's `sources:` frontmatter so [`/doc-wiki:lint`](commands.md#doc-wikilint--health-check-and-auto-heal)'s `code_ref_drift` and `references_inventory` checks can flag staleness on the next run.
+
+### Phase 8 — Finalize
+
+Five deterministic steps:
+
+1. `lint_checks.js` runs the full check suite, including the new `references_inventory` check that pulls the run's manifest.
+2. `wiki/index.md` is updated to list all atlas-tagged pages.
+3. The post-op crosslink + tag-harmonize pass runs (skipped when wiki has fewer than three pages).
+4. An `op: atlas` event is appended to `log/events.jsonl` carrying the `atlas_run_id`, scope, and outcome counts.
+5. The gap report is written at `wiki/outputs/atlas/<run-id>/gap-report.md` (REST endpoints + code-client callsites without documentation, plus uncovered topics from gitlog).
+
+The cost report (actual vs estimated, per-entry breakdown) lands at `wiki/outputs/atlas/<run-id>/cost-report.md`.
+
+## Configuration
+
+Atlas reads from `wiki.config.yaml`. The relevant blocks:
+
+| Block | What it controls | See |
+|---|---|---|
+| `autonomy.mode` | Whether Phase 3 prompts and how Phase 8 lint fixes apply | [`configuration.md` § autonomy](configuration.md#autonomy-section) |
+| `ecosystem.orm` | Which ORM profiles drive Phase 1b entity discovery | [`configuration.md` § ecosystem](configuration.md#ecosystem-section) |
+| `ecosystem.rest` | Whether Phase 1b walks REST endpoints, and which custom profiles to load | [`configuration.md` § ecosystem.rest](configuration.md#ecosystem-section) and [`rest-profiles.md`](rest-profiles.md) |
+| `lint` | Per-category severity overrides applied in Phase 8 | [`configuration.md` § lint](configuration.md#lint-section) |
+
+CLI flags are documented in [`commands.md` § /doc-wiki:atlas](commands.md#doc-wikiatlas--full-application-documentation).
+
+## Output structure
+
+After a run completes:
+
+```
+wiki/
+├── overview.md, integrations.md, deploy.md, …  ← Phase 7 globals
+├── <topic>/<facet>.md                            ← Phase 6 per-topic atlas pages
+├── index.md                                      ← updated in Phase 8
+└── outputs/atlas/<run-id>/
+    ├── code-inventory.json   ← Phase 1b
+    ├── plan.json             ← Phase 4 plan snapshot
+    ├── drift-report.md       ← Phase 5 (existing/hybrid only)
+    ├── errors.jsonl          ← Phase 6 (only if any entry failed)
+    ├── gap-report.md         ← Phase 8
+    └── cost-report.md        ← Phase 8
+
+log/events.jsonl              ← appended every phase
+```
+
+The `outputs/atlas/<run-id>/` directory is the canonical artifact bundle for one run — `--resume` reads `plan.json` from here.
+
+## Resuming a partial run
+
+If atlas is interrupted (Ctrl-C, crash, disk full), the latest plan snapshot persists. Re-invoke with `--resume`:
+
+```bash
+/doc-wiki:atlas --resume
+```
+
+The run picks up at the first Phase 6 entry whose page was not committed. Re-discovery is suppressed — the saved plan is the contract; gitlog churn arriving between attempts does not expand scope. This is enforced by reading `wiki/outputs/atlas/<run-id>/plan.json` rather than re-running Phase 2.
+
+`--resume` operates on the most recent run id by default; pass an explicit `--run-id` to resume an older one.
+
+## Cost and cap
+
+Atlas spends LLM time mostly on Phases 6 and 7. Order of magnitude on a typical mid-sized repo:
+
+- Phase 1b inventory: $0 (deterministic).
+- Phase 2 topic discovery: ~$0.05–$0.20 depending on repo size.
+- Phase 5 validation: scales with the number of existing atlas pages, ~$0.01 per page.
+- Phase 6 per-entry ingest: ~$0.10–$0.50 per `(topic, facet)` pair, dominated by source-file size.
+- Phase 7 globals: ~$0.30 total.
+
+The `--max-cost` flag is your guard rail. The pre-Phase-6 estimate uses a rolling per-ingest average from your wiki's own history, so it sharpens over time.
+
+## Related commands
+
+- [`/doc-wiki:ingest`](commands.md#doc-wikiingest--fetch-extract-compile) — single-source compile; what Phase 6 dispatches per entry.
+- [`/doc-wiki:refresh`](commands.md#doc-wikirefresh--re-fetch-and-update) — re-fetch and update an existing page; used by Phase 6 for stale entries.
+- [`/doc-wiki:lint`](commands.md#doc-wikilint--health-check-and-auto-heal) — runs as part of Phase 8; the new `--inventory-run-id` flag scopes the `references_inventory` check to a specific atlas run.
+- [`/doc-wiki:query`](commands.md#doc-wikiquery--summary-first-search-synthesis-and-shortest-path) — interactive search over the resulting wiki.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -90,6 +90,10 @@ ecosystem:
     custom_profiles: []       # paths to additional profile YAML files
     cross_validate_against_db: true
 
+  rest:
+    enabled: false            # opt-in: when true, /doc-wiki:atlas Phase 1b inventory walks REST endpoints
+    custom_profiles: []       # zero or more inline RestProfile entries; same shape as agents/lib/rest_profiles/*.yaml
+
   claude_md:
     enabled: true
     submodule_support: true
@@ -105,6 +109,31 @@ ecosystem:
 The `ecosystem.agents.custom` block is how you register a custom local connector with doc-wiki — see [`connectors.md`](connectors.md#adding-a-custom-local-connector). Each entry maps URL patterns (or scheme prefixes) to the connector's invocation template; `source_registry.ts` uses these to classify sources during `/doc-wiki:ingest`.
 
 The `ecosystem.database` block configures `wiki-orm-agent`'s cross-validation flow against a live DB. The actual connection lives under `connectors.db` in `.connectors/config.yaml`; this block just enables the cross-validation behavior and defines a wiki-side audit log.
+
+The `ecosystem.rest` block controls REST-endpoint detection during `/doc-wiki:atlas` Phase 1b. It is **off by default** so the inventory step stays fast on repos that aren't HTTP services. Set `enabled: true` to opt in. The flag is read automatically by `atlas_inventory.js generate`, so the orchestrator doesn't have to know whether to pass `--enable-rest` — see [`atlas.md` § Phase 1b](atlas.md#phase-1b--inventory-the-repo). Override at the CLI with `--enable-rest` when needed regardless of config.
+
+`custom_profiles` is a list of inline [`RestProfile`](rest-profiles.md) objects — same shape as the YAML files under [`agents/lib/rest_profiles/`](../agents/lib/rest_profiles/). Custom profiles win on name collision with shipped profiles, so this slot is the right place to teach atlas about an in-house framework without modifying doc-wiki:
+
+```yaml
+ecosystem:
+  rest:
+    enabled: true
+    custom_profiles:
+      - name: company-rpc
+        language: typescript
+        description: "In-house RPC façade over Express"
+        detection:
+          file_patterns: ["**/*.ts"]
+          markers:
+            - { pattern: "@company/rpc-server", type: import }
+        endpoint_extraction:
+          patterns:
+            - regex: "rpc\\.(get|post|put|delete)\\s*\\(\\s*['\"`]([^'\"`]+)['\"`]"
+              method_group: 1
+              path_group: 2
+```
+
+Authoring a profile (regex grouping rules, the `default_method` and `file_prefix` schema extensions, how to dedupe) is documented in detail at [`rest-profiles.md`](rest-profiles.md).
 
 ### `autonomy` section
 

--- a/docs/rest-profiles.md
+++ b/docs/rest-profiles.md
@@ -1,0 +1,238 @@
+# Custom REST profiles
+
+A **REST profile** teaches `/doc-wiki:atlas`'s Phase 1b inventory how to recognise HTTP routes in a particular framework. Eighteen profiles ship with doc-wiki today (Express, FastAPI, Spring, Rails, Django, Flask, ASP.NET, Gin, Laravel, Hono, Fastify, Koa, Echo, Rocket, Actix, Slim, Phoenix, Vapor — see [`agents/lib/rest_profiles/`](../agents/lib/rest_profiles/)). When your repo uses a framework that isn't on that list — or an in-house RPC façade with a custom calling convention — author a profile so atlas can include those endpoints in the inventory and downstream gap report.
+
+## Table of contents
+
+- [Where profiles live](#where-profiles-live)
+- [The profile schema](#the-profile-schema)
+- [Authoring a profile end to end](#authoring-a-profile-end-to-end)
+- [Worked examples](#worked-examples)
+  - [Plain method-on-app routes (Express-style)](#plain-method-on-app-routes-express-style)
+  - [Annotation-attached routes (Spring-style)](#annotation-attached-routes-spring-style)
+  - [Default-GET routes (Flask-style)](#default-get-routes-flask-style)
+  - [Class-prefixed routes (ASP.NET-style)](#class-prefixed-routes-aspnet-style)
+- [Testing a profile](#testing-a-profile)
+- [What deduplication does](#what-deduplication-does)
+
+## Where profiles live
+
+| Source | Loaded by | When to use it |
+|---|---|---|
+| Shipped: [`agents/lib/rest_profiles/<name>.yaml`](../agents/lib/rest_profiles/) | Auto-discovered by `atlas_inventory.js` | A new well-known framework that should benefit every doc-wiki user. Send a PR. |
+| Custom: `ecosystem.rest.custom_profiles` in [`wiki.config.yaml`](configuration.md#ecosystem-section) | Read at inventory time, merged with shipped profiles | An in-house framework / RPC façade specific to your repo. Stays local. |
+
+Custom profiles win on name collision, so you can also override a shipped profile's matcher locally without touching the doc-wiki repo.
+
+## The profile schema
+
+A profile is a single YAML object with this shape:
+
+```yaml
+name: <string>            # unique identifier; collision-key against shipped profiles
+language: <string>        # "python" | "typescript" | "go" | "java" | … (informational)
+description: <string>     # one-line summary, surfaced in error messages
+
+detection:
+  file_patterns:          # globs handed to walkCodebase; the union across all profiles
+    - "**/*.ts"           #   is the file set walked once per atlas run
+  markers:                # cheap substring pre-filter; a file must contain
+    - pattern: <string>   #   at least one marker before regex extraction runs
+      type: <string>      # informational (`import`, `annotation`, `instantiation`, ...)
+
+endpoint_extraction:
+  file_prefix:            # OPTIONAL — see "Class-prefixed routes" below
+    regex: <string>
+    prefix_group: <int>
+    expand_controller_token: <bool>
+
+  patterns:               # one or more per-line regexes; each match is one endpoint
+    - regex: <string>
+      method_group: <int> # 1-indexed capture group of the HTTP verb;
+                          # 0 = no method captured (then default_method MUST be set)
+      path_group: <int>   # 1-indexed capture group of the URL path
+      default_method:     # OPTIONAL — used when method_group is 0
+        <string>
+```
+
+The TypeScript types are in [`agents/lib/atlas_inventory.ts`](../agents/lib/atlas_inventory.ts) (`RestProfile`, `endpoint_extraction.patterns`, `file_prefix`).
+
+A few rules the engine enforces:
+
+- **Markers are literal substrings**, not regex. Cheap `String.includes` test before the regex pass — files with no marker are skipped silently. Keep markers tight: an `import` line, a base class, a framework annotation. Avoid markers that might appear in a comment in unrelated files.
+- **Patterns are JavaScript regex applied per line.** Capture the method (when present) and the path. Both must be non-empty after capture or the match is dropped.
+- **Endpoints are deduplicated by `(file, line, method, path)` across all profiles.** A line matched by two profiles only emits one endpoint; the first profile wins on `framework`. See [What deduplication does](#what-deduplication-does).
+
+## Authoring a profile end to end
+
+The shortest path to a working custom profile:
+
+1. **Pick a representative file** in the target repo — one that you know contains routes the inventory should pick up.
+2. **Choose markers.** Read the framework's import statement and pick one or two unique-ish substrings. Wrong markers manifest as silent zero-extraction; check by removing the marker filter temporarily and seeing whether the regex matches.
+3. **Write the regex against one or two route lines.** Use [regex101.com](https://regex101.com/) or `node -e` to iterate. Capture the verb in one group and the path in another. For frameworks that omit the verb (path-only routes default to GET), set `method_group: 0` and `default_method: GET` (see [Flask-style](#default-get-routes-flask-style)).
+4. **Drop the YAML into `wiki.config.yaml`** under `ecosystem.rest.custom_profiles`. Set `ecosystem.rest.enabled: true` if it isn't already.
+5. **Run `atlas_inventory.js generate`** against the repo and inspect the resulting `code-inventory.json` for your endpoints.
+6. **Add a vitest fixture.** Even for custom profiles you don't intend to upstream, a tiny `it("extracts X routes", ...)` test in your project's own suite is worth ten minutes — it locks the regex in against framework upgrades.
+
+## Worked examples
+
+### Plain method-on-app routes (Express-style)
+
+The simplest shape. The verb and path are right next to each other on the same line:
+
+```javascript
+app.get('/api/users', handler);
+app.post("/api/users", handler);
+```
+
+Profile:
+
+```yaml
+name: express
+language: typescript
+description: "Express / Node.js HTTP routes"
+
+detection:
+  file_patterns:
+    - "**/*.ts"
+    - "**/*.js"
+  markers:
+    - { pattern: 'from "express"',  type: import }
+    - { pattern: "from 'express'",  type: import }
+    - { pattern: "require('express')", type: import }
+
+endpoint_extraction:
+  patterns:
+    - regex: "(?:app|router|api)\\.(get|post|put|delete|patch|options|head)\\s*\\(\\s*['\"`]([^'\"`]+)['\"`]"
+      method_group: 1
+      path_group: 2
+```
+
+Notes:
+
+- The `(?:app|router|api)` non-capturing group covers common variable names; tweak for your codebase.
+- The path's character class `[^'\"\`]+` matches inside any quote style without choking on the closing quote.
+
+### Annotation-attached routes (Spring-style)
+
+The verb is *part of the annotation name* (e.g. `@GetMapping`), and the path is the annotation's first quoted argument — possibly wrapped in `value =` or `path =`:
+
+```java
+@GetMapping("/api/users")
+@PostMapping(value = "/api/users")
+@PatchMapping(path = "/api/users/{id}")
+```
+
+Profile (this is the actual shipped Spring matcher):
+
+```yaml
+endpoint_extraction:
+  patterns:
+    - regex: "@(Get|Post|Put|Delete|Patch|Options|Head)Mapping\\s*\\(\\s*(?:(?:value|path)\\s*=\\s*)?[\"']([^\"']+)[\"']"
+      method_group: 1
+      path_group: 2
+```
+
+The `(?:(?:value|path)\\s*=\\s*)?` non-capturing optional handles both bare-arg and named-arg forms.
+
+### Default-GET routes (Flask-style)
+
+When the route declaration carries the path but not an explicit verb (Flask's `@app.route('/x')` defaults to GET if `methods=` is omitted), set `method_group: 0` and use `default_method`:
+
+```python
+@app.route("/api/health")
+def health(): pass
+```
+
+Profile fragment:
+
+```yaml
+endpoint_extraction:
+  patterns:
+    - regex: "@(?:app|bp|blueprint)\\.route\\s*\\(\\s*['\"]([^'\"]+)['\"]\\s*\\)"
+      method_group: 0
+      path_group: 1
+      default_method: GET
+```
+
+Notes:
+
+- The trailing `\\s*\\)` anchor is what keeps this pattern from also matching the explicit-`methods=` form (`@app.route("/x", methods=...)`) — the closing paren can't sit immediately after the path string when there are more arguments.
+- `method_group: 0` is the explicit "no method captured" sentinel. The engine reads `default_method` only in that case.
+
+### Class-prefixed routes (ASP.NET-style)
+
+When routes are scoped by a class-level annotation (ASP.NET's `[Route("api/users")]` above the controller), the per-method path is *relative*:
+
+```csharp
+[ApiController]
+[Route("api/users")]
+public class UsersController : ControllerBase
+{
+    [HttpGet]                       // → "api/users"
+    [HttpGet("{id:int}")]           // → "api/users/{id:int}"
+    [HttpDelete("/healthz")]        // → "/healthz"  (absolute path bypasses the prefix)
+}
+```
+
+Profile (this is the actual shipped ASP.NET matcher):
+
+```yaml
+endpoint_extraction:
+  file_prefix:
+    regex: "\\[Route\\s*\\(\\s*[\"']([^\"']+)[\"']\\s*\\)\\s*\\]"
+    prefix_group: 1
+    expand_controller_token: true
+
+  patterns:
+    - regex: "\\[Http(Get|Post|Put|Delete|Patch|Options|Head)(?:\\s*\\(\\s*[\"']([^\"']+)[\"']\\s*\\))?\\s*\\]"
+      method_group: 1
+      path_group: 2
+```
+
+Behavior:
+
+- `file_prefix.regex` runs once per file (not per line) — the first match's `prefix_group` capture becomes the prefix.
+- For each per-line pattern match: paths starting with `/` are absolute and bypass the prefix; empty paths (e.g. `[HttpGet]` with no argument) inherit the prefix as the full path; otherwise the prefix and path are joined with a single `/`.
+- `expand_controller_token: true` substitutes `[controller]` in the captured prefix with the controller class name (lowercased, `Controller` suffix stripped). So `[Route("api/[controller]")]` on `class AuthController` resolves to `api/auth`.
+
+If you don't need any of these — straight-line per-method routes with absolute paths — leave `file_prefix` out. The engine ignores it.
+
+## Testing a profile
+
+The shipped profiles are tested in [`agents/lib/tests/atlas_inventory.test.ts`](../agents/lib/tests/atlas_inventory.test.ts). The pattern is the same for any custom profile:
+
+```typescript
+import { describe, it, expect } from "vitest";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { detectRestEndpoints, loadRestProfile } from "../atlas_inventory.js";
+
+describe("custom company-rpc profile", () => {
+  it("extracts rpc.<verb> routes", () => {
+    const tmp = makeTmpDir();
+    fs.writeFileSync(
+      path.join(tmp, "service.ts"),
+      `import { rpc } from "@company/rpc-server";
+rpc.get('/api/widgets', listWidgets);
+rpc.post('/api/widgets', createWidget);
+`,
+    );
+    const profile = /* loaded from your wiki.config.yaml or inline */;
+    const eps = detectRestEndpoints(tmp, [profile]);
+    const tuples = eps.map((e) => `${e.method} ${e.path}`);
+    expect(tuples).toContain("GET /api/widgets");
+    expect(tuples).toContain("POST /api/widgets");
+  });
+});
+```
+
+For shipped profiles, also add a `loads cleanly from disk` smoke test (mirrors every existing profile's first `it()` block).
+
+## What deduplication does
+
+Endpoints are deduplicated across profiles by `(file, line, method, path)`. The first profile to match a given tuple wins — its `name` is recorded as the endpoint's `framework` field.
+
+This matters when you have overlapping matchers — e.g. both `express` and `hono` markers on the same file (rare but possible in libraries that re-export). The marker-pre-filter keeps non-matching files out, but for files that pass both filters, dedup ensures one endpoint, one framework. If the order matters to you, register your custom profile *before* the shipped one with the same matcher; custom profiles always win on name collision.
+
+The dedup key is intentionally narrow — same file, same line, same method, same path. Two routes on different lines with the same path (rare but legitimate, e.g. a router prefix mounted twice) are kept as distinct endpoints.


### PR DESCRIPTION
## Summary

Closes the **Documentation** sub-section in [`ROADMAP.md`](https://github.com/narailabs/doc-wiki/blob/main/ROADMAP.md)'s "Before main release" milestone. Three new docs in three commits, each independently reviewable.

### 5b1d4e0 — `docs/atlas.md`

The atlas command is the tentpole, but the only public prose for it lived as a one-line synopsis in `commands.md` with a link into `SKILL.md`. New operators had to read the orchestrator's prompt to understand what the eight phases do, what they write to disk, and how cost / resumption work.

`docs/atlas.md` is now the canonical operator walkthrough — a section per phase, an output-structure diagram, a "Resuming a partial run" section explaining the plan-snapshot contract, and order-of-magnitude cost numbers. The Mermaid pipeline diagram intentionally stays in `architecture.md § Diagram 4`; this doc cross-links to it.

### 7d10056 — `ecosystem.rest` in `docs/configuration.md`

The `ecosystem.rest` block was added in PR #14 (custom profiles) and PR #20 (auto-read by `atlas_inventory.js`), but the configuration reference still didn't describe it — deferred from PR #14. This commit adds the YAML block to the example, explains opt-in default-false semantics, and shows a real custom profile inline. Cross-links to `atlas.md § Phase 1b` and `rest-profiles.md`.

### 73d48a2 — `docs/rest-profiles.md`

The schema (markers + regex patterns) was already documented inline in the profile YAMLs and the engine's TypeScript types, but there was no public guide explaining the moving parts together — including the recently-added `default_method` and `file_prefix` extensions (PR #19).

Includes:
- Where shipped vs custom profiles live, and which wins on collision.
- Schema walkthrough.
- Step-by-step authoring path.
- Four worked examples covering the four route shapes the engine supports: plain method-on-app (Express), annotation-attached (Spring), default-GET (Flask), class-prefixed with `[controller]` expansion (ASP.NET).
- Testing pattern + dedup semantics.

`docs/README.md` is updated in commits 1 and 3 to surface the new docs in both routing tables.

## Test plan

- [x] `npm test` — 1129 passed (no engine changes, no new tests required)
- [x] `npm run typecheck` — clean
- [ ] Manual: render the three new docs on GitHub and check that all cross-links resolve. (`atlas.md` ↔ `commands.md`, `architecture.md`, `configuration.md`, `rest-profiles.md`; `rest-profiles.md` ↔ `atlas.md`, `configuration.md`, `agents/lib/...`.)