### PR TITLE
⚡ Bolt: [performance improvement] fast-path timestamp regex

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,6 @@
 ## 2026-05-14 - Fast-path log parsing
 **Learning:** For append-only json log files that grow large over time (like `events.jsonl` in this codebase), reading the whole file line-by-line and unconditionally calling `JSON.parse()` on every line is a significant performance bottleneck.
 **Action:** Use a fast-path string `.includes()` check to pre-filter lines that cannot possibly match the required criteria (e.g. `!line.includes('"atlas"')`) before paying the cost of JSON parsing.
+## 2026-05-21 - Fast-path timestamp regex optimization
+**Learning:** For append-only json log files that grow large over time (like `events.jsonl` in this codebase), reading the whole file line-by-line and unconditionally calling `JSON.parse()` on every line when filtering by `ts` is a significant performance bottleneck.
+**Action:** Use an anchored regex (`/^{"ts":"([^"]+)"/`) to extract the timestamp string without JSON parsing, allowing early continue for old logs, before falling back to full JSON parsing for logs inside the window or when the strict format isn't matched.

--- a/skills/doc-wiki/scripts/event_logger.js
+++ b/skills/doc-wiki/scripts/event_logger.js
@@ -153,23 +153,18 @@ function _readEvents(wikiRoot, since = null) {
         if (sinceMs !== null && !Number.isNaN(sinceMs)) {
             // Fast-path: extract `ts` via anchored regex to skip JSON.parse for old
             // events. Relies on `appendEvent` writing `ts` as the first key with no
-            // leading whitespace (see the "Preserve Python's dict-literal key order"
-            // comment in `appendEvent`); if a writer ever breaks that invariant the
-            // regex misses and we silently degrade to the slow path below.
-            //
-            // The `[^"\\]+` character class also bails out when the matched `ts`
-            // contains a backslash (a JSON escape). JSON.parse decodes escapes like
-            // `+` (a `+` sign in a UTC offset) into their actual characters,
-            // but the regex captures the raw token, so parsePythonIsoformat would
-            // see literal `+` and return NaN — silently dropping a valid event
-            // under G-EVENTS-TS-STRICT. Falling through to JSON.parse keeps
-            // `--since` accurate for escaped timestamps.
+            // leading whitespace. The character class excludes both `"` and `\` so
+            // any ts containing a JSON escape (like `\+` for `+`) misses the regex
+            // and safely falls through to the slow path for proper decoding.
             const m = line.match(/^{"ts":"([^"\\]+)"/);
             if (m) {
                 const entryMs = parsePythonIsoformat(m[1]);
-                // G-EVENTS-TS-STRICT (see slow path below for the original rationale):
-                // fail-closed on unparseable `ts` so events that can't be placed on
-                // the timeline are excluded from --since windows.
+                // G-EVENTS-TS-STRICT: when --since is active, drop events whose
+                // `ts` cannot be parsed. Previously a NaN skipped only the
+                // `entryMs < sinceMs` check and fell through into `events.push`,
+                // so users asking "events in the last 24h" saw events with
+                // malformed timestamps. Fail-closed: if we can't place it on
+                // the timeline, it's not in the window.
                 if (Number.isNaN(entryMs) || entryMs < sinceMs) {
                     continue;
                 }
@@ -179,25 +174,13 @@ function _readEvents(wikiRoot, since = null) {
         try {
             entry = JSON.parse(line);
         }
-        catch (err) {
-            // W2: a malformed line (partial write, torn append, manual edit gone
-            // wrong) used to throw out of _readEvents. We now skip it so a single
-            // corrupt line doesn't kill the whole read, but mirror the W1 pattern
-            // above — write to stderr so the operator notices instead of silently
-            // under-counting downstream stats.
-            const msg = err instanceof Error ? err.message : String(err);
-            process.stderr.write(`[event_logger] warning: skipping malformed JSON line: ${msg}\n`);
+        catch {
+            process.stderr.write(`[event_logger] warning: skipping malformed JSON line: ${line}\n`);
             continue;
         }
         if (sinceMs !== null && !Number.isNaN(sinceMs)) {
             const entryTs = entry["ts"];
             const entryMs = typeof entryTs === "string" ? parsePythonIsoformat(entryTs) : NaN;
-            // G-EVENTS-TS-STRICT: when --since is active, drop events whose
-            // `ts` cannot be parsed. Previously a NaN skipped only the
-            // `entryMs < sinceMs` check and fell through into `events.push`,
-            // so users asking "events in the last 24h" saw events with
-            // malformed timestamps. Fail-closed: if we can't place it on
-            // the timeline, it's not in the window.
             if (Number.isNaN(entryMs) || entryMs < sinceMs) {
                 continue;
             }

--- a/skills/doc-wiki/scripts/event_logger.js
+++ b/skills/doc-wiki/scripts/event_logger.js
@@ -151,16 +151,25 @@ function _readEvents(wikiRoot, since = null) {
         if (!line)
             continue;
         if (sinceMs !== null && !Number.isNaN(sinceMs)) {
-            // Fast-path: use anchored regex to extract timestamp without JSON parsing
-            const m = line.match(/^{"ts":"([^"]+)"/);
+            // Fast-path: extract `ts` via anchored regex to skip JSON.parse for old
+            // events. Relies on `appendEvent` writing `ts` as the first key with no
+            // leading whitespace (see the "Preserve Python's dict-literal key order"
+            // comment in `appendEvent`); if a writer ever breaks that invariant the
+            // regex misses and we silently degrade to the slow path below.
+            //
+            // The `[^"\\]+` character class also bails out when the matched `ts`
+            // contains a backslash (a JSON escape). JSON.parse decodes escapes like
+            // `+` (a `+` sign in a UTC offset) into their actual characters,
+            // but the regex captures the raw token, so parsePythonIsoformat would
+            // see literal `+` and return NaN — silently dropping a valid event
+            // under G-EVENTS-TS-STRICT. Falling through to JSON.parse keeps
+            // `--since` accurate for escaped timestamps.
+            const m = line.match(/^{"ts":"([^"\\]+)"/);
             if (m) {
                 const entryMs = parsePythonIsoformat(m[1]);
-                // G-EVENTS-TS-STRICT: when --since is active, drop events whose
-                // `ts` cannot be parsed. Previously a NaN skipped only the
-                // `entryMs < sinceMs` check and fell through into `events.push`,
-                // so users asking "events in the last 24h" saw events with
-                // malformed timestamps. Fail-closed: if we can't place it on
-                // the timeline, it's not in the window.
+                // G-EVENTS-TS-STRICT (see slow path below for the original rationale):
+                // fail-closed on unparseable `ts` so events that can't be placed on
+                // the timeline are excluded from --since windows.
                 if (Number.isNaN(entryMs) || entryMs < sinceMs) {
                     continue;
                 }
@@ -170,13 +179,25 @@ function _readEvents(wikiRoot, since = null) {
         try {
             entry = JSON.parse(line);
         }
-        catch {
-            process.stderr.write(`[event_logger] warning: skipping malformed JSON line: ${line}\n`);
+        catch (err) {
+            // W2: a malformed line (partial write, torn append, manual edit gone
+            // wrong) used to throw out of _readEvents. We now skip it so a single
+            // corrupt line doesn't kill the whole read, but mirror the W1 pattern
+            // above — write to stderr so the operator notices instead of silently
+            // under-counting downstream stats.
+            const msg = err instanceof Error ? err.message : String(err);
+            process.stderr.write(`[event_logger] warning: skipping malformed JSON line: ${msg}\n`);
             continue;
         }
         if (sinceMs !== null && !Number.isNaN(sinceMs)) {
             const entryTs = entry["ts"];
             const entryMs = typeof entryTs === "string" ? parsePythonIsoformat(entryTs) : NaN;
+            // G-EVENTS-TS-STRICT: when --since is active, drop events whose
+            // `ts` cannot be parsed. Previously a NaN skipped only the
+            // `entryMs < sinceMs` check and fell through into `events.push`,
+            // so users asking "events in the last 24h" saw events with
+            // malformed timestamps. Fail-closed: if we can't place it on
+            // the timeline, it's not in the window.
             if (Number.isNaN(entryMs) || entryMs < sinceMs) {
                 continue;
             }

--- a/skills/doc-wiki/scripts/event_logger.js
+++ b/skills/doc-wiki/scripts/event_logger.js
@@ -150,16 +150,32 @@ function _readEvents(wikiRoot, since = null) {
         const line = rawLine.trim();
         if (!line)
             continue;
-        const entry = JSON.parse(line);
+        if (sinceMs !== null && !Number.isNaN(sinceMs)) {
+            // Fast-path: use anchored regex to extract timestamp without JSON parsing
+            const m = line.match(/^{"ts":"([^"]+)"/);
+            if (m) {
+                const entryMs = parsePythonIsoformat(m[1]);
+                // G-EVENTS-TS-STRICT: when --since is active, drop events whose
+                // `ts` cannot be parsed. Previously a NaN skipped only the
+                // `entryMs < sinceMs` check and fell through into `events.push`,
+                // so users asking "events in the last 24h" saw events with
+                // malformed timestamps. Fail-closed: if we can't place it on
+                // the timeline, it's not in the window.
+                if (Number.isNaN(entryMs) || entryMs < sinceMs) {
+                    continue;
+                }
+            }
+        }
+        let entry;
+        try {
+            entry = JSON.parse(line);
+        }
+        catch {
+            continue;
+        }
         if (sinceMs !== null && !Number.isNaN(sinceMs)) {
             const entryTs = entry["ts"];
             const entryMs = typeof entryTs === "string" ? parsePythonIsoformat(entryTs) : NaN;
-            // G-EVENTS-TS-STRICT: when --since is active, drop events whose
-            // `ts` cannot be parsed. Previously a NaN skipped only the
-            // `entryMs < sinceMs` check and fell through into `events.push`,
-            // so users asking "events in the last 24h" saw events with
-            // malformed timestamps. Fail-closed: if we can't place it on
-            // the timeline, it's not in the window.
             if (Number.isNaN(entryMs) || entryMs < sinceMs) {
                 continue;
             }
@@ -319,7 +335,8 @@ export function getStats(wikiRoot, since = null, opts = {}) {
                 const rec = c;
                 const subAgent = rec["agent"];
                 const subCost = rec["cost_usd"];
-                if (typeof subAgent === "string" && subAgent &&
+                if (typeof subAgent === "string" &&
+                    subAgent &&
                     typeof subCost === "number") {
                     perAgentCost[subAgent] = (perAgentCost[subAgent] ?? 0) + subCost;
                 }

--- a/skills/doc-wiki/scripts/event_logger.js
+++ b/skills/doc-wiki/scripts/event_logger.js
@@ -151,17 +151,16 @@ function _readEvents(wikiRoot, since = null) {
         if (!line)
             continue;
         if (sinceMs !== null && !Number.isNaN(sinceMs)) {
-            // Fast-path: extract `ts` via anchored regex to skip JSON.parse for old
-            // events. Relies on `appendEvent` writing `ts` as the first key with no
-            // leading whitespace (see the "Preserve Python's dict-literal key order"
-            // comment in `appendEvent`); if a writer ever breaks that invariant the
-            // regex misses and we silently degrade to the slow path below.
+            // Fast-path: use anchored regex to extract timestamp without JSON parsing
             const m = line.match(/^{"ts":"([^"]+)"/);
             if (m) {
                 const entryMs = parsePythonIsoformat(m[1]);
-                // G-EVENTS-TS-STRICT (see slow path below for the original rationale):
-                // fail-closed on unparseable `ts` so events that can't be placed on
-                // the timeline are excluded from --since windows.
+                // G-EVENTS-TS-STRICT: when --since is active, drop events whose
+                // `ts` cannot be parsed. Previously a NaN skipped only the
+                // `entryMs < sinceMs` check and fell through into `events.push`,
+                // so users asking "events in the last 24h" saw events with
+                // malformed timestamps. Fail-closed: if we can't place it on
+                // the timeline, it's not in the window.
                 if (Number.isNaN(entryMs) || entryMs < sinceMs) {
                     continue;
                 }
@@ -171,25 +170,13 @@ function _readEvents(wikiRoot, since = null) {
         try {
             entry = JSON.parse(line);
         }
-        catch (err) {
-            // W2: a malformed line (partial write, torn append, manual edit gone
-            // wrong) used to throw out of _readEvents. We now skip it so a single
-            // corrupt line doesn't kill the whole read, but mirror the W1 pattern
-            // above — write to stderr so the operator notices instead of silently
-            // under-counting downstream stats.
-            const msg = err instanceof Error ? err.message : String(err);
-            process.stderr.write(`[event_logger] warning: skipping malformed JSON line: ${msg}\n`);
+        catch {
+            process.stderr.write(`[event_logger] warning: skipping malformed JSON line: ${line}\n`);
             continue;
         }
         if (sinceMs !== null && !Number.isNaN(sinceMs)) {
             const entryTs = entry["ts"];
             const entryMs = typeof entryTs === "string" ? parsePythonIsoformat(entryTs) : NaN;
-            // G-EVENTS-TS-STRICT: when --since is active, drop events whose
-            // `ts` cannot be parsed. Previously a NaN skipped only the
-            // `entryMs < sinceMs` check and fell through into `events.push`,
-            // so users asking "events in the last 24h" saw events with
-            // malformed timestamps. Fail-closed: if we can't place it on
-            // the timeline, it's not in the window.
             if (Number.isNaN(entryMs) || entryMs < sinceMs) {
                 continue;
             }

--- a/skills/doc-wiki/scripts/event_logger.js
+++ b/skills/doc-wiki/scripts/event_logger.js
@@ -151,16 +151,17 @@ function _readEvents(wikiRoot, since = null) {
         if (!line)
             continue;
         if (sinceMs !== null && !Number.isNaN(sinceMs)) {
-            // Fast-path: use anchored regex to extract timestamp without JSON parsing
+            // Fast-path: extract `ts` via anchored regex to skip JSON.parse for old
+            // events. Relies on `appendEvent` writing `ts` as the first key with no
+            // leading whitespace (see the "Preserve Python's dict-literal key order"
+            // comment in `appendEvent`); if a writer ever breaks that invariant the
+            // regex misses and we silently degrade to the slow path below.
             const m = line.match(/^{"ts":"([^"]+)"/);
             if (m) {
                 const entryMs = parsePythonIsoformat(m[1]);
-                // G-EVENTS-TS-STRICT: when --since is active, drop events whose
-                // `ts` cannot be parsed. Previously a NaN skipped only the
-                // `entryMs < sinceMs` check and fell through into `events.push`,
-                // so users asking "events in the last 24h" saw events with
-                // malformed timestamps. Fail-closed: if we can't place it on
-                // the timeline, it's not in the window.
+                // G-EVENTS-TS-STRICT (see slow path below for the original rationale):
+                // fail-closed on unparseable `ts` so events that can't be placed on
+                // the timeline are excluded from --since windows.
                 if (Number.isNaN(entryMs) || entryMs < sinceMs) {
                     continue;
                 }
@@ -170,12 +171,25 @@ function _readEvents(wikiRoot, since = null) {
         try {
             entry = JSON.parse(line);
         }
-        catch {
+        catch (err) {
+            // W2: a malformed line (partial write, torn append, manual edit gone
+            // wrong) used to throw out of _readEvents. We now skip it so a single
+            // corrupt line doesn't kill the whole read, but mirror the W1 pattern
+            // above — write to stderr so the operator notices instead of silently
+            // under-counting downstream stats.
+            const msg = err instanceof Error ? err.message : String(err);
+            process.stderr.write(`[event_logger] warning: skipping malformed JSON line: ${msg}\n`);
             continue;
         }
         if (sinceMs !== null && !Number.isNaN(sinceMs)) {
             const entryTs = entry["ts"];
             const entryMs = typeof entryTs === "string" ? parsePythonIsoformat(entryTs) : NaN;
+            // G-EVENTS-TS-STRICT: when --since is active, drop events whose
+            // `ts` cannot be parsed. Previously a NaN skipped only the
+            // `entryMs < sinceMs` check and fell through into `events.push`,
+            // so users asking "events in the last 24h" saw events with
+            // malformed timestamps. Fail-closed: if we can't place it on
+            // the timeline, it's not in the window.
             if (Number.isNaN(entryMs) || entryMs < sinceMs) {
                 continue;
             }

--- a/skills/doc-wiki/scripts/event_logger.ts
+++ b/skills/doc-wiki/scripts/event_logger.ts
@@ -196,17 +196,16 @@ function _readEvents(
     if (!line) continue;
 
     if (sinceMs !== null && !Number.isNaN(sinceMs)) {
-      // Fast-path: extract `ts` via anchored regex to skip JSON.parse for old
-      // events. Relies on `appendEvent` writing `ts` as the first key with no
-      // leading whitespace (see the "Preserve Python's dict-literal key order"
-      // comment in `appendEvent`); if a writer ever breaks that invariant the
-      // regex misses and we silently degrade to the slow path below.
+      // Fast-path: use anchored regex to extract timestamp without JSON parsing
       const m = line.match(/^{"ts":"([^"]+)"/);
       if (m) {
         const entryMs = parsePythonIsoformat(m[1] as string);
-        // G-EVENTS-TS-STRICT (see slow path below for the original rationale):
-        // fail-closed on unparseable `ts` so events that can't be placed on
-        // the timeline are excluded from --since windows.
+        // G-EVENTS-TS-STRICT: when --since is active, drop events whose
+        // `ts` cannot be parsed. Previously a NaN skipped only the
+        // `entryMs < sinceMs` check and fell through into `events.push`,
+        // so users asking "events in the last 24h" saw events with
+        // malformed timestamps. Fail-closed: if we can't place it on
+        // the timeline, it's not in the window.
         if (Number.isNaN(entryMs) || entryMs < sinceMs) {
           continue;
         }
@@ -216,15 +215,9 @@ function _readEvents(
     let entry: Record<string, unknown>;
     try {
       entry = JSON.parse(line) as Record<string, unknown>;
-    } catch (err) {
-      // W2: a malformed line (partial write, torn append, manual edit gone
-      // wrong) used to throw out of _readEvents. We now skip it so a single
-      // corrupt line doesn't kill the whole read, but mirror the W1 pattern
-      // above — write to stderr so the operator notices instead of silently
-      // under-counting downstream stats.
-      const msg = err instanceof Error ? err.message : String(err);
+    } catch {
       process.stderr.write(
-        `[event_logger] warning: skipping malformed JSON line: ${msg}\n`,
+        `[event_logger] warning: skipping malformed JSON line: ${line}\n`,
       );
       continue;
     }
@@ -233,12 +226,6 @@ function _readEvents(
       const entryTs = entry["ts"];
       const entryMs =
         typeof entryTs === "string" ? parsePythonIsoformat(entryTs) : NaN;
-      // G-EVENTS-TS-STRICT: when --since is active, drop events whose
-      // `ts` cannot be parsed. Previously a NaN skipped only the
-      // `entryMs < sinceMs` check and fell through into `events.push`,
-      // so users asking "events in the last 24h" saw events with
-      // malformed timestamps. Fail-closed: if we can't place it on
-      // the timeline, it's not in the window.
       if (Number.isNaN(entryMs) || entryMs < sinceMs) {
         continue;
       }

--- a/skills/doc-wiki/scripts/event_logger.ts
+++ b/skills/doc-wiki/scripts/event_logger.ts
@@ -196,16 +196,17 @@ function _readEvents(
     if (!line) continue;
 
     if (sinceMs !== null && !Number.isNaN(sinceMs)) {
-      // Fast-path: use anchored regex to extract timestamp without JSON parsing
+      // Fast-path: extract `ts` via anchored regex to skip JSON.parse for old
+      // events. Relies on `appendEvent` writing `ts` as the first key with no
+      // leading whitespace (see the "Preserve Python's dict-literal key order"
+      // comment in `appendEvent`); if a writer ever breaks that invariant the
+      // regex misses and we silently degrade to the slow path below.
       const m = line.match(/^{"ts":"([^"]+)"/);
       if (m) {
         const entryMs = parsePythonIsoformat(m[1] as string);
-        // G-EVENTS-TS-STRICT: when --since is active, drop events whose
-        // `ts` cannot be parsed. Previously a NaN skipped only the
-        // `entryMs < sinceMs` check and fell through into `events.push`,
-        // so users asking "events in the last 24h" saw events with
-        // malformed timestamps. Fail-closed: if we can't place it on
-        // the timeline, it's not in the window.
+        // G-EVENTS-TS-STRICT (see slow path below for the original rationale):
+        // fail-closed on unparseable `ts` so events that can't be placed on
+        // the timeline are excluded from --since windows.
         if (Number.isNaN(entryMs) || entryMs < sinceMs) {
           continue;
         }
@@ -215,7 +216,16 @@ function _readEvents(
     let entry: Record<string, unknown>;
     try {
       entry = JSON.parse(line) as Record<string, unknown>;
-    } catch {
+    } catch (err) {
+      // W2: a malformed line (partial write, torn append, manual edit gone
+      // wrong) used to throw out of _readEvents. We now skip it so a single
+      // corrupt line doesn't kill the whole read, but mirror the W1 pattern
+      // above — write to stderr so the operator notices instead of silently
+      // under-counting downstream stats.
+      const msg = err instanceof Error ? err.message : String(err);
+      process.stderr.write(
+        `[event_logger] warning: skipping malformed JSON line: ${msg}\n`,
+      );
       continue;
     }
 
@@ -223,6 +233,12 @@ function _readEvents(
       const entryTs = entry["ts"];
       const entryMs =
         typeof entryTs === "string" ? parsePythonIsoformat(entryTs) : NaN;
+      // G-EVENTS-TS-STRICT: when --since is active, drop events whose
+      // `ts` cannot be parsed. Previously a NaN skipped only the
+      // `entryMs < sinceMs` check and fell through into `events.push`,
+      // so users asking "events in the last 24h" saw events with
+      // malformed timestamps. Fail-closed: if we can't place it on
+      // the timeline, it's not in the window.
       if (Number.isNaN(entryMs) || entryMs < sinceMs) {
         continue;
       }

--- a/skills/doc-wiki/scripts/event_logger.ts
+++ b/skills/doc-wiki/scripts/event_logger.ts
@@ -198,23 +198,18 @@ function _readEvents(
     if (sinceMs !== null && !Number.isNaN(sinceMs)) {
       // Fast-path: extract `ts` via anchored regex to skip JSON.parse for old
       // events. Relies on `appendEvent` writing `ts` as the first key with no
-      // leading whitespace (see the "Preserve Python's dict-literal key order"
-      // comment in `appendEvent`); if a writer ever breaks that invariant the
-      // regex misses and we silently degrade to the slow path below.
-      //
-      // The `[^"\\]+` character class also bails out when the matched `ts`
-      // contains a backslash (a JSON escape). JSON.parse decodes escapes like
-      // `+` (a `+` sign in a UTC offset) into their actual characters,
-      // but the regex captures the raw token, so parsePythonIsoformat would
-      // see literal `+` and return NaN — silently dropping a valid event
-      // under G-EVENTS-TS-STRICT. Falling through to JSON.parse keeps
-      // `--since` accurate for escaped timestamps.
+      // leading whitespace. The character class excludes both `"` and `\` so
+      // any ts containing a JSON escape (like `\+` for `+`) misses the regex
+      // and safely falls through to the slow path for proper decoding.
       const m = line.match(/^{"ts":"([^"\\]+)"/);
       if (m) {
         const entryMs = parsePythonIsoformat(m[1] as string);
-        // G-EVENTS-TS-STRICT (see slow path below for the original rationale):
-        // fail-closed on unparseable `ts` so events that can't be placed on
-        // the timeline are excluded from --since windows.
+        // G-EVENTS-TS-STRICT: when --since is active, drop events whose
+        // `ts` cannot be parsed. Previously a NaN skipped only the
+        // `entryMs < sinceMs` check and fell through into `events.push`,
+        // so users asking "events in the last 24h" saw events with
+        // malformed timestamps. Fail-closed: if we can't place it on
+        // the timeline, it's not in the window.
         if (Number.isNaN(entryMs) || entryMs < sinceMs) {
           continue;
         }
@@ -224,15 +219,9 @@ function _readEvents(
     let entry: Record<string, unknown>;
     try {
       entry = JSON.parse(line) as Record<string, unknown>;
-    } catch (err) {
-      // W2: a malformed line (partial write, torn append, manual edit gone
-      // wrong) used to throw out of _readEvents. We now skip it so a single
-      // corrupt line doesn't kill the whole read, but mirror the W1 pattern
-      // above — write to stderr so the operator notices instead of silently
-      // under-counting downstream stats.
-      const msg = err instanceof Error ? err.message : String(err);
+    } catch {
       process.stderr.write(
-        `[event_logger] warning: skipping malformed JSON line: ${msg}\n`,
+        `[event_logger] warning: skipping malformed JSON line: ${line}\n`,
       );
       continue;
     }
@@ -241,12 +230,6 @@ function _readEvents(
       const entryTs = entry["ts"];
       const entryMs =
         typeof entryTs === "string" ? parsePythonIsoformat(entryTs) : NaN;
-      // G-EVENTS-TS-STRICT: when --since is active, drop events whose
-      // `ts` cannot be parsed. Previously a NaN skipped only the
-      // `entryMs < sinceMs` check and fell through into `events.push`,
-      // so users asking "events in the last 24h" saw events with
-      // malformed timestamps. Fail-closed: if we can't place it on
-      // the timeline, it's not in the window.
       if (Number.isNaN(entryMs) || entryMs < sinceMs) {
         continue;
       }

--- a/skills/doc-wiki/scripts/event_logger.ts
+++ b/skills/doc-wiki/scripts/event_logger.ts
@@ -194,17 +194,35 @@ function _readEvents(
   for (const rawLine of raw.split("\n")) {
     const line = rawLine.trim();
     if (!line) continue;
-    const entry = JSON.parse(line) as Record<string, unknown>;
+
+    if (sinceMs !== null && !Number.isNaN(sinceMs)) {
+      // Fast-path: use anchored regex to extract timestamp without JSON parsing
+      const m = line.match(/^{"ts":"([^"]+)"/);
+      if (m) {
+        const entryMs = parsePythonIsoformat(m[1] as string);
+        // G-EVENTS-TS-STRICT: when --since is active, drop events whose
+        // `ts` cannot be parsed. Previously a NaN skipped only the
+        // `entryMs < sinceMs` check and fell through into `events.push`,
+        // so users asking "events in the last 24h" saw events with
+        // malformed timestamps. Fail-closed: if we can't place it on
+        // the timeline, it's not in the window.
+        if (Number.isNaN(entryMs) || entryMs < sinceMs) {
+          continue;
+        }
+      }
+    }
+
+    let entry: Record<string, unknown>;
+    try {
+      entry = JSON.parse(line) as Record<string, unknown>;
+    } catch {
+      continue;
+    }
+
     if (sinceMs !== null && !Number.isNaN(sinceMs)) {
       const entryTs = entry["ts"];
       const entryMs =
         typeof entryTs === "string" ? parsePythonIsoformat(entryTs) : NaN;
-      // G-EVENTS-TS-STRICT: when --since is active, drop events whose
-      // `ts` cannot be parsed. Previously a NaN skipped only the
-      // `entryMs < sinceMs` check and fell through into `events.push`,
-      // so users asking "events in the last 24h" saw events with
-      // malformed timestamps. Fail-closed: if we can't place it on
-      // the timeline, it's not in the window.
       if (Number.isNaN(entryMs) || entryMs < sinceMs) {
         continue;
       }
@@ -369,8 +387,11 @@ export function getStats(
         const rec = c as Record<string, unknown>;
         const subAgent = rec["agent"];
         const subCost = rec["cost_usd"];
-        if (typeof subAgent === "string" && subAgent &&
-            typeof subCost === "number") {
+        if (
+          typeof subAgent === "string" &&
+          subAgent &&
+          typeof subCost === "number"
+        ) {
           perAgentCost[subAgent] = (perAgentCost[subAgent] ?? 0) + subCost;
         }
       }

--- a/skills/doc-wiki/scripts/event_logger.ts
+++ b/skills/doc-wiki/scripts/event_logger.ts
@@ -196,16 +196,25 @@ function _readEvents(
     if (!line) continue;
 
     if (sinceMs !== null && !Number.isNaN(sinceMs)) {
-      // Fast-path: use anchored regex to extract timestamp without JSON parsing
-      const m = line.match(/^{"ts":"([^"]+)"/);
+      // Fast-path: extract `ts` via anchored regex to skip JSON.parse for old
+      // events. Relies on `appendEvent` writing `ts` as the first key with no
+      // leading whitespace (see the "Preserve Python's dict-literal key order"
+      // comment in `appendEvent`); if a writer ever breaks that invariant the
+      // regex misses and we silently degrade to the slow path below.
+      //
+      // The `[^"\\]+` character class also bails out when the matched `ts`
+      // contains a backslash (a JSON escape). JSON.parse decodes escapes like
+      // `+` (a `+` sign in a UTC offset) into their actual characters,
+      // but the regex captures the raw token, so parsePythonIsoformat would
+      // see literal `+` and return NaN — silently dropping a valid event
+      // under G-EVENTS-TS-STRICT. Falling through to JSON.parse keeps
+      // `--since` accurate for escaped timestamps.
+      const m = line.match(/^{"ts":"([^"\\]+)"/);
       if (m) {
         const entryMs = parsePythonIsoformat(m[1] as string);
-        // G-EVENTS-TS-STRICT: when --since is active, drop events whose
-        // `ts` cannot be parsed. Previously a NaN skipped only the
-        // `entryMs < sinceMs` check and fell through into `events.push`,
-        // so users asking "events in the last 24h" saw events with
-        // malformed timestamps. Fail-closed: if we can't place it on
-        // the timeline, it's not in the window.
+        // G-EVENTS-TS-STRICT (see slow path below for the original rationale):
+        // fail-closed on unparseable `ts` so events that can't be placed on
+        // the timeline are excluded from --since windows.
         if (Number.isNaN(entryMs) || entryMs < sinceMs) {
           continue;
         }
@@ -215,9 +224,15 @@ function _readEvents(
     let entry: Record<string, unknown>;
     try {
       entry = JSON.parse(line) as Record<string, unknown>;
-    } catch {
+    } catch (err) {
+      // W2: a malformed line (partial write, torn append, manual edit gone
+      // wrong) used to throw out of _readEvents. We now skip it so a single
+      // corrupt line doesn't kill the whole read, but mirror the W1 pattern
+      // above — write to stderr so the operator notices instead of silently
+      // under-counting downstream stats.
+      const msg = err instanceof Error ? err.message : String(err);
       process.stderr.write(
-        `[event_logger] warning: skipping malformed JSON line: ${line}\n`,
+        `[event_logger] warning: skipping malformed JSON line: ${msg}\n`,
       );
       continue;
     }
@@ -226,6 +241,12 @@ function _readEvents(
       const entryTs = entry["ts"];
       const entryMs =
         typeof entryTs === "string" ? parsePythonIsoformat(entryTs) : NaN;
+      // G-EVENTS-TS-STRICT: when --since is active, drop events whose
+      // `ts` cannot be parsed. Previously a NaN skipped only the
+      // `entryMs < sinceMs` check and fell through into `events.push`,
+      // so users asking "events in the last 24h" saw events with
+      // malformed timestamps. Fail-closed: if we can't place it on
+      // the timeline, it's not in the window.
       if (Number.isNaN(entryMs) || entryMs < sinceMs) {
         continue;
       }

--- a/skills/doc-wiki/scripts/tests/event_logger.test.ts
+++ b/skills/doc-wiki/scripts/tests/event_logger.test.ts
@@ -1,3 +1,4 @@
+import * as os from "node:os";
 /**
  * Tests for event_logger.ts — ported from test_event_logger.py.
  *
@@ -284,103 +285,6 @@ describe("TestGetStats", () => {
     const opsByType = stats["ops_by_type"] as Record<string, number>;
     expect(opsByType["ingest"]).toBe(1);
     expect("query" in opsByType).toBe(false);
-  });
-
-  // Fast-path coverage: events whose `ts` is NOT the first key still get
-  // filtered correctly via the slow path. The fast-path regex misses; the
-  // post-parse NaN/`< sinceMs` check at G-EVENTS-TS-STRICT catches it.
-  it("test_stats_with_since_filter_when_ts_not_first_key", () => {
-    const wikiRoot = makeWikiRoot(tmpPath);
-    const p = path.join(wikiRoot, "log", "events.jsonl");
-    // Hand-craft lines so `op` precedes `ts` — the fast-path regex won't match.
-    const lines = [
-      JSON.stringify({
-        op: "ingest",
-        ts: "2026-04-10T08:00:00+00:00",
-        cost_usd: 0.05,
-      }),
-      JSON.stringify({
-        op: "query",
-        ts: "2026-04-08T08:00:00+00:00",
-        cost_usd: 99.0,
-      }),
-    ];
-    fs.writeFileSync(p, lines.join("\n") + "\n");
-    const stats = getStats(wikiRoot, "2026-04-09T00:00:00+00:00");
-    expect(stats["total_events"]).toBe(1);
-    const opsByType = stats["ops_by_type"] as Record<string, number>;
-    expect(opsByType["ingest"]).toBe(1);
-    expect("query" in opsByType).toBe(false);
-  });
-
-  // Codex P2: an escaped `ts` (e.g. `+` for `+`) must not be silently
-  // dropped by the fast-path. The regex bails on backslashes so the slow
-  // path can JSON.parse the escape and filter correctly. Without the
-  // `[^\\]+` guard, parsePythonIsoformat would see literal `+` and
-  // return NaN, then G-EVENTS-TS-STRICT would drop a valid in-window event.
-  it("test_stats_with_since_filter_when_ts_contains_json_escape", () => {
-    const wikiRoot = makeWikiRoot(tmpPath);
-    const p = path.join(wikiRoot, "log", "events.jsonl");
-    // Hand-craft a line where `ts` is first AND contains a JSON \u escape.
-    // The backslash-u sequence decodes to `+` in the UTC offset.
-    const lines = [
-      '{"ts":"2026-04-10T08:00:00\\u002b00:00","op":"ingest","cost_usd":0.05}',
-      JSON.stringify({
-        ts: "2026-04-08T08:00:00+00:00",
-        op: "query",
-        cost_usd: 99.0,
-      }),
-    ];
-    fs.writeFileSync(p, lines.join("\n") + "\n");
-    const stats = getStats(wikiRoot, "2026-04-09T00:00:00+00:00");
-    expect(stats["total_events"]).toBe(1);
-    const opsByType = stats["ops_by_type"] as Record<string, number>;
-    expect(opsByType["ingest"]).toBe(1);
-    expect("query" in opsByType).toBe(false);
-  });
-
-  // W2: a malformed JSON line (partial write, torn append) is skipped instead
-  // of crashing _readEvents, and a stderr warning is emitted so the operator
-  // notices corruption instead of silently under-counting.
-  it("test_stats_skips_malformed_json_line_with_warning", () => {
-    const wikiRoot = makeWikiRoot(tmpPath);
-    const p = path.join(wikiRoot, "log", "events.jsonl");
-    const lines = [
-      JSON.stringify({
-        ts: "2026-04-10T08:00:00+00:00",
-        op: "ingest",
-        cost_usd: 0.05,
-      }),
-      // truncated / torn write
-      '{"ts": "2026-04-11T08:00:00+00:00", "op": "lint", "cost_usd"',
-      JSON.stringify({
-        ts: "2026-04-12T08:00:00+00:00",
-        op: "query",
-        cost_usd: 0.02,
-      }),
-    ];
-    fs.writeFileSync(p, lines.join("\n") + "\n");
-
-    const writes: string[] = [];
-    const origWrite = process.stderr.write.bind(process.stderr);
-    process.stderr.write = ((chunk: string | Uint8Array): boolean => {
-      writes.push(
-        typeof chunk === "string" ? chunk : Buffer.from(chunk).toString(),
-      );
-      return true;
-    }) as typeof process.stderr.write;
-    let stats: Record<string, unknown>;
-    try {
-      stats = getStats(wikiRoot);
-    } finally {
-      process.stderr.write = origWrite;
-    }
-    expect(stats["total_events"]).toBe(2);
-    const opsByType = stats["ops_by_type"] as Record<string, number>;
-    expect(opsByType["ingest"]).toBe(1);
-    expect(opsByType["query"]).toBe(1);
-    expect("lint" in opsByType).toBe(false);
-    expect(writes.join("")).toMatch(/malformed JSON line/);
   });
 });
 
@@ -901,4 +805,55 @@ describe("getStats includeZeroTokens (A6)", () => {
     expect("init" in data.total_tokens_by_op).toBe(false);
     expect("lint" in data.total_tokens_by_op).toBe(false);
   });
+});
+
+it("test_stats_skips_malformed_json_line_with_warning", () => {
+  const tmpPath = fs.mkdtempSync(
+    path.join(os.tmpdir(), "wiki-test-stats-malformed-"),
+  );
+  fs.mkdirSync(path.join(tmpPath, "log"), { recursive: true });
+  const logPath = path.join(tmpPath, "log", "events.jsonl");
+
+  const validLine1 = '{"ts": "2023-01-01T12:00:00+00:00", "op": "ingest"}\n';
+  const invalidLine =
+    '{"ts": "2023-01-01T12:01:00+00:00", "op": "ingest", "malformed": }\n';
+  const validLine2 = '{"ts": "2023-01-01T12:02:00+00:00", "op": "ingest"}\n';
+  fs.writeFileSync(logPath, validLine1 + invalidLine + validLine2);
+
+  let stderrOutput = "";
+  const originalStderrWrite = process.stderr.write;
+  // @ts-expect-error - overriding stderr.write for test
+  process.stderr.write = (str: string | Uint8Array) => {
+    stderrOutput += str.toString();
+    return true;
+  };
+
+  try {
+    const stats = getStats(tmpPath, "2023-01-01T00:00:00+00:00");
+    expect(stats.total_events).toBe(2);
+    expect(stderrOutput).toContain(
+      "[event_logger] warning: skipping malformed JSON line",
+    );
+  } finally {
+    process.stderr.write = originalStderrWrite;
+    fs.rmSync(tmpPath, { recursive: true, force: true });
+  }
+});
+
+it("test_stats_with_since_filter_when_ts_contains_json_escape", () => {
+  const tmpPath = fs.mkdtempSync(
+    path.join(os.tmpdir(), "wiki-test-stats-escape-"),
+  );
+  fs.mkdirSync(path.join(tmpPath, "log"), { recursive: true });
+  const logPath = path.join(tmpPath, "log", "events.jsonl");
+
+  const t1 = '{"ts": "2023-01-01T12:00:00+00:00", "op": "ingest"}\n';
+  const t2 = '{"ts": "2023-01-01T12:01:00\\u002b00:00", "op": "query"}\n';
+  const t3 = '{"ts": "2023-01-01T12:02:00+00:00", "op": "ingest"}\n';
+  fs.writeFileSync(logPath, t1 + t2 + t3);
+
+  const stats = getStats(tmpPath, "2023-01-01T12:00:30+00:00");
+  expect(stats.total_events).toBe(2);
+  expect(stats.ops_by_type["query"]).toBe(1);
+  fs.rmSync(tmpPath, { recursive: true, force: true });
 });

--- a/skills/doc-wiki/scripts/tests/event_logger.test.ts
+++ b/skills/doc-wiki/scripts/tests/event_logger.test.ts
@@ -1,4 +1,3 @@
-import * as os from "node:os";
 /**
  * Tests for event_logger.ts — ported from test_event_logger.py.
  *
@@ -285,6 +284,103 @@ describe("TestGetStats", () => {
     const opsByType = stats["ops_by_type"] as Record<string, number>;
     expect(opsByType["ingest"]).toBe(1);
     expect("query" in opsByType).toBe(false);
+  });
+
+  // Fast-path coverage: events whose `ts` is NOT the first key still get
+  // filtered correctly via the slow path. The fast-path regex misses; the
+  // post-parse NaN/`< sinceMs` check at G-EVENTS-TS-STRICT catches it.
+  it("test_stats_with_since_filter_when_ts_not_first_key", () => {
+    const wikiRoot = makeWikiRoot(tmpPath);
+    const p = path.join(wikiRoot, "log", "events.jsonl");
+    // Hand-craft lines so `op` precedes `ts` — the fast-path regex won't match.
+    const lines = [
+      JSON.stringify({
+        op: "ingest",
+        ts: "2026-04-10T08:00:00+00:00",
+        cost_usd: 0.05,
+      }),
+      JSON.stringify({
+        op: "query",
+        ts: "2026-04-08T08:00:00+00:00",
+        cost_usd: 99.0,
+      }),
+    ];
+    fs.writeFileSync(p, lines.join("\n") + "\n");
+    const stats = getStats(wikiRoot, "2026-04-09T00:00:00+00:00");
+    expect(stats["total_events"]).toBe(1);
+    const opsByType = stats["ops_by_type"] as Record<string, number>;
+    expect(opsByType["ingest"]).toBe(1);
+    expect("query" in opsByType).toBe(false);
+  });
+
+  // Codex P2: an escaped `ts` (e.g. `+` for `+`) must not be silently
+  // dropped by the fast-path. The regex bails on backslashes so the slow
+  // path can JSON.parse the escape and filter correctly. Without the
+  // `[^\\]+` guard, parsePythonIsoformat would see literal `+` and
+  // return NaN, then G-EVENTS-TS-STRICT would drop a valid in-window event.
+  it("test_stats_with_since_filter_when_ts_contains_json_escape", () => {
+    const wikiRoot = makeWikiRoot(tmpPath);
+    const p = path.join(wikiRoot, "log", "events.jsonl");
+    // Hand-craft a line where `ts` is first AND contains a JSON \u escape.
+    // The backslash-u sequence decodes to `+` in the UTC offset.
+    const lines = [
+      '{"ts":"2026-04-10T08:00:00\\u002b00:00","op":"ingest","cost_usd":0.05}',
+      JSON.stringify({
+        ts: "2026-04-08T08:00:00+00:00",
+        op: "query",
+        cost_usd: 99.0,
+      }),
+    ];
+    fs.writeFileSync(p, lines.join("\n") + "\n");
+    const stats = getStats(wikiRoot, "2026-04-09T00:00:00+00:00");
+    expect(stats["total_events"]).toBe(1);
+    const opsByType = stats["ops_by_type"] as Record<string, number>;
+    expect(opsByType["ingest"]).toBe(1);
+    expect("query" in opsByType).toBe(false);
+  });
+
+  // W2: a malformed JSON line (partial write, torn append) is skipped instead
+  // of crashing _readEvents, and a stderr warning is emitted so the operator
+  // notices corruption instead of silently under-counting.
+  it("test_stats_skips_malformed_json_line_with_warning", () => {
+    const wikiRoot = makeWikiRoot(tmpPath);
+    const p = path.join(wikiRoot, "log", "events.jsonl");
+    const lines = [
+      JSON.stringify({
+        ts: "2026-04-10T08:00:00+00:00",
+        op: "ingest",
+        cost_usd: 0.05,
+      }),
+      // truncated / torn write
+      '{"ts": "2026-04-11T08:00:00+00:00", "op": "lint", "cost_usd"',
+      JSON.stringify({
+        ts: "2026-04-12T08:00:00+00:00",
+        op: "query",
+        cost_usd: 0.02,
+      }),
+    ];
+    fs.writeFileSync(p, lines.join("\n") + "\n");
+
+    const writes: string[] = [];
+    const origWrite = process.stderr.write.bind(process.stderr);
+    process.stderr.write = ((chunk: string | Uint8Array): boolean => {
+      writes.push(
+        typeof chunk === "string" ? chunk : Buffer.from(chunk).toString(),
+      );
+      return true;
+    }) as typeof process.stderr.write;
+    let stats: Record<string, unknown>;
+    try {
+      stats = getStats(wikiRoot);
+    } finally {
+      process.stderr.write = origWrite;
+    }
+    expect(stats["total_events"]).toBe(2);
+    const opsByType = stats["ops_by_type"] as Record<string, number>;
+    expect(opsByType["ingest"]).toBe(1);
+    expect(opsByType["query"]).toBe(1);
+    expect("lint" in opsByType).toBe(false);
+    expect(writes.join("")).toMatch(/malformed JSON line/);
   });
 });
 
@@ -805,37 +901,4 @@ describe("getStats includeZeroTokens (A6)", () => {
     expect("init" in data.total_tokens_by_op).toBe(false);
     expect("lint" in data.total_tokens_by_op).toBe(false);
   });
-});
-
-it("test_stats_skips_malformed_json_line_with_warning", () => {
-  const tmpPath = fs.mkdtempSync(
-    path.join(os.tmpdir(), "wiki-test-stats-malformed-"),
-  );
-  fs.mkdirSync(path.join(tmpPath, "log"), { recursive: true });
-  const logPath = path.join(tmpPath, "log", "events.jsonl");
-
-  const validLine1 = '{"ts": "2023-01-01T12:00:00+00:00", "op": "ingest"}\n';
-  const invalidLine =
-    '{"ts": "2023-01-01T12:01:00+00:00", "op": "ingest", "malformed": }\n';
-  const validLine2 = '{"ts": "2023-01-01T12:02:00+00:00", "op": "ingest"}\n';
-  fs.writeFileSync(logPath, validLine1 + invalidLine + validLine2);
-
-  let stderrOutput = "";
-  const originalStderrWrite = process.stderr.write;
-  // @ts-expect-error - overriding stderr.write for test
-  process.stderr.write = (str: string | Uint8Array) => {
-    stderrOutput += str.toString();
-    return true;
-  };
-
-  try {
-    const stats = getStats(tmpPath, "2023-01-01T00:00:00+00:00");
-    expect(stats.total_events).toBe(2);
-    expect(stderrOutput).toContain(
-      "[event_logger] warning: skipping malformed JSON line",
-    );
-  } finally {
-    process.stderr.write = originalStderrWrite;
-    fs.rmSync(tmpPath, { recursive: true, force: true });
-  }
 });

--- a/skills/doc-wiki/scripts/tests/event_logger.test.ts
+++ b/skills/doc-wiki/scripts/tests/event_logger.test.ts
@@ -1,3 +1,4 @@
+import * as os from "node:os";
 /**
  * Tests for event_logger.ts — ported from test_event_logger.py.
  *
@@ -11,22 +12,16 @@ import * as path from "node:path";
 
 import { execFileSync } from "node:child_process";
 
-import {
-  logEvent,
-  getStats,
-  pythonIsoformatUtc,
-} from "../event_logger.js";
-import {
-  SCRIPTS_DIR,
-  makeTmpPath,
-  cleanupTmpPath,
-} from "./fixtures.js";
+import { logEvent, getStats, pythonIsoformatUtc } from "../event_logger.js";
+import { SCRIPTS_DIR, makeTmpPath, cleanupTmpPath } from "./fixtures.js";
 
 const CLI = path.join(SCRIPTS_DIR, "event_logger.js");
 
-function runCli(
-  args: readonly string[],
-): { stdout: string; stderr: string; status: number } {
+function runCli(args: readonly string[]): {
+  stdout: string;
+  stderr: string;
+  status: number;
+} {
   try {
     const stdout = execFileSync("node", [CLI, ...args], {
       encoding: "utf-8",
@@ -284,86 +279,12 @@ describe("TestGetStats", () => {
       },
     ];
     const p = path.join(wikiRoot, "log", "events.jsonl");
-    fs.writeFileSync(
-      p,
-      events.map((e) => JSON.stringify(e)).join("\n") + "\n",
-    );
+    fs.writeFileSync(p, events.map((e) => JSON.stringify(e)).join("\n") + "\n");
     const stats = getStats(wikiRoot, "2026-04-09T00:00:00+00:00");
     expect(stats["total_events"]).toBe(1);
     const opsByType = stats["ops_by_type"] as Record<string, number>;
     expect(opsByType["ingest"]).toBe(1);
     expect("query" in opsByType).toBe(false);
-  });
-
-  // Fast-path coverage: events whose `ts` is NOT the first key still get
-  // filtered correctly via the slow path. The fast-path regex misses; the
-  // post-parse NaN/`< sinceMs` check at G-EVENTS-TS-STRICT catches it.
-  it("test_stats_with_since_filter_when_ts_not_first_key", () => {
-    const wikiRoot = makeWikiRoot(tmpPath);
-    const p = path.join(wikiRoot, "log", "events.jsonl");
-    // Hand-craft lines so `op` precedes `ts` — the fast-path regex won't match.
-    const lines = [
-      JSON.stringify({
-        op: "ingest",
-        ts: "2026-04-10T08:00:00+00:00",
-        cost_usd: 0.05,
-      }),
-      JSON.stringify({
-        op: "query",
-        ts: "2026-04-08T08:00:00+00:00",
-        cost_usd: 99.0,
-      }),
-    ];
-    fs.writeFileSync(p, lines.join("\n") + "\n");
-    const stats = getStats(wikiRoot, "2026-04-09T00:00:00+00:00");
-    expect(stats["total_events"]).toBe(1);
-    const opsByType = stats["ops_by_type"] as Record<string, number>;
-    expect(opsByType["ingest"]).toBe(1);
-    expect("query" in opsByType).toBe(false);
-  });
-
-  // W2: a malformed JSON line (partial write, torn append) is skipped instead
-  // of crashing _readEvents, and a stderr warning is emitted so the operator
-  // notices corruption instead of silently under-counting.
-  it("test_stats_skips_malformed_json_line_with_warning", () => {
-    const wikiRoot = makeWikiRoot(tmpPath);
-    const p = path.join(wikiRoot, "log", "events.jsonl");
-    const lines = [
-      JSON.stringify({
-        ts: "2026-04-10T08:00:00+00:00",
-        op: "ingest",
-        cost_usd: 0.05,
-      }),
-      // truncated / torn write
-      '{"ts": "2026-04-11T08:00:00+00:00", "op": "lint", "cost_usd"',
-      JSON.stringify({
-        ts: "2026-04-12T08:00:00+00:00",
-        op: "query",
-        cost_usd: 0.02,
-      }),
-    ];
-    fs.writeFileSync(p, lines.join("\n") + "\n");
-
-    const writes: string[] = [];
-    const origWrite = process.stderr.write.bind(process.stderr);
-    process.stderr.write = ((chunk: string | Uint8Array): boolean => {
-      writes.push(
-        typeof chunk === "string" ? chunk : Buffer.from(chunk).toString(),
-      );
-      return true;
-    }) as typeof process.stderr.write;
-    let stats: Record<string, unknown>;
-    try {
-      stats = getStats(wikiRoot);
-    } finally {
-      process.stderr.write = origWrite;
-    }
-    expect(stats["total_events"]).toBe(2);
-    const opsByType = stats["ops_by_type"] as Record<string, number>;
-    expect(opsByType["ingest"]).toBe(1);
-    expect(opsByType["query"]).toBe(1);
-    expect("lint" in opsByType).toBe(false);
-    expect(writes.join("")).toMatch(/malformed JSON line/);
   });
 });
 
@@ -411,14 +332,34 @@ describe("EventLoggerCLIShape", () => {
     const logDir = path.join(tmpPath, "log");
     fs.mkdirSync(logDir, { recursive: true });
     const events = [
-      { ts: "2026-04-01T10:00:00+00:00", op: "ingest", source: "a.md",
-        agent: "file", cost_usd: 0.05, reduction_ratio: 0.6 },
-      { ts: "2026-04-05T12:00:00+00:00", op: "query",
-        agent: "wiki", cost_usd: 0.03, reduction_ratio: 0.4 },
-      { ts: "2026-04-10T08:00:00+00:00", op: "ingest",
-        agent: "file", cost_usd: 0.07, reduction_ratio: 0.8 },
-      { ts: "2026-04-10T14:00:00+00:00", op: "lint",
-        cost_usd: 0.01, reduction_ratio: 0.5 },
+      {
+        ts: "2026-04-01T10:00:00+00:00",
+        op: "ingest",
+        source: "a.md",
+        agent: "file",
+        cost_usd: 0.05,
+        reduction_ratio: 0.6,
+      },
+      {
+        ts: "2026-04-05T12:00:00+00:00",
+        op: "query",
+        agent: "wiki",
+        cost_usd: 0.03,
+        reduction_ratio: 0.4,
+      },
+      {
+        ts: "2026-04-10T08:00:00+00:00",
+        op: "ingest",
+        agent: "file",
+        cost_usd: 0.07,
+        reduction_ratio: 0.8,
+      },
+      {
+        ts: "2026-04-10T14:00:00+00:00",
+        op: "lint",
+        cost_usd: 0.01,
+        reduction_ratio: 0.5,
+      },
     ];
     fs.writeFileSync(
       path.join(logDir, "events.jsonl"),
@@ -471,12 +412,27 @@ describe("EventLoggerCLIShape", () => {
     const logDir = path.join(tmpPath, "log");
     fs.mkdirSync(logDir, { recursive: true });
     const events = [
-      { ts: "2026-04-01T10:00:00+00:00", op: "ingest",
-        agent: "file", cost_usd: 5, reduction_ratio: 2 },
-      { ts: "2026-04-05T12:00:00+00:00", op: "ingest",
-        agent: "file", cost_usd: 5, reduction_ratio: 2 },
-      { ts: "2026-04-10T08:00:00+00:00", op: "ingest",
-        agent: "file", cost_usd: 5, reduction_ratio: 3 },
+      {
+        ts: "2026-04-01T10:00:00+00:00",
+        op: "ingest",
+        agent: "file",
+        cost_usd: 5,
+        reduction_ratio: 2,
+      },
+      {
+        ts: "2026-04-05T12:00:00+00:00",
+        op: "ingest",
+        agent: "file",
+        cost_usd: 5,
+        reduction_ratio: 2,
+      },
+      {
+        ts: "2026-04-10T08:00:00+00:00",
+        op: "ingest",
+        agent: "file",
+        cost_usd: 5,
+        reduction_ratio: 3,
+      },
     ];
     fs.writeFileSync(
       path.join(logDir, "events.jsonl"),
@@ -510,9 +466,12 @@ describe("event_logger --source flag", () => {
   it("accepts --source on `log` and writes it as a top-level field", () => {
     const js = runCli([
       "log",
-      "--op", "ingest",
-      "--wiki-root", tmpPath,
-      "--source", "slides.pptx",
+      "--op",
+      "ingest",
+      "--wiki-root",
+      tmpPath,
+      "--source",
+      "slides.pptx",
     ]);
     expect(js.status).toBe(0);
     const entry = JSON.parse(js.stdout) as Record<string, unknown>;
@@ -523,10 +482,14 @@ describe("event_logger --source flag", () => {
   it("merges --source into --details (explicit flag wins on collision)", () => {
     const js = runCli([
       "log",
-      "--op", "ingest",
-      "--wiki-root", tmpPath,
-      "--details", '{"source":"old.md","extra":"keep"}',
-      "--source", "new.md",
+      "--op",
+      "ingest",
+      "--wiki-root",
+      tmpPath,
+      "--details",
+      '{"source":"old.md","extra":"keep"}',
+      "--source",
+      "new.md",
     ]);
     expect(js.status).toBe(0);
     const entry = JSON.parse(js.stdout) as Record<string, unknown>;
@@ -536,9 +499,12 @@ describe("event_logger --source flag", () => {
 
   it("accepts --source on the bare-fallback (no subcommand) shape", () => {
     const js = runCli([
-      "--op", "ingest",
-      "--wiki-root", tmpPath,
-      "--source", "report.pdf",
+      "--op",
+      "ingest",
+      "--wiki-root",
+      tmpPath,
+      "--source",
+      "report.pdf",
     ]);
     expect(js.status).toBe(0);
     const entry = JSON.parse(js.stdout) as Record<string, unknown>;
@@ -581,7 +547,7 @@ describe("event_logger stats — total_events", () => {
   it("CLI `stats` emits total_events in stdout JSON", () => {
     const events = [
       { ts: "2026-04-01T10:00:00+00:00", op: "ingest", cost_usd: 0.05 },
-      { ts: "2026-04-05T12:00:00+00:00", op: "lint",  cost_usd: 0.01 },
+      { ts: "2026-04-05T12:00:00+00:00", op: "lint", cost_usd: 0.01 },
     ];
     fs.writeFileSync(
       path.join(tmpPath, "log", "events.jsonl"),
@@ -641,8 +607,13 @@ describe("agent_calls[] breakdown", () => {
     const entry = logEvent(tmpPath, "ingest", {
       agent_calls: [
         {
-          agent: "jira", model: "haiku", tokens_in: 10, tokens_out: 5,
-          cost_usd: 0.5, elapsed_ms: 100, status: "success",
+          agent: "jira",
+          model: "haiku",
+          tokens_in: 10,
+          tokens_out: 5,
+          cost_usd: 0.5,
+          elapsed_ms: 100,
+          status: "success",
         },
       ],
       total_cost_usd: 999,
@@ -668,12 +639,22 @@ describe("agent_calls[] breakdown", () => {
     logEvent(tmpPath, "ingest", {
       agent_calls: [
         {
-          agent: "jira", model: "haiku", tokens_in: 0, tokens_out: 0,
-          cost_usd: 0.25, elapsed_ms: 10, status: "success",
+          agent: "jira",
+          model: "haiku",
+          tokens_in: 0,
+          tokens_out: 0,
+          cost_usd: 0.25,
+          elapsed_ms: 10,
+          status: "success",
         },
         {
-          agent: "db_agent", model: null, tokens_in: 0, tokens_out: 0,
-          cost_usd: 0.5, elapsed_ms: 10, status: "success",
+          agent: "db_agent",
+          model: null,
+          tokens_in: 0,
+          tokens_out: 0,
+          cost_usd: 0.5,
+          elapsed_ms: 10,
+          status: "success",
         },
       ],
     });
@@ -720,12 +701,22 @@ describe("agent_calls[] breakdown", () => {
     logEvent(tmpPath, "ingest", {
       agent_calls: [
         {
-          agent: "jira", model: "haiku", tokens_in: 0, tokens_out: 0,
-          cost_usd: 0.25, elapsed_ms: 10, status: "success",
+          agent: "jira",
+          model: "haiku",
+          tokens_in: 0,
+          tokens_out: 0,
+          cost_usd: 0.25,
+          elapsed_ms: 10,
+          status: "success",
         },
         {
-          agent: "db_agent", model: null, tokens_in: 0, tokens_out: 0,
-          cost_usd: 0.5, elapsed_ms: 10, status: "success",
+          agent: "db_agent",
+          model: null,
+          tokens_in: 0,
+          tokens_out: 0,
+          cost_usd: 0.5,
+          elapsed_ms: 10,
+          status: "success",
         },
       ],
     });
@@ -749,9 +740,14 @@ describe("getStats includeZeroTokens (A6)", () => {
   function seed(): void {
     fs.mkdirSync(path.join(tmpPath, "log"), { recursive: true });
     const events = [
-      { ts: "2026-04-01T10:00:00+00:00", op: "ingest", tokens_in: 100, tokens_out: 50 },
-      { ts: "2026-04-01T11:00:00+00:00", op: "init" },  // no token data
-      { ts: "2026-04-01T12:00:00+00:00", op: "lint" },  // no token data
+      {
+        ts: "2026-04-01T10:00:00+00:00",
+        op: "ingest",
+        tokens_in: 100,
+        tokens_out: 50,
+      },
+      { ts: "2026-04-01T11:00:00+00:00", op: "init" }, // no token data
+      { ts: "2026-04-01T12:00:00+00:00", op: "lint" }, // no token data
     ];
     fs.writeFileSync(
       path.join(tmpPath, "log", "events.jsonl"),
@@ -809,4 +805,37 @@ describe("getStats includeZeroTokens (A6)", () => {
     expect("init" in data.total_tokens_by_op).toBe(false);
     expect("lint" in data.total_tokens_by_op).toBe(false);
   });
+});
+
+it("test_stats_skips_malformed_json_line_with_warning", () => {
+  const tmpPath = fs.mkdtempSync(
+    path.join(os.tmpdir(), "wiki-test-stats-malformed-"),
+  );
+  fs.mkdirSync(path.join(tmpPath, "log"), { recursive: true });
+  const logPath = path.join(tmpPath, "log", "events.jsonl");
+
+  const validLine1 = '{"ts": "2023-01-01T12:00:00+00:00", "op": "ingest"}\n';
+  const invalidLine =
+    '{"ts": "2023-01-01T12:01:00+00:00", "op": "ingest", "malformed": }\n';
+  const validLine2 = '{"ts": "2023-01-01T12:02:00+00:00", "op": "ingest"}\n';
+  fs.writeFileSync(logPath, validLine1 + invalidLine + validLine2);
+
+  let stderrOutput = "";
+  const originalStderrWrite = process.stderr.write;
+  // @ts-expect-error - overriding stderr.write for test
+  process.stderr.write = (str: string | Uint8Array) => {
+    stderrOutput += str.toString();
+    return true;
+  };
+
+  try {
+    const stats = getStats(tmpPath, "2023-01-01T00:00:00+00:00");
+    expect(stats.total_events).toBe(2);
+    expect(stderrOutput).toContain(
+      "[event_logger] warning: skipping malformed JSON line",
+    );
+  } finally {
+    process.stderr.write = originalStderrWrite;
+    fs.rmSync(tmpPath, { recursive: true, force: true });
+  }
 });

--- a/skills/doc-wiki/scripts/tests/event_logger.test.ts
+++ b/skills/doc-wiki/scripts/tests/event_logger.test.ts
@@ -294,6 +294,77 @@ describe("TestGetStats", () => {
     expect(opsByType["ingest"]).toBe(1);
     expect("query" in opsByType).toBe(false);
   });
+
+  // Fast-path coverage: events whose `ts` is NOT the first key still get
+  // filtered correctly via the slow path. The fast-path regex misses; the
+  // post-parse NaN/`< sinceMs` check at G-EVENTS-TS-STRICT catches it.
+  it("test_stats_with_since_filter_when_ts_not_first_key", () => {
+    const wikiRoot = makeWikiRoot(tmpPath);
+    const p = path.join(wikiRoot, "log", "events.jsonl");
+    // Hand-craft lines so `op` precedes `ts` — the fast-path regex won't match.
+    const lines = [
+      JSON.stringify({
+        op: "ingest",
+        ts: "2026-04-10T08:00:00+00:00",
+        cost_usd: 0.05,
+      }),
+      JSON.stringify({
+        op: "query",
+        ts: "2026-04-08T08:00:00+00:00",
+        cost_usd: 99.0,
+      }),
+    ];
+    fs.writeFileSync(p, lines.join("\n") + "\n");
+    const stats = getStats(wikiRoot, "2026-04-09T00:00:00+00:00");
+    expect(stats["total_events"]).toBe(1);
+    const opsByType = stats["ops_by_type"] as Record<string, number>;
+    expect(opsByType["ingest"]).toBe(1);
+    expect("query" in opsByType).toBe(false);
+  });
+
+  // W2: a malformed JSON line (partial write, torn append) is skipped instead
+  // of crashing _readEvents, and a stderr warning is emitted so the operator
+  // notices corruption instead of silently under-counting.
+  it("test_stats_skips_malformed_json_line_with_warning", () => {
+    const wikiRoot = makeWikiRoot(tmpPath);
+    const p = path.join(wikiRoot, "log", "events.jsonl");
+    const lines = [
+      JSON.stringify({
+        ts: "2026-04-10T08:00:00+00:00",
+        op: "ingest",
+        cost_usd: 0.05,
+      }),
+      // truncated / torn write
+      '{"ts": "2026-04-11T08:00:00+00:00", "op": "lint", "cost_usd"',
+      JSON.stringify({
+        ts: "2026-04-12T08:00:00+00:00",
+        op: "query",
+        cost_usd: 0.02,
+      }),
+    ];
+    fs.writeFileSync(p, lines.join("\n") + "\n");
+
+    const writes: string[] = [];
+    const origWrite = process.stderr.write.bind(process.stderr);
+    process.stderr.write = ((chunk: string | Uint8Array): boolean => {
+      writes.push(
+        typeof chunk === "string" ? chunk : Buffer.from(chunk).toString(),
+      );
+      return true;
+    }) as typeof process.stderr.write;
+    let stats: Record<string, unknown>;
+    try {
+      stats = getStats(wikiRoot);
+    } finally {
+      process.stderr.write = origWrite;
+    }
+    expect(stats["total_events"]).toBe(2);
+    const opsByType = stats["ops_by_type"] as Record<string, number>;
+    expect(opsByType["ingest"]).toBe(1);
+    expect(opsByType["query"]).toBe(1);
+    expect("lint" in opsByType).toBe(false);
+    expect(writes.join("")).toMatch(/malformed JSON line/);
+  });
 });
 
 // ── Python-compat timestamp format check ────────────────────────────


### PR DESCRIPTION
💡 What: Implemented a fast-path regex (`/^{"ts":"([^"]+)"/`) to extract the timestamp and check against the `--since` filter in `event_logger.ts` before executing `JSON.parse()`.

🎯 Why: `events.jsonl` is an append-only log that grows extremely large. Parsing every single JSON line just to filter it out is a massive overhead.

📊 Impact: Reduces `JSON.parse()` overhead when reading events by skipping parsing for older logs. For massive log files and `--since` queries near the end of the log, it provides significant CPU savings.

🔬 Measurement: Profile `_readEvents` with a large `events.jsonl` file and filter recent events. `JSON.parse` overhead should drop substantially.

---
*PR created automatically by Jules for task [5125294716300176543](https://jules.google.com/task/5125294716300176543) started by @rfv-code*