### PR TITLE
⚡ Bolt: Fast-path json parsing in event logger

### DIFF
--- a/skills/doc-wiki/scripts/event_logger.js
+++ b/skills/doc-wiki/scripts/event_logger.js
@@ -150,6 +150,16 @@ function _readEvents(wikiRoot, since = null) {
         const line = rawLine.trim();
         if (!line)
             continue;
+        // Fast-path log parsing: avoid JSON.parse on every line if we can reject based on timestamp
+        if (sinceMs !== null && !Number.isNaN(sinceMs)) {
+            const tsMatch = line.match(/^{"ts":"([^"]+)"/);
+            if (tsMatch && tsMatch[1]) {
+                const entryMs = parsePythonIsoformat(tsMatch[1]);
+                if (Number.isNaN(entryMs) || entryMs < sinceMs) {
+                    continue;
+                }
+            }
+        }
         const entry = JSON.parse(line);
         if (sinceMs !== null && !Number.isNaN(sinceMs)) {
             const entryTs = entry["ts"];

--- a/skills/doc-wiki/scripts/event_logger.ts
+++ b/skills/doc-wiki/scripts/event_logger.ts
@@ -194,6 +194,16 @@ function _readEvents(
   for (const rawLine of raw.split("\n")) {
     const line = rawLine.trim();
     if (!line) continue;
+    // Fast-path log parsing: avoid JSON.parse on every line if we can reject based on timestamp
+    if (sinceMs !== null && !Number.isNaN(sinceMs)) {
+      const tsMatch = line.match(/^{"ts":"([^"]+)"/);
+      if (tsMatch && tsMatch[1]) {
+        const entryMs = parsePythonIsoformat(tsMatch[1]);
+        if (Number.isNaN(entryMs) || entryMs < sinceMs) {
+          continue;
+        }
+      }
+    }
     const entry = JSON.parse(line) as Record<string, unknown>;
     if (sinceMs !== null && !Number.isNaN(sinceMs)) {
       const entryTs = entry["ts"];


### PR DESCRIPTION
💡 What: Added a fast-path regex check to `event_logger.ts` to skip full `JSON.parse` operations on out-of-bounds log entries based on the `ts` timestamp prefix.
🎯 Why: Parsing thousands of append-only events unconditionally is slow. We can peek at the start of each line for the timestamp and safely discard out-of-range rows without JSON overhead. 
📊 Impact: Considerably faster `getStats` runs when filtering by `since`, improving script responsiveness for large log files.
🔬 Measurement: Can benchmark `event_logger.ts stats --since <date>` on large wiki directories to observe faster execution times.

---
*PR created automatically by Jules for task [13967536611440863765](https://jules.google.com/task/13967536611440863765) started by @rfv-code*