### PR TITLE
⚡ Bolt: [performance improvement] Fast-path JSON log parsing in event_logger

### DIFF
--- a/skills/doc-wiki/scripts/event_logger.js
+++ b/skills/doc-wiki/scripts/event_logger.js
@@ -150,6 +150,18 @@ function _readEvents(wikiRoot, since = null) {
         const line = rawLine.trim();
         if (!line)
             continue;
+        if (sinceMs !== null && !Number.isNaN(sinceMs)) {
+            // Fast-path: extract ts field without parsing the whole JSON
+            const match = line.match(/^{"ts":"([^"]+)"/);
+            if (match && match[1]) {
+                const entryMs = parsePythonIsoformat(match[1]);
+                // Fast-path should match exactly the slow-path discard logic below:
+                // if Number.isNaN(entryMs) || entryMs < sinceMs, it drops the event.
+                if (Number.isNaN(entryMs) || entryMs < sinceMs) {
+                    continue;
+                }
+            }
+        }
         const entry = JSON.parse(line);
         if (sinceMs !== null && !Number.isNaN(sinceMs)) {
             const entryTs = entry["ts"];

--- a/skills/doc-wiki/scripts/event_logger.ts
+++ b/skills/doc-wiki/scripts/event_logger.ts
@@ -194,6 +194,20 @@ function _readEvents(
   for (const rawLine of raw.split("\n")) {
     const line = rawLine.trim();
     if (!line) continue;
+
+    if (sinceMs !== null && !Number.isNaN(sinceMs)) {
+      // Fast-path: extract ts field without parsing the whole JSON
+      const match = line.match(/^{"ts":"([^"]+)"/);
+      if (match && match[1]) {
+        const entryMs = parsePythonIsoformat(match[1]);
+        // Fast-path should match exactly the slow-path discard logic below:
+        // if Number.isNaN(entryMs) || entryMs < sinceMs, it drops the event.
+        if (Number.isNaN(entryMs) || entryMs < sinceMs) {
+          continue;
+        }
+      }
+    }
+
     const entry = JSON.parse(line) as Record<string, unknown>;
     if (sinceMs !== null && !Number.isNaN(sinceMs)) {
       const entryTs = entry["ts"];


### PR DESCRIPTION
💡 What: Adds an anchored regex to `_readEvents` in `event_logger.ts` to extract the `ts` field quickly, skipping `JSON.parse` if the event is older than `--since`.
🎯 Why: Calling `JSON.parse` unconditionally on every line of large log files like `events.jsonl` is a major performance bottleneck, especially when filtering.
📊 Impact: Significantly reduces processing time for `_readEvents` on large log files by avoiding full JSON deserialization for discarded events.
🔬 Measurement: Compare the execution time of `node event_logger.js stats --since X` before and after this change on a large `events.jsonl` file.

---
*PR created automatically by Jules for task [14721205366596663419](https://jules.google.com/task/14721205366596663419) started by @rfv-code*