### PR TITLE
fix(event-logger): roll total_cost_usd into top-level stats

### DIFF
--- a/skills/doc-wiki/scripts/event_logger.js
+++ b/skills/doc-wiki/scripts/event_logger.js
@@ -255,8 +255,14 @@ export function getStats(wikiRoot, since = null, opts = {}) {
     for (const e of events) {
         const op = typeof e["op"] === "string" ? e["op"] : "unknown";
         opsByType[op] = (opsByType[op] ?? 0) + 1;
-        const costVal = e["cost_usd"];
-        const cost = typeof costVal === "number" ? costVal : 0.0;
+        // Accept `total_cost_usd` as a fallback for `cost_usd`. The atlas
+        // op writes `total_cost_usd` directly (per SKILL.md finalize step),
+        // and `_normalizeAgentCalls` synthesizes the same field from
+        // `agent_calls[]`. Without this fallback, both classes of events
+        // contribute $0 to the top-level total even though their costs
+        // are real.
+        const costRaw = e["cost_usd"] ?? e["total_cost_usd"];
+        const cost = typeof costRaw === "number" ? costRaw : 0.0;
         totalCost += cost;
         // v2.1 per-op token aggregation. Accept several event-level keys so
         // producers that emit `tokens`, `total_tokens`, or `tokens_in + tokens_out`

--- a/skills/doc-wiki/scripts/event_logger.ts
+++ b/skills/doc-wiki/scripts/event_logger.ts
@@ -305,8 +305,14 @@ export function getStats(
     const op = typeof e["op"] === "string" ? e["op"] : "unknown";
     opsByType[op] = (opsByType[op] ?? 0) + 1;
 
-    const costVal = e["cost_usd"];
-    const cost = typeof costVal === "number" ? costVal : 0.0;
+    // Accept `total_cost_usd` as a fallback for `cost_usd`. The atlas
+    // op writes `total_cost_usd` directly (per SKILL.md finalize step),
+    // and `_normalizeAgentCalls` synthesizes the same field from
+    // `agent_calls[]`. Without this fallback, both classes of events
+    // contribute $0 to the top-level total even though their costs
+    // are real.
+    const costRaw = e["cost_usd"] ?? e["total_cost_usd"];
+    const cost = typeof costRaw === "number" ? costRaw : 0.0;
     totalCost += cost;
 
     // v2.1 per-op token aggregation. Accept several event-level keys so

--- a/skills/doc-wiki/scripts/tests/event_logger.test.ts
+++ b/skills/doc-wiki/scripts/tests/event_logger.test.ts
@@ -611,6 +611,56 @@ describe("agent_calls[] breakdown", () => {
     expect(perAgent["jira"]).toBeCloseTo(0.25, 5);
     expect(perAgent["db_agent"]).toBeCloseTo(0.5, 5);
   });
+
+  // Regression: events that record cost as `total_cost_usd` (atlas op
+  // finalize step, or any event auto-normalized from agent_calls[])
+  // must contribute to the top-level total_cost_usd. Previously the
+  // aggregator only read `cost_usd`, so atlas's $7.60 silently dropped.
+  it("stats sums total_cost_usd when cost_usd is absent (atlas-style)", () => {
+    fs.mkdirSync(path.join(tmpPath, "log"), { recursive: true });
+    const events = [
+      { ts: "2026-05-10T02:01:18+00:00", op: "init" },
+      {
+        ts: "2026-05-10T02:38:52+00:00",
+        op: "atlas",
+        atlas_run_id: "2026-05-10T02-01-52",
+        total_cost_usd: 7.6,
+        pages_generated: 38,
+      },
+    ];
+    fs.writeFileSync(
+      path.join(tmpPath, "log", "events.jsonl"),
+      events.map((e) => JSON.stringify(e)).join("\n") + "\n",
+    );
+    const stats = getStats(tmpPath);
+    expect(stats["total_events"]).toBe(2);
+    expect(approxEqual(stats["total_cost_usd"] as number, 7.6)).toBe(true);
+    // Sanity: both ops still show in the type breakdown.
+    const opsByType = stats["ops_by_type"] as Record<string, number>;
+    expect(opsByType["init"]).toBe(1);
+    expect(opsByType["atlas"]).toBe(1);
+  });
+
+  // Regression: events that carry agent_calls[] (so the logger writes
+  // total_cost_usd but not cost_usd) must also contribute their
+  // synthesized total to the top-level aggregate, not just to
+  // per_agent_cost.
+  it("stats sums agent_calls-synthesized total_cost_usd at top level", () => {
+    logEvent(tmpPath, "ingest", {
+      agent_calls: [
+        {
+          agent: "jira", model: "haiku", tokens_in: 0, tokens_out: 0,
+          cost_usd: 0.25, elapsed_ms: 10, status: "success",
+        },
+        {
+          agent: "db_agent", model: null, tokens_in: 0, tokens_out: 0,
+          cost_usd: 0.5, elapsed_ms: 10, status: "success",
+        },
+      ],
+    });
+    const stats = getStats(tmpPath);
+    expect(approxEqual(stats["total_cost_usd"] as number, 0.75)).toBe(true);
+  });
 });
 
 // ── A6: includeZeroTokens flag for getStats ────────────────────────


### PR DESCRIPTION
## Summary

- `getStats` only read `cost_usd` from each event, so `op: atlas` events (which record cost as `total_cost_usd` per `SKILL.md` finalize step) and any event auto-normalized from `agent_calls[]` silently contributed $0 to the top-level total. Reproduced on `docs/doc-wiki-wiki/`: an atlas event with `total_cost_usd: 7.6` was reported as `total_cost_usd: 0` by `/doc-wiki:stats`.
- One-line fix in `skills/doc-wiki/scripts/event_logger.ts`: accept `total_cost_usd` as a fallback when `cost_usd` is absent. Existing `cost_usd`-only events are unchanged because `??` precedence still picks `cost_usd` when present.
- Two regression tests added: atlas-style event (literal `total_cost_usd`) and `agent_calls[]`-synthesized event.

Out of scope (left for follow-ups, can do if asked):
- `avg_duration_ms_by_op` doesn't recognize the atlas `phase_durations` shape.
- No per-op `cost_usd_by_op` breakdown — `per_agent_cost` is still the only per-key cost rollup.

## Test plan

- [x] `npx vitest run skills/doc-wiki/scripts/tests/event_logger.test.ts` — 31/31 pass
- [x] `npm run build` — clean
- [x] `node skills/doc-wiki/scripts/event_logger.js stats --wiki-root docs/doc-wiki-wiki --since 7d` reports `total_cost_usd: 7.6` (was `0`)
- [ ] CI green