### PR TITLE
fix(graph-ops): warn when --all-paths is combined with ignored flags

### DIFF
--- a/skills/doc-wiki/scripts/graph_ops.js
+++ b/skills/doc-wiki/scripts/graph_ops.js
@@ -559,6 +559,21 @@ export function main(argv = process.argv.slice(2)) {
             const from = args.fromConcept ?? "";
             const to = args.toConcept ?? "";
             if (args.allPaths) {
+                // --all-paths is count-bounded (top 5 simple paths), not
+                // hop-bounded. references/operations.md says --max-hops and
+                // --via are ignored in this mode. Without a warning, a user
+                // passing them silently gets results that don't reflect those
+                // flags. Mirror event_logger's W1 stderr pattern so stdout
+                // stays machine-readable.
+                const ignored = [];
+                if (args.maxHops !== undefined)
+                    ignored.push("--max-hops");
+                if (args.via !== undefined)
+                    ignored.push("--via");
+                if (ignored.length > 0) {
+                    const verb = ignored.length === 1 ? "is" : "are";
+                    process.stderr.write(`[graph_ops] warning: ${ignored.join(" and ")} ${verb} ignored when --all-paths is set (path mode is count-bounded, not hop-bounded)\n`);
+                }
                 const paths = allPaths(args.edges ?? "", from, to);
                 if (paths.length === 0) {
                     process.stdout.write(JSON.stringify({

--- a/skills/doc-wiki/scripts/graph_ops.ts
+++ b/skills/doc-wiki/scripts/graph_ops.ts
@@ -689,6 +689,21 @@ export function main(argv: readonly string[] = process.argv.slice(2)): number {
       const from = args.fromConcept ?? "";
       const to = args.toConcept ?? "";
       if (args.allPaths) {
+        // --all-paths is count-bounded (top 5 simple paths), not
+        // hop-bounded. references/operations.md says --max-hops and
+        // --via are ignored in this mode. Without a warning, a user
+        // passing them silently gets results that don't reflect those
+        // flags. Mirror event_logger's W1 stderr pattern so stdout
+        // stays machine-readable.
+        const ignored: string[] = [];
+        if (args.maxHops !== undefined) ignored.push("--max-hops");
+        if (args.via !== undefined) ignored.push("--via");
+        if (ignored.length > 0) {
+          const verb = ignored.length === 1 ? "is" : "are";
+          process.stderr.write(
+            `[graph_ops] warning: ${ignored.join(" and ")} ${verb} ignored when --all-paths is set (path mode is count-bounded, not hop-bounded)\n`,
+          );
+        }
         const paths = allPaths(args.edges ?? "", from, to);
         if (paths.length === 0) {
           process.stdout.write(

--- a/skills/doc-wiki/scripts/tests/graph_ops.test.ts
+++ b/skills/doc-wiki/scripts/tests/graph_ops.test.ts
@@ -503,6 +503,102 @@ describe("TestGraphOpsCLI", () => {
     }
   });
 
+  // runCli discards stderr on success exit; spawnSync captures both
+  // streams. Used by the warning tests below — keep local so the
+  // shared helper stays unchanged.
+  function runCliCapturingStderr(
+    args: readonly string[],
+  ): { stdout: string; stderr: string; status: number } {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { spawnSync } = require("node:child_process") as typeof import("node:child_process");
+    const r = spawnSync("node", [CLI, ...args], { encoding: "utf-8" });
+    return {
+      stdout: r.stdout ?? "",
+      stderr: r.stderr ?? "",
+      status: r.status ?? 1,
+    };
+  }
+
+  it("cli_path_all_paths_warns_when_max_hops_is_also_passed", () => {
+    const r = runCliCapturingStderr([
+      "path",
+      "--edges",
+      edgesFile,
+      "--from",
+      "A",
+      "--to",
+      "D",
+      "--all-paths",
+      "--max-hops",
+      "4",
+    ]);
+    expect(r.status).toBe(0);
+    // stdout must still be machine-readable JSON.
+    expect(() => JSON.parse(r.stdout)).not.toThrow();
+    // stderr carries the warning.
+    expect(r.stderr).toContain("[graph_ops] warning");
+    expect(r.stderr).toContain("--max-hops");
+    expect(r.stderr).toContain("--all-paths");
+    expect(r.stderr).not.toContain("--via");
+  });
+
+  it("cli_path_all_paths_warns_when_via_is_also_passed", () => {
+    const r = runCliCapturingStderr([
+      "path",
+      "--edges",
+      edgesFile,
+      "--from",
+      "A",
+      "--to",
+      "D",
+      "--all-paths",
+      "--via",
+      "B",
+    ]);
+    expect(r.status).toBe(0);
+    expect(() => JSON.parse(r.stdout)).not.toThrow();
+    expect(r.stderr).toContain("[graph_ops] warning");
+    expect(r.stderr).toContain("--via");
+    expect(r.stderr).not.toContain("--max-hops");
+  });
+
+  it("cli_path_all_paths_warns_with_both_flags_combined", () => {
+    const r = runCliCapturingStderr([
+      "path",
+      "--edges",
+      edgesFile,
+      "--from",
+      "A",
+      "--to",
+      "D",
+      "--all-paths",
+      "--max-hops",
+      "3",
+      "--via",
+      "B",
+    ]);
+    expect(r.status).toBe(0);
+    expect(r.stderr).toContain("[graph_ops] warning");
+    expect(r.stderr).toContain("--max-hops");
+    expect(r.stderr).toContain("--via");
+    expect(r.stderr).toContain("are ignored");
+  });
+
+  it("cli_path_all_paths_no_warning_when_flags_absent", () => {
+    const r = runCliCapturingStderr([
+      "path",
+      "--edges",
+      edgesFile,
+      "--from",
+      "A",
+      "--to",
+      "D",
+      "--all-paths",
+    ]);
+    expect(r.status).toBe(0);
+    expect(r.stderr).toBe("");
+  });
+
   it("cli_add_writes_edge", () => {
     const fresh = path.join(tmpPath, "fresh.jsonl");
     fs.writeFileSync(fresh, "");

--- a/skills/doc-wiki/scripts/tests/graph_ops.test.ts
+++ b/skills/doc-wiki/scripts/tests/graph_ops.test.ts
@@ -6,7 +6,7 @@
  * against graph_ops.py's output.
  */
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { execFileSync } from "node:child_process";
+import { execFileSync, spawnSync } from "node:child_process";
 import * as fs from "node:fs";
 import * as path from "node:path";
 
@@ -509,8 +509,6 @@ describe("TestGraphOpsCLI", () => {
   function runCliCapturingStderr(
     args: readonly string[],
   ): { stdout: string; stderr: string; status: number } {
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
-    const { spawnSync } = require("node:child_process") as typeof import("node:child_process");
     const r = spawnSync("node", [CLI, ...args], { encoding: "utf-8" });
     return {
       stdout: r.stdout ?? "",


### PR DESCRIPTION
## Summary

Follow-up to PR #10 (the `/doc-wiki:path` → `/doc-wiki:query` path-mode consolidation). `references/operations.md` documents that `--max-hops` and `--via` are ignored when `--all-paths` is set (path mode is count-bounded, not hop-bounded), but the CLI silently dropped them. A user copying an old `/doc-wiki:path --via session --max-hops 4` example and tacking on `--all-paths` got results with no signal of misuse.

- Emit a stderr warning in `graph_ops.ts` when either `--max-hops` or `--via` is passed alongside `--all-paths` — mirrors `event_logger.ts`'s W1 stderr pattern so stdout stays machine-readable. No exit-code change, no behavior change to the underlying `allPaths()` result.
- Four regression tests (`cli_path_all_paths_warns_when_max_hops_is_also_passed`, `..._when_via_is_also_passed`, `..._with_both_flags_combined`, `..._no_warning_when_flags_absent`) cover both the single-flag and combined-flag cases, plus the negative case to lock in "no warning when flags are absent."

The new tests use a small local `runCliCapturingStderr` helper (a `spawnSync`-based wrapper) because the shared `runCli` discards stderr on success exit. Left the shared helper alone to keep the blast radius narrow.

## Test plan

- [x] `npm run build` — clean
- [x] `npx vitest run skills/doc-wiki/scripts/tests/graph_ops.test.ts` — 36/36 pass (+4 new)
- [x] `npm test` — 1228 passed / 5 skipped (was 1224/5)
- [x] Manual: `node skills/doc-wiki/scripts/graph_ops.js path --edges <f> --from A --to D --all-paths --via B --max-hops 3` now emits `[graph_ops] warning: --max-hops and --via are ignored when --all-paths is set (path mode is count-bounded, not hop-bounded)` on stderr; stdout is unchanged JSON.
- [ ] CI green