### PR TITLE
fix(skills): three eval-surfaced papercuts (event_logger --source, init_wiki --wiki-root, total_events)

### DIFF
--- a/skills/doc-wiki/scripts/event_logger.js
+++ b/skills/doc-wiki/scripts/event_logger.js
@@ -226,7 +226,7 @@ function median(values) {
  * Compute aggregate statistics from the event log.
  *
  * Returns a dict with:
- *   total_ops: number
+ *   total_events: number                            -- count of events in the window
  *   ops_by_type: { [op: string]: number }
  *   total_cost_usd: number
  *   reduction_ratio: { mean, p50, p95 } (only keys present when ratios > 0)
@@ -348,7 +348,7 @@ export function getStats(wikiRoot, since = null, opts = {}) {
         ratioStats["p95"] = sortedRatios[idx95] ?? 0;
     }
     const result = {
-        total_ops: events.length,
+        total_events: events.length,
         ops_by_type: opsByType,
         total_cost_usd: totalCost,
         reduction_ratio: ratioStats,
@@ -437,6 +437,9 @@ function parseArgs(argv) {
             case "since":
                 out.since = value ?? null;
                 break;
+            case "source":
+                out.source = value ?? "";
+                break;
             default:
                 throw new Error(`unrecognized argument: --${name}`);
         }
@@ -454,6 +457,14 @@ positional arguments:
 
 options:
   -h, --help            show this help message and exit
+
+log options:
+  --op OP               Operation name (required)
+  --wiki-root PATH      Wiki root (required)
+  --details JSON        Event details as a JSON object (default: {})
+  --source SOURCE       Sugar that merges into details.source — convenient
+                        for ingest events that just need a source identifier
+                        without a hand-built JSON blob.
 
 stats options:
   --since SINCE         Filter events to ts >= SINCE (ISO-8601 or
@@ -514,6 +525,9 @@ export function main(argv = process.argv.slice(2)) {
             return 2;
         }
         const details = JSON.parse(args.details ?? "{}");
+        if (typeof args.source === "string" && args.source !== "") {
+            details["source"] = args.source;
+        }
         const entry = logEvent(args.wikiRoot, args.op, details);
         process.stdout.write(JSON.stringify(entry, null, 2) + "\n");
         return 0;
@@ -521,6 +535,9 @@ export function main(argv = process.argv.slice(2)) {
     // Fallback: bare --op style (no subcommand)
     if (args.op && args.wikiRoot) {
         const details = JSON.parse(args.details ?? "{}");
+        if (typeof args.source === "string" && args.source !== "") {
+            details["source"] = args.source;
+        }
         const entry = logEvent(args.wikiRoot, args.op, details);
         process.stdout.write(JSON.stringify(entry, null, 2) + "\n");
         return 0;

--- a/skills/doc-wiki/scripts/event_logger.ts
+++ b/skills/doc-wiki/scripts/event_logger.ts
@@ -269,7 +269,7 @@ function median(values: readonly number[]): number {
  * Compute aggregate statistics from the event log.
  *
  * Returns a dict with:
- *   total_ops: number
+ *   total_events: number                            -- count of events in the window
  *   ops_by_type: { [op: string]: number }
  *   total_cost_usd: number
  *   reduction_ratio: { mean, p50, p95 } (only keys present when ratios > 0)
@@ -401,7 +401,7 @@ export function getStats(
   }
 
   const result: Record<string, unknown> = {
-    total_ops: events.length,
+    total_events: events.length,
     ops_by_type: opsByType,
     total_cost_usd: totalCost,
     reduction_ratio: ratioStats,
@@ -428,6 +428,11 @@ interface ParsedArgs {
   /** A6: when true, total_tokens_by_op contains a 0-entry for every op
    *  observed in the log (including ops that emitted no token data). */
   includeZeroTokens?: boolean;
+  /** Sugar over `--details '{"source":"..."}'` — SKILL.md step 12 documents
+   *  this flag for the common ingest case. Merged into `details.source`
+   *  before logging; if `--details` already carries `source`, the explicit
+   *  flag wins. */
+  source?: string;
   help?: boolean;
 }
 
@@ -504,6 +509,9 @@ function parseArgs(argv: readonly string[]): ParsedArgs {
       case "since":
         out.since = value ?? null;
         break;
+      case "source":
+        out.source = value ?? "";
+        break;
       default:
         throw new Error(`unrecognized argument: --${name}`);
     }
@@ -522,6 +530,14 @@ positional arguments:
 
 options:
   -h, --help            show this help message and exit
+
+log options:
+  --op OP               Operation name (required)
+  --wiki-root PATH      Wiki root (required)
+  --details JSON        Event details as a JSON object (default: {})
+  --source SOURCE       Sugar that merges into details.source — convenient
+                        for ingest events that just need a source identifier
+                        without a hand-built JSON blob.
 
 stats options:
   --since SINCE         Filter events to ts >= SINCE (ISO-8601 or
@@ -592,6 +608,9 @@ export function main(argv: readonly string[] = process.argv.slice(2)): number {
       return 2;
     }
     const details = JSON.parse(args.details ?? "{}") as Record<string, unknown>;
+    if (typeof args.source === "string" && args.source !== "") {
+      details["source"] = args.source;
+    }
     const entry = logEvent(args.wikiRoot, args.op, details);
     process.stdout.write(JSON.stringify(entry, null, 2) + "\n");
     return 0;
@@ -600,6 +619,9 @@ export function main(argv: readonly string[] = process.argv.slice(2)): number {
   // Fallback: bare --op style (no subcommand)
   if (args.op && args.wikiRoot) {
     const details = JSON.parse(args.details ?? "{}") as Record<string, unknown>;
+    if (typeof args.source === "string" && args.source !== "") {
+      details["source"] = args.source;
+    }
     const entry = logEvent(args.wikiRoot, args.op, details);
     process.stdout.write(JSON.stringify(entry, null, 2) + "\n");
     return 0;

--- a/skills/doc-wiki/scripts/init_wiki.js
+++ b/skills/doc-wiki/scripts/init_wiki.js
@@ -6,6 +6,9 @@
  * Usage:
  *   node init_wiki.js --path /path/to/wiki-root [--domain general] [--name "My Wiki"]
  *
+ * `--wiki-root` is accepted as an alias for `--path`, matching the convention
+ * used by the rest of the wiki scripts (event_logger, graph_ops, etc.).
+ *
  * The script is idempotent: existing directories are kept, existing config is
  * not overwritten, and existing wiki files are preserved.
  *
@@ -506,8 +509,14 @@ export function initWiki(wikiPath, domain = "general", name = "My Wiki", seedDat
     };
 }
 // ── CLI ─────────────────────────────────────────────────────────────
+// `--wiki-root` is an alias for `--path` so callers using the more
+// descriptive "wiki-root" convention (the same name event_logger,
+// graph_ops, etc. already use) work without translation. Both flags map
+// to the same `path` field below — providing both is fine, but the last
+// one parsed wins (parseFlags overwrites).
 const FLAG_SPEC = {
     "--path": "path",
+    "--wiki-root": "path",
     "--domain": "domain",
     "--name": "name",
 };
@@ -516,10 +525,12 @@ const HELP_TEXT = `usage: init_wiki.js [-h] --path PATH [--domain DOMAIN] [--nam
 Initialize a documentation wiki scaffold.
 
 options:
-  -h, --help       show this help message and exit
-  --path PATH      Root directory for the wiki.
-  --domain DOMAIN  Knowledge domain (default: general).
-  --name NAME      Display name for the wiki (default: "My Wiki").
+  -h, --help            show this help message and exit
+  --path PATH           Root directory for the wiki.
+  --wiki-root PATH      Alias for --path (matches the convention used by
+                        event_logger.js, graph_ops.js, and friends).
+  --domain DOMAIN       Knowledge domain (default: general).
+  --name NAME           Display name for the wiki (default: "My Wiki").
 `;
 export function main(argv = process.argv.slice(2)) {
     let parsed;
@@ -536,7 +547,7 @@ export function main(argv = process.argv.slice(2)) {
     }
     const pathArg = parsed.values["path"];
     if (typeof pathArg !== "string" || pathArg === "") {
-        process.stderr.write("the following arguments are required: --path\n");
+        process.stderr.write("the following arguments are required: --path (or --wiki-root)\n");
         return 2;
     }
     const domain = typeof parsed.values["domain"] === "string" && parsed.values["domain"]

--- a/skills/doc-wiki/scripts/init_wiki.ts
+++ b/skills/doc-wiki/scripts/init_wiki.ts
@@ -6,6 +6,9 @@
  * Usage:
  *   node init_wiki.js --path /path/to/wiki-root [--domain general] [--name "My Wiki"]
  *
+ * `--wiki-root` is accepted as an alias for `--path`, matching the convention
+ * used by the rest of the wiki scripts (event_logger, graph_ops, etc.).
+ *
  * The script is idempotent: existing directories are kept, existing config is
  * not overwritten, and existing wiki files are preserved.
  *
@@ -573,8 +576,14 @@ export function initWiki(
 
 // ── CLI ─────────────────────────────────────────────────────────────
 
+// `--wiki-root` is an alias for `--path` so callers using the more
+// descriptive "wiki-root" convention (the same name event_logger,
+// graph_ops, etc. already use) work without translation. Both flags map
+// to the same `path` field below — providing both is fine, but the last
+// one parsed wins (parseFlags overwrites).
 const FLAG_SPEC = {
   "--path": "path",
+  "--wiki-root": "path",
   "--domain": "domain",
   "--name": "name",
 } as const;
@@ -584,10 +593,12 @@ const HELP_TEXT = `usage: init_wiki.js [-h] --path PATH [--domain DOMAIN] [--nam
 Initialize a documentation wiki scaffold.
 
 options:
-  -h, --help       show this help message and exit
-  --path PATH      Root directory for the wiki.
-  --domain DOMAIN  Knowledge domain (default: general).
-  --name NAME      Display name for the wiki (default: "My Wiki").
+  -h, --help            show this help message and exit
+  --path PATH           Root directory for the wiki.
+  --wiki-root PATH      Alias for --path (matches the convention used by
+                        event_logger.js, graph_ops.js, and friends).
+  --domain DOMAIN       Knowledge domain (default: general).
+  --name NAME           Display name for the wiki (default: "My Wiki").
 `;
 
 export function main(
@@ -608,7 +619,9 @@ export function main(
 
   const pathArg = parsed.values["path"];
   if (typeof pathArg !== "string" || pathArg === "") {
-    process.stderr.write("the following arguments are required: --path\n");
+    process.stderr.write(
+      "the following arguments are required: --path (or --wiki-root)\n",
+    );
     return 2;
   }
   const domain =

--- a/skills/doc-wiki/scripts/tests/event_logger.test.ts
+++ b/skills/doc-wiki/scripts/tests/event_logger.test.ts
@@ -235,7 +235,7 @@ describe("TestGetStats", () => {
     expect(opsByType["ingest"]).toBe(2);
     expect(opsByType["query"]).toBe(1);
     expect(opsByType["lint"]).toBe(1);
-    expect(stats["total_ops"]).toBe(4);
+    expect(stats["total_events"]).toBe(4);
 
     expect(approxEqual(stats["total_cost_usd"] as number, 0.16)).toBe(true);
 
@@ -253,7 +253,7 @@ describe("TestGetStats", () => {
     // Only events on or after 2026-04-10
     const stats = getStats(wikiRoot, "2026-04-09T00:00:00+00:00");
 
-    expect(stats["total_ops"]).toBe(2);
+    expect(stats["total_events"]).toBe(2);
     const opsByType = stats["ops_by_type"] as Record<string, number>;
     expect(opsByType["ingest"]).toBe(1);
     expect(opsByType["lint"]).toBe(1);
@@ -289,7 +289,7 @@ describe("TestGetStats", () => {
       events.map((e) => JSON.stringify(e)).join("\n") + "\n",
     );
     const stats = getStats(wikiRoot, "2026-04-09T00:00:00+00:00");
-    expect(stats["total_ops"]).toBe(1);
+    expect(stats["total_events"]).toBe(1);
     const opsByType = stats["ops_by_type"] as Record<string, number>;
     expect(opsByType["ingest"]).toBe(1);
     expect("query" in opsByType).toBe(false);
@@ -371,7 +371,7 @@ describe("EventLoggerCLIShape", () => {
     const data = JSON.parse(js.stdout);
     expect(typeof data.total_cost_usd).toBe("number");
     expect(data.total_cost_usd).toBeGreaterThan(0);
-    expect(data.total_ops).toBeGreaterThanOrEqual(4);
+    expect(data.total_events).toBeGreaterThanOrEqual(4);
   });
 
   it("cli_stats_since_iso_filters_older_events", () => {
@@ -386,7 +386,7 @@ describe("EventLoggerCLIShape", () => {
     expect(js.status).toBe(0);
     const data = JSON.parse(js.stdout);
     // Only two events fall on or after 2026-04-09.
-    expect(data.total_ops).toBe(2);
+    expect(data.total_events).toBe(2);
   });
 
   it("cli_stats_integer_ratios_emit_python_style_numbers", () => {
@@ -414,6 +414,113 @@ describe("EventLoggerCLIShape", () => {
     const js = runCli(["stats", "--wiki-root", tmpPath]);
     expect(js.status).toBe(0);
     expect(js.stdout).toMatch(/"total_cost_usd":\s*15\b/);
+  });
+});
+
+// ── --source CLI flag ────────────────────────────────────────────────
+//
+// SKILL.md step 12 documents `--source <source>` as a convenience over
+// `--details '{"source":"..."}'` for the common ingest case. These tests
+// pin that contract: the flag is accepted, lands as a top-level `source`
+// field on the entry, and merges cleanly with `--details`.
+
+describe("event_logger --source flag", () => {
+  let tmpPath: string;
+
+  beforeEach(() => {
+    tmpPath = makeTmpPath("event-source-flag-");
+    fs.mkdirSync(path.join(tmpPath, "log"), { recursive: true });
+  });
+
+  afterEach(() => {
+    cleanupTmpPath(tmpPath);
+  });
+
+  it("accepts --source on `log` and writes it as a top-level field", () => {
+    const js = runCli([
+      "log",
+      "--op", "ingest",
+      "--wiki-root", tmpPath,
+      "--source", "slides.pptx",
+    ]);
+    expect(js.status).toBe(0);
+    const entry = JSON.parse(js.stdout) as Record<string, unknown>;
+    expect(entry["source"]).toBe("slides.pptx");
+    expect(entry["op"]).toBe("ingest");
+  });
+
+  it("merges --source into --details (explicit flag wins on collision)", () => {
+    const js = runCli([
+      "log",
+      "--op", "ingest",
+      "--wiki-root", tmpPath,
+      "--details", '{"source":"old.md","extra":"keep"}',
+      "--source", "new.md",
+    ]);
+    expect(js.status).toBe(0);
+    const entry = JSON.parse(js.stdout) as Record<string, unknown>;
+    expect(entry["source"]).toBe("new.md");
+    expect(entry["extra"]).toBe("keep");
+  });
+
+  it("accepts --source on the bare-fallback (no subcommand) shape", () => {
+    const js = runCli([
+      "--op", "ingest",
+      "--wiki-root", tmpPath,
+      "--source", "report.pdf",
+    ]);
+    expect(js.status).toBe(0);
+    const entry = JSON.parse(js.stdout) as Record<string, unknown>;
+    expect(entry["source"]).toBe("report.pdf");
+  });
+});
+
+// ── stats output: total_events ───────────────────────────────────────
+//
+// Pin the renamed top-level count field so a future rename (or mistaken
+// revert) breaks loudly.
+
+describe("event_logger stats — total_events", () => {
+  let tmpPath: string;
+
+  beforeEach(() => {
+    tmpPath = makeTmpPath("event-total-events-");
+    fs.mkdirSync(path.join(tmpPath, "log"), { recursive: true });
+  });
+
+  afterEach(() => {
+    cleanupTmpPath(tmpPath);
+  });
+
+  it("getStats returns total_events (not total_ops) and counts every entry", () => {
+    const events = [
+      { ts: "2026-04-01T10:00:00+00:00", op: "ingest", cost_usd: 0.05 },
+      { ts: "2026-04-05T12:00:00+00:00", op: "query", cost_usd: 0.03 },
+      { ts: "2026-04-10T08:00:00+00:00", op: "ingest", cost_usd: 0.07 },
+    ];
+    fs.writeFileSync(
+      path.join(tmpPath, "log", "events.jsonl"),
+      events.map((e) => JSON.stringify(e)).join("\n") + "\n",
+    );
+    const stats = getStats(tmpPath);
+    expect(stats["total_events"]).toBe(3);
+    expect("total_ops" in stats).toBe(false);
+  });
+
+  it("CLI `stats` emits total_events in stdout JSON", () => {
+    const events = [
+      { ts: "2026-04-01T10:00:00+00:00", op: "ingest", cost_usd: 0.05 },
+      { ts: "2026-04-05T12:00:00+00:00", op: "lint",  cost_usd: 0.01 },
+    ];
+    fs.writeFileSync(
+      path.join(tmpPath, "log", "events.jsonl"),
+      events.map((e) => JSON.stringify(e)).join("\n") + "\n",
+    );
+    const js = runCli(["stats", "--wiki-root", tmpPath]);
+    expect(js.status).toBe(0);
+    const data = JSON.parse(js.stdout) as Record<string, unknown>;
+    expect(data["total_events"]).toBe(2);
+    expect("total_ops" in data).toBe(false);
   });
 });
 

--- a/skills/doc-wiki/scripts/tests/init_wiki.test.ts
+++ b/skills/doc-wiki/scripts/tests/init_wiki.test.ts
@@ -309,6 +309,41 @@ describe("init_wiki — missing args", () => {
   });
 });
 
+// ── --wiki-root alias ───────────────────────────────────────────────
+//
+// `--wiki-root` is accepted as an alias for `--path` so callers using the
+// convention shared with event_logger / graph_ops / etc. work without
+// translation. Both flags map to the same internal field.
+
+describe("init_wiki — --wiki-root alias", () => {
+  let tmpPath: string;
+  beforeEach(() => {
+    tmpPath = makeTmpPath("init-wiki-alias-");
+  });
+  afterEach(() => {
+    cleanupTmpPath(tmpPath);
+  });
+
+  it("accepts --wiki-root as a synonym for --path", () => {
+    const wiki = tmpWiki(tmpPath);
+    const rc = main(["--wiki-root", wiki]);
+    expect(rc).toBe(0);
+    expect(fs.existsSync(path.join(wiki, "wiki.config.yaml"))).toBe(true);
+  });
+
+  it("CLI: --wiki-root works as a synonym for --path", () => {
+    const wiki = tmpWiki(tmpPath);
+    const stdout = execFileSync(
+      "node",
+      [CLI, "--wiki-root", wiki],
+      { encoding: "utf-8" },
+    );
+    const result = JSON.parse(stdout) as { status: string; wiki_root: string };
+    expect(result.status).toBe("ok");
+    expect(fs.existsSync(path.join(wiki, "wiki.config.yaml"))).toBe(true);
+  });
+});
+
 // ── v2 config blocks (Phase H2) ─────────────────────────────────────
 
 describe("init_wiki — v2 config blocks", () => {


### PR DESCRIPTION
## Summary

Three small consistency papercuts surfaced from running evals against the actual code (docs / eval prompts said one thing, code did another). All three fixed code-side because the alternative (rewriting eval prompts + prose mentions) had a larger blast radius in every case.

## The papercuts and what changed

### P1 — `event_logger.js` rejects `--source` even though SKILL.md documents it

- **Before:** `skills/doc-wiki/SKILL.md` line 373 (step 12) shows `--source <source>` as an arg to `event_logger.js`, but `parseArgs` in `skills/doc-wiki/scripts/event_logger.ts` only accepts `--op`, `--wiki-root`, `--details`, `--since`. Anyone copying the documented invocation got `unrecognized argument: --source`.
- **Fix (code-side):** Added `--source` to the parser as sugar that merges into the event entry's top-level `source` field. Works on both `log <args>` and the bare-fallback `--op ... --wiki-root ...` shape. If `--details` already carries `source`, the explicit flag wins on collision (consistent with how every other CLI handles flag-vs-blob duplication). HELP_TEXT updated.
- **Why code-side:** The flag is already documented; rewriting SKILL.md step 12 to remove `--source` would force every caller to construct a JSON blob just to log a source string. Adding the flag is a strict superset.

### P2 — `init_wiki.js` arg naming is `--path` but the wiki convention is `--wiki-root`

- **Before:** `init_wiki.ts` accepts only `--path`. Every other wiki script (`event_logger`, `graph_ops`, `daily_summary`, ...) uses `--wiki-root`. eval-14 runners reaching for the established convention got `unrecognized argument`.
- **Fix (code-side):** Added `--wiki-root` as an alias for `--path` in the FLAG_SPEC. Both flags map to the same internal field; SKILL.md keeps `--path` as canonical (no doc churn). Updated HELP_TEXT and the file-header usage comment to mention the alias.
- **Why code-side:** SKILL.md uses `--path` in two places; switching to `--wiki-root` would still leave existing callers (and old transcripts) using `--path` broken. Accepting both is a pure superset.

### P3 — `total_ops` vs `total_events` naming in `event_logger stats`

- **Before:** `event_logger stats` emits a JSON output where the count field is `total_ops`. eval-12 (`wiki-stats-since`) and its expectations refer to `total_events` — runners had to mentally translate.
- **Fix (code-side rename, no compat alias):** Renamed `total_ops` → `total_events` in source + tests. Call-site count:
  - **2** source occurrences (event_logger.ts: doc comment + result key)
  - **5** test assertions in `event_logger.test.ts`
  - **0** in SKILL.md, `docs/`, references, or any external consumer
  vs. the alternative — updating eval-12 (which already exists) + every future eval that imports the field name + the prose mention. Smaller change overall, and `total_events` is also more accurate (the field counts events, not operations in the operational sense; per-op breakdown lives under `ops_by_type`).
- **No compat alias kept** because there are no external consumers and the field name is purely an output contract — the alias would just defer the rename.

## Verification

- `npm run typecheck` — clean
- `npm run build` — clean
- `npm test` — **1137 passed, 5 skipped** (previously 1130 / 5)
  - +7 new tests: 3 cover `--source` (log subcommand, bare fallback, `--details` collision), 2 cover `total_events` (getStats unit + CLI), 2 cover `--wiki-root` alias (unit + CLI)
- Smoke-tested `init_wiki.js --wiki-root /tmp/...`, `event_logger.js log --source ...`, and `event_logger.js stats` end-to-end against the built `.js` artifacts — all three flow through and produce the documented output.

## Test plan

- [x] `npm run typecheck` is clean
- [x] `npm run build` is clean
- [x] `npm test` is green (1137 passed, 5 skipped)
- [x] Manual smoke test of all three flags via the built `.js` artifacts
- [ ] Reviewer: re-run eval-12 (`wiki-stats-since`) and eval-14 against the branch and confirm both stop tripping on the renamed field / new flags