### PR TITLE
⚡ Bolt: [performance improvement] fast-path log parsing

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,7 @@
 ## 2026-05-14 - Fast-path log parsing
 **Learning:** For append-only json log files that grow large over time (like `events.jsonl` in this codebase), reading the whole file line-by-line and unconditionally calling `JSON.parse()` on every line is a significant performance bottleneck.
 **Action:** Use a fast-path string `.includes()` check to pre-filter lines that cannot possibly match the required criteria (e.g. `!line.includes('"atlas"')`) before paying the cost of JSON parsing.
+
+## 2026-05-15 - Fast-path parsing with anchored regex
+**Learning:** For fast-path parsing, using `line.includes()` is sometimes fragile and can match inner JSON fields causing data loss if the inner field data unexpectedly changes.
+**Action:** Use an anchored regex `/^{"ts":"([^"]+)"/` (or equivalent prefix regex) to ensure you are matching the correct field in the JSON structure at the exact location, without paying the cost of `JSON.parse()`.

--- a/skills/doc-wiki/scripts/event_logger.js
+++ b/skills/doc-wiki/scripts/event_logger.js
@@ -150,7 +150,27 @@ function _readEvents(wikiRoot, since = null) {
         const line = rawLine.trim();
         if (!line)
             continue;
+        if (sinceMs !== null && !Number.isNaN(sinceMs)) {
+            // ⚡ Bolt: Fast-path string check to avoid JSON.parse on old log lines.
+            // Use strict, anchored regex check to pre-filter relevant lines before
+            // parsing, preventing fragile regex matches on inner JSON fields.
+            const match = line.match(/^{"ts":"([^"]+)"/);
+            let entryMs = NaN;
+            let fastPathSuccess = false;
+            if (match) {
+                entryMs = parsePythonIsoformat(match[1]);
+                fastPathSuccess = true;
+            }
+            if (fastPathSuccess) {
+                // G-EVENTS-TS-STRICT
+                if (Number.isNaN(entryMs) || entryMs < sinceMs) {
+                    continue;
+                }
+            }
+        }
         const entry = JSON.parse(line);
+        // We still do the strict parsing check just in case the fast-path didn't hit
+        // (e.g. "ts" was not the very first key in the JSON line)
         if (sinceMs !== null && !Number.isNaN(sinceMs)) {
             const entryTs = entry["ts"];
             const entryMs = typeof entryTs === "string" ? parsePythonIsoformat(entryTs) : NaN;

--- a/skills/doc-wiki/scripts/event_logger.ts
+++ b/skills/doc-wiki/scripts/event_logger.ts
@@ -194,11 +194,35 @@ function _readEvents(
   for (const rawLine of raw.split("\n")) {
     const line = rawLine.trim();
     if (!line) continue;
+
+    if (sinceMs !== null && !Number.isNaN(sinceMs)) {
+      // ⚡ Bolt: Fast-path string check to avoid JSON.parse on old log lines.
+      // Use strict, anchored regex check to pre-filter relevant lines before
+      // parsing, preventing fragile regex matches on inner JSON fields.
+      const match = line.match(/^{"ts":"([^"]+)"/);
+      let entryMs = NaN;
+      let fastPathSuccess = false;
+
+      if (match) {
+        entryMs = parsePythonIsoformat(match[1] as string);
+        fastPathSuccess = true;
+      }
+
+      if (fastPathSuccess) {
+        // G-EVENTS-TS-STRICT
+        if (Number.isNaN(entryMs) || entryMs < sinceMs) {
+          continue;
+        }
+      }
+    }
+
     const entry = JSON.parse(line) as Record<string, unknown>;
+
+    // We still do the strict parsing check just in case the fast-path didn't hit
+    // (e.g. "ts" was not the very first key in the JSON line)
     if (sinceMs !== null && !Number.isNaN(sinceMs)) {
       const entryTs = entry["ts"];
-      const entryMs =
-        typeof entryTs === "string" ? parsePythonIsoformat(entryTs) : NaN;
+      const entryMs = typeof entryTs === "string" ? parsePythonIsoformat(entryTs) : NaN;
       // G-EVENTS-TS-STRICT: when --since is active, drop events whose
       // `ts` cannot be parsed. Previously a NaN skipped only the
       // `entryMs < sinceMs` check and fell through into `events.push`,


### PR DESCRIPTION
💡 What: The optimization implements a fast-path string extraction (`/^{"ts":"([^"]+)"/`) to parse log timestamp without doing `JSON.parse` on the whole line if the timestamp falls before `--since`.
🎯 Why: Reading a massive `events.jsonl` file and evaluating `JSON.parse()` on thousands of lines just to skip them later introduces unnecessary GC and CPU overhead.
📊 Impact: Considerably faster `getStats` or log reads when limiting logs with `--since`.
🔬 Measurement: Run the test suite (`vitest run skills/doc-wiki/scripts/tests/event_logger.test.ts`) and optionally profile the `event_logger`'s read performance when filtering out millions of older records.

---
*PR created automatically by Jules for task [13313259636941311736](https://jules.google.com/task/13313259636941311736) started by @rfv-code*