### PR TITLE
⚡ Bolt: Strict JSON structure in fast-path event log parsing

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -12,3 +12,8 @@
 
 **Learning:** Inner JSON fields might mistakenly contain match substrings like dates (e.g., inside the text of the event). Utilizing a strict, anchored regex check for extracting fields like timestamps directly (`/^{"ts":"([^"\\]+)"/`) avoids both `JSON.parse` overhead and incorrect partial string matches from `String.includes()`.
 **Action:** Use an anchored regex (`/^{"ts":"([^"\\]+)"/`) and check the captured group directly before falling back to full JSON parsing.
+
+## 2026-05-23 - Fast-path false positives with `.includes()`
+
+**Learning:** When using `.includes()` as a fast-path filter before `JSON.parse()`, using loose substrings (e.g., `line.includes("atlas")` or `line.includes(dateStr)`) can cause false positives if those strings appear elsewhere in the JSON body (e.g., inside error messages, URLs, or text fields). This forces the code to fall back to the slow `JSON.parse()` or full regex evaluation unnecessarily, negating the fast-path optimization.
+**Action:** Make `.includes()` checks as strict as possible by including JSON structural characters, relying on the predictable output of `JSON.stringify()`. For example, change `line.includes('"atlas"')` to `line.includes('"op":"atlas"')`, and `line.includes(dateStr)` to `line.includes('"ts":"' + dateStr)`.

--- a/skills/doc-wiki/scripts/atlas_gitlog.js
+++ b/skills/doc-wiki/scripts/atlas_gitlog.js
@@ -65,7 +65,7 @@ export function getLastAtlasTimestamp(wikiRoot) {
         if (!line)
             continue;
         // Fast-path: skip JSON parse overhead if this line cannot be an atlas event
-        if (!line.includes('"atlas"'))
+        if (!line.includes('"op":"atlas"'))
             continue;
         let parsed;
         try {

--- a/skills/doc-wiki/scripts/atlas_gitlog.ts
+++ b/skills/doc-wiki/scripts/atlas_gitlog.ts
@@ -91,7 +91,7 @@ export function getLastAtlasTimestamp(wikiRoot: string): string | null {
     if (!line) continue;
 
     // Fast-path: skip JSON parse overhead if this line cannot be an atlas event
-    if (!line.includes('"atlas"')) continue;
+    if (!line.includes('"op":"atlas"')) continue;
 
     let parsed: unknown;
     try {

--- a/skills/doc-wiki/scripts/atlas_orchestrator.js
+++ b/skills/doc-wiki/scripts/atlas_orchestrator.js
@@ -136,7 +136,7 @@ export function getLastAtlasRunId(wikiRoot) {
         if (!line)
             continue;
         // Fast-path: skip JSON parse overhead if this line cannot be an atlas event
-        if (!line.includes('"atlas"'))
+        if (!line.includes('"op":"atlas"'))
             continue;
         let parsed;
         try {
@@ -215,7 +215,7 @@ export function getRollingPerIngestAvg(wikiRoot, sampleSize = 50) {
         if (!line)
             continue;
         // Fast-path: skip JSON parse overhead if this line cannot be an ingest event
-        if (!line.includes('"ingest"'))
+        if (!line.includes('"op":"ingest"'))
             continue;
         let parsed;
         try {

--- a/skills/doc-wiki/scripts/atlas_orchestrator.ts
+++ b/skills/doc-wiki/scripts/atlas_orchestrator.ts
@@ -179,7 +179,7 @@ export function getLastAtlasRunId(wikiRoot: string): string | null {
     if (!line) continue;
 
     // Fast-path: skip JSON parse overhead if this line cannot be an atlas event
-    if (!line.includes('"atlas"')) continue;
+    if (!line.includes('"op":"atlas"')) continue;
 
     let parsed: unknown;
     try {
@@ -263,7 +263,7 @@ export function getRollingPerIngestAvg(
     if (!line) continue;
 
     // Fast-path: skip JSON parse overhead if this line cannot be an ingest event
-    if (!line.includes('"ingest"')) continue;
+    if (!line.includes('"op":"ingest"')) continue;
 
     let parsed: unknown;
     try {

--- a/skills/doc-wiki/scripts/daily_summary.js
+++ b/skills/doc-wiki/scripts/daily_summary.js
@@ -38,7 +38,7 @@ function readEvents(wikiRoot, dateStr) {
         if (!line)
             continue;
         // Fast-path: skip JSON parse overhead if this line cannot match our date
-        if (!line.includes(dateStr))
+        if (!line.includes(`"ts":"${dateStr}`))
             continue;
         const match = line.match(/^{"ts":"([^"\\]+)"/);
         if (match && match[1] && !match[1].startsWith(dateStr))

--- a/skills/doc-wiki/scripts/daily_summary.ts
+++ b/skills/doc-wiki/scripts/daily_summary.ts
@@ -43,7 +43,7 @@ function readEvents(
     if (!line) continue;
 
     // Fast-path: skip JSON parse overhead if this line cannot match our date
-    if (!line.includes(dateStr)) continue;
+    if (!line.includes(`"ts":"${dateStr}`)) continue;
     const match = line.match(/^{"ts":"([^"\\]+)"/);
     if (match && match[1] && !match[1].startsWith(dateStr)) continue;
 


### PR DESCRIPTION
💡 What: Updated fast-path `.includes()` checks on `events.jsonl` reading loops to match specific JSON keys/values (e.g., `\"op\":\"atlas\"` instead of just `\"atlas\"`).
🎯 Why: Loose `.includes()` checks caused false positives if the target string appeared elsewhere in the JSON body, causing the fast-path to fail and incurring unnecessary `JSON.parse` or regex execution overhead.
📊 Impact: Reduces CPU cycles spent uselessly parsing JSON for log lines that have matching substrings but aren't actually the target event, especially on large log files.
🔬 Measurement: Run a large `doc-wiki` orchestrator process and measure the time it takes to scan events. The overhead is strictly bounded to the `.includes()` string scan and avoids the heavier execution blocks.

---
*PR created automatically by Jules for task [1660958195833863884](https://jules.google.com/task/1660958195833863884) started by @rfv-code*