### PR TITLE
⚡ Bolt: Add fast-path string checks to atlas_synthesize log parsing

### DIFF
--- a/agents/lib/atlas_synthesize.js
+++ b/agents/lib/atlas_synthesize.js
@@ -640,6 +640,9 @@ export function assembleTroubleshootingInputs(wikiRoot) {
             const line = lines[i];
             if (!line)
                 continue;
+            // Fast-path: skip JSON parse overhead if this line cannot match our error checks
+            if (!line.includes('"error"') && !line.includes('"failed"'))
+                continue;
             let parsed;
             try {
                 parsed = JSON.parse(line);

--- a/agents/lib/atlas_synthesize.ts
+++ b/agents/lib/atlas_synthesize.ts
@@ -713,6 +713,10 @@ export function assembleTroubleshootingInputs(wikiRoot: string): SynthesisBundle
     ) {
       const line = lines[i];
       if (!line) continue;
+
+      // Fast-path: skip JSON parse overhead if this line cannot match our error checks
+      if (!line.includes('"error"') && !line.includes('"failed"')) continue;
+
       let parsed: unknown;
       try {
         parsed = JSON.parse(line);


### PR DESCRIPTION
💡 What: Added `.includes` string checks before running `JSON.parse(line)` inside `assembleTroubleshootingInputs` in `agents/lib/atlas_synthesize.ts`.
🎯 Why: `events.jsonl` can grow large over time, and reading the whole file line-by-line and unconditionally calling `JSON.parse()` on every line is a significant CPU and garbage collection bottleneck. Most lines will not be errors.
📊 Impact: Considerably faster `events.jsonl` troubleshooting extraction when there are many non-error log lines. Avoids parsing overhead.
🔬 Measurement: Can be measured by generating an atlas synthesis with a large `events.jsonl` file and observing processing time.

---
*PR created automatically by Jules for task [15487919951933359792](https://jules.google.com/task/15487919951933359792) started by @rfv-code*