### PR TITLE
⚡ Bolt: [performance improvement] Fast-path timestamp check in event_logger

### DIFF
--- a/skills/doc-wiki/scripts/event_logger.js
+++ b/skills/doc-wiki/scripts/event_logger.js
@@ -150,6 +150,18 @@ function _readEvents(wikiRoot, since = null) {
         const line = rawLine.trim();
         if (!line)
             continue;
+        // Fast-path: if --since is active, use a strict regex anchored to the
+        // beginning of the JSON object to extract `ts` and check it before paying
+        // the JSON parse overhead.
+        if (sinceMs !== null && !Number.isNaN(sinceMs)) {
+            const match = line.match(/^{"ts":"([^"]+)"/);
+            if (match && match[1]) {
+                const entryMs = parsePythonIsoformat(match[1]);
+                if (!Number.isNaN(entryMs) && entryMs < sinceMs) {
+                    continue;
+                }
+            }
+        }
         const entry = JSON.parse(line);
         if (sinceMs !== null && !Number.isNaN(sinceMs)) {
             const entryTs = entry["ts"];

--- a/skills/doc-wiki/scripts/event_logger.ts
+++ b/skills/doc-wiki/scripts/event_logger.ts
@@ -194,6 +194,20 @@ function _readEvents(
   for (const rawLine of raw.split("\n")) {
     const line = rawLine.trim();
     if (!line) continue;
+
+    // Fast-path: if --since is active, use a strict regex anchored to the
+    // beginning of the JSON object to extract `ts` and check it before paying
+    // the JSON parse overhead.
+    if (sinceMs !== null && !Number.isNaN(sinceMs)) {
+      const match = line.match(/^{"ts":"([^"]+)"/);
+      if (match && match[1]) {
+        const entryMs = parsePythonIsoformat(match[1]);
+        if (!Number.isNaN(entryMs) && entryMs < sinceMs) {
+          continue;
+        }
+      }
+    }
+
     const entry = JSON.parse(line) as Record<string, unknown>;
     if (sinceMs !== null && !Number.isNaN(sinceMs)) {
       const entryTs = entry["ts"];


### PR DESCRIPTION
**What:**
Added a fast-path regex check to `_readEvents` in `skills/doc-wiki/scripts/event_logger.ts` to extract the timestamp and verify it against `--since` constraints before executing `JSON.parse()`.

**Why:**
For large append-only JSON log files like `events.jsonl`, running `JSON.parse()` unconditionally on every single line when calculating stats (e.g., via `--since`) is a performance bottleneck. Checking the timestamp directly via regex allows skipping irrelevant lines extremely quickly.

**Impact:**
Substantially speeds up log reading queries filtered by date (such as `--since 7d`) on large logs by reducing the total number of expensive JSON parsing operations by a factor roughly proportional to the dropped lines.

**Measurement:**
Run `node event_logger.js stats --wiki-root <root> --since 1d` on a large test wiki that has tens of thousands of older event logs. Profile the execution time with and without the change to see the reduction in CPU parse time.

---
*PR created automatically by Jules for task [5579811276243423081](https://jules.google.com/task/5579811276243423081) started by @rfv-code*