### PR TITLE
⚡ Bolt: [performance improvement] Add fast-path string check for events.jsonl parsing

### DIFF
--- a/agents/lib/atlas_synthesize.js
+++ b/agents/lib/atlas_synthesize.js
@@ -642,6 +642,10 @@ export function assembleTroubleshootingInputs(wikiRoot) {
             const line = lines[i];
             if (!line)
                 continue;
+            // Fast-path: avoid JSON.parse on lines that cannot possibly be error events
+            if (!line.includes('"error"') && !line.includes('"failed"') && !line.includes('"status"')) {
+                continue;
+            }
             let parsed;
             try {
                 parsed = JSON.parse(line);

--- a/agents/lib/atlas_synthesize.ts
+++ b/agents/lib/atlas_synthesize.ts
@@ -714,6 +714,12 @@ export function assembleTroubleshootingInputs(wikiRoot: string): SynthesisBundle
     ) {
       const line = lines[i];
       if (!line) continue;
+
+      // Fast-path: avoid JSON.parse on lines that cannot possibly be error events
+      if (!line.includes('"error"') && !line.includes('"failed"') && !line.includes('"status"')) {
+        continue;
+      }
+
       let parsed: unknown;
       try {
         parsed = JSON.parse(line);


### PR DESCRIPTION
💡 What: Added a `String.includes()` fast-path filter to `assembleTroubleshootingInputs` before calling `JSON.parse()`.
🎯 Why: To prevent unconditionally parsing every line of `events.jsonl` (which can grow large) when searching for the 30 most recent errors. Lines without `"error"`, `"failed"`, or `"status"` are skipped immediately.
📊 Impact: Reduces CPU and memory overhead during atlas synthesis on wikis with large event logs, skipping expensive `JSON.parse` operations for successful events.
🔬 Measurement: Run atlas synthesis on a wiki with thousands of success events; CPU usage and execution time should drop.

---
*PR created automatically by Jules for task [825957516462663187](https://jules.google.com/task/825957516462663187) started by @rfv-code*