### PR TITLE
⚡ Bolt: Optimize JSON log fast-path filtering to prevent false positives

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -12,3 +12,8 @@
 
 **Learning:** Inner JSON fields might mistakenly contain match substrings like dates (e.g., inside the text of the event). Utilizing a strict, anchored regex check for extracting fields like timestamps directly (`/^{"ts":"([^"\\]+)"/`) avoids both `JSON.parse` overhead and incorrect partial string matches from `String.includes()`.
 **Action:** Use an anchored regex (`/^{"ts":"([^"\\]+)"/`) and check the captured group directly before falling back to full JSON parsing.
+
+## 2026-05-28 - Precise fast-path string matching
+
+**Learning:** When using `String.includes()` as a fast-path filter for append-only JSON logs (like checking for `!line.includes('"atlas"')`), inner JSON fields might inadvertently contain the match substring (e.g., inside the text or details of an unrelated event). This causes false positives, falling through to the slow path and paying the full `JSON.parse` overhead unnecessarily.
+**Action:** Use highly specific `String.includes()` checks that match the exact key-value serialization structure (e.g., `line.includes('"op":"atlas"')`) to filter relevant lines and prevent false positives before calling `JSON.parse()`.

--- a/skills/doc-wiki/scripts/atlas_gitlog.js
+++ b/skills/doc-wiki/scripts/atlas_gitlog.js
@@ -65,7 +65,7 @@ export function getLastAtlasTimestamp(wikiRoot) {
         if (!line)
             continue;
         // Fast-path: skip JSON parse overhead if this line cannot be an atlas event
-        if (!line.includes('"atlas"'))
+        if (!line.includes('"op":"atlas"'))
             continue;
         let parsed;
         try {

--- a/skills/doc-wiki/scripts/atlas_gitlog.ts
+++ b/skills/doc-wiki/scripts/atlas_gitlog.ts
@@ -91,7 +91,7 @@ export function getLastAtlasTimestamp(wikiRoot: string): string | null {
     if (!line) continue;
 
     // Fast-path: skip JSON parse overhead if this line cannot be an atlas event
-    if (!line.includes('"atlas"')) continue;
+    if (!line.includes('"op":"atlas"')) continue;
 
     let parsed: unknown;
     try {

--- a/skills/doc-wiki/scripts/atlas_orchestrator.js
+++ b/skills/doc-wiki/scripts/atlas_orchestrator.js
@@ -136,7 +136,7 @@ export function getLastAtlasRunId(wikiRoot) {
         if (!line)
             continue;
         // Fast-path: skip JSON parse overhead if this line cannot be an atlas event
-        if (!line.includes('"atlas"'))
+        if (!line.includes('"op":"atlas"'))
             continue;
         let parsed;
         try {
@@ -215,7 +215,7 @@ export function getRollingPerIngestAvg(wikiRoot, sampleSize = 50) {
         if (!line)
             continue;
         // Fast-path: skip JSON parse overhead if this line cannot be an ingest event
-        if (!line.includes('"ingest"'))
+        if (!line.includes('"op":"ingest"'))
             continue;
         let parsed;
         try {

--- a/skills/doc-wiki/scripts/atlas_orchestrator.ts
+++ b/skills/doc-wiki/scripts/atlas_orchestrator.ts
@@ -179,7 +179,7 @@ export function getLastAtlasRunId(wikiRoot: string): string | null {
     if (!line) continue;
 
     // Fast-path: skip JSON parse overhead if this line cannot be an atlas event
-    if (!line.includes('"atlas"')) continue;
+    if (!line.includes('"op":"atlas"')) continue;
 
     let parsed: unknown;
     try {
@@ -263,7 +263,7 @@ export function getRollingPerIngestAvg(
     if (!line) continue;
 
     // Fast-path: skip JSON parse overhead if this line cannot be an ingest event
-    if (!line.includes('"ingest"')) continue;
+    if (!line.includes('"op":"ingest"')) continue;
 
     let parsed: unknown;
     try {


### PR DESCRIPTION
💡 What: Made the `String.includes()` fast-path checks more specific in `atlas_orchestrator.ts` and `atlas_gitlog.ts` (e.g., matching `"op":"atlas"` instead of just `"atlas"`).
🎯 Why: Inner JSON fields might mistakenly contain match substrings like "atlas" or "ingest" (e.g., inside the text of the event). This leads to false positives where `JSON.parse` is executed on lines that ultimately do not match the expected event operation, which degrades performance for append-only large log files.
📊 Impact: Reduces unnecessary `JSON.parse` operations for lines that contain the target string within an unrelated field.
🔬 Measurement: Verify by executing commands that scan the log with log lines containing the target string in non-op fields.
Added the learning and action to the `.jules/bolt.md` performance journal.

---
*PR created automatically by Jules for task [17088032016332356907](https://jules.google.com/task/17088032016332356907) started by @rfv-code*