### PR TITLE
⚡ Bolt: [performance improvement]

### DIFF
--- a/agents/lib/atlas_synthesize.js
+++ b/agents/lib/atlas_synthesize.js
@@ -105,7 +105,8 @@ function _extractTldr(body) {
  * `references/compilation.md` ("Additional frontmatter for atlas pages").
  */
 function _inferAudience(facet, frontmatterAudience) {
-    if (typeof frontmatterAudience === "string" && frontmatterAudience.length > 0) {
+    if (typeof frontmatterAudience === "string" &&
+        frontmatterAudience.length > 0) {
         return frontmatterAudience;
     }
     switch (facet) {
@@ -164,7 +165,13 @@ export function assembleOverviewInputs(wikiRoot) {
         parts.push("## Audience routing\n");
         parts.push("| Audience | Pages |");
         parts.push("|---|---|");
-        const order = ["new-user", "operator", "contributor", "integrator", "debugger"];
+        const order = [
+            "new-user",
+            "operator",
+            "contributor",
+            "integrator",
+            "debugger",
+        ];
         for (const audience of order) {
             const pages = grouped.get(audience);
             if (!pages || pages.length === 0)
@@ -483,7 +490,10 @@ export function assembleCommandsInputs(repoRoot) {
                     headings.push(line.trim());
             }
             if (headings.length > 0) {
-                const rel = path.relative(repoRoot, skillFile).split(path.sep).join("/");
+                const rel = path
+                    .relative(repoRoot, skillFile)
+                    .split(path.sep)
+                    .join("/");
                 sources.push(rel);
                 parts.push(`## Slash-command headings in ${rel}\n\n${headings.join("\n")}\n`);
             }
@@ -845,11 +855,14 @@ export function main(argv = process.argv.slice(2)) {
         return 0;
     }
     const wikiRoot = parsed.values["wikiRoot"];
-    const repoRoot = typeof parsed.values["repoRoot"] === "string" && parsed.values["repoRoot"].length > 0
+    const repoRoot = typeof parsed.values["repoRoot"] === "string" &&
+        parsed.values["repoRoot"].length > 0
         ? parsed.values["repoRoot"]
         : process.cwd();
     // Subcommands that need --wiki-root.
-    if (sub === "overview" || sub === "integrations" || sub === "troubleshooting") {
+    if (sub === "overview" ||
+        sub === "integrations" ||
+        sub === "troubleshooting") {
         if (typeof wikiRoot !== "string" || wikiRoot.length === 0) {
             process.stderr.write("--wiki-root is required\n");
             return 2;

--- a/agents/lib/atlas_synthesize.js
+++ b/agents/lib/atlas_synthesize.js
@@ -642,6 +642,10 @@ export function assembleTroubleshootingInputs(wikiRoot) {
             const line = lines[i];
             if (!line)
                 continue;
+            // Fast-path: skip JSON parse overhead if this line cannot be an error event
+            if (!line.includes('"error"') && !line.includes('"failed"')) {
+                continue;
+            }
             let parsed;
             try {
                 parsed = JSON.parse(line);

--- a/agents/lib/atlas_synthesize.ts
+++ b/agents/lib/atlas_synthesize.ts
@@ -130,11 +130,11 @@ function _extractTldr(body: string): string {
  * derived from the `atlas_facet`. Mirrors the table documented in
  * `references/compilation.md` ("Additional frontmatter for atlas pages").
  */
-function _inferAudience(
-  facet: string,
-  frontmatterAudience: unknown,
-): string {
-  if (typeof frontmatterAudience === "string" && frontmatterAudience.length > 0) {
+function _inferAudience(facet: string, frontmatterAudience: unknown): string {
+  if (
+    typeof frontmatterAudience === "string" &&
+    frontmatterAudience.length > 0
+  ) {
     return frontmatterAudience;
   }
   switch (facet) {
@@ -197,7 +197,13 @@ export function assembleOverviewInputs(wikiRoot: string): SynthesisBundle {
     parts.push("## Audience routing\n");
     parts.push("| Audience | Pages |");
     parts.push("|---|---|");
-    const order = ["new-user", "operator", "contributor", "integrator", "debugger"];
+    const order = [
+      "new-user",
+      "operator",
+      "contributor",
+      "integrator",
+      "debugger",
+    ];
     for (const audience of order) {
       const pages = grouped.get(audience);
       if (!pages || pages.length === 0) continue;
@@ -260,7 +266,9 @@ export function assembleIntegrationsInputs(
 
   const apis = _findAtlasPages(wikiRoot, ["api"]);
   if (apis.length === 0) {
-    notes.push("no api.md pages found — integrations will draw only from architecture mentions");
+    notes.push(
+      "no api.md pages found — integrations will draw only from architecture mentions",
+    );
   }
   for (const page of apis) {
     sources.push(page.page);
@@ -284,7 +292,9 @@ export function assembleIntegrationsInputs(
     }
     if (hits.length > 0) {
       sources.push(page.page);
-      parts.push(`## external-mentions in ${page.page}\n\n${hits.join("\n")}\n`);
+      parts.push(
+        `## external-mentions in ${page.page}\n\n${hits.join("\n")}\n`,
+      );
     }
   }
 
@@ -443,7 +453,12 @@ function _commandsLifecycleSeed(slugs: readonly string[]): string {
     { name: "cmd", fill: "#fff3cd", stroke: "#856404" },
     { name: "orch", fill: "#d4edda", stroke: "#155724" },
   ];
-  const block = formatPhaseFlow("slash-command fan-out", nodes, edges, classDefs);
+  const block = formatPhaseFlow(
+    "slash-command fan-out",
+    nodes,
+    edges,
+    classDefs,
+  );
   return [
     "<!-- mermaid-seed: slash-command fan-out — preserve in synthesized page -->",
     "```mermaid",
@@ -532,7 +547,10 @@ export function assembleCommandsInputs(repoRoot: string): SynthesisBundle {
         if (/^###\s+\//.test(line)) headings.push(line.trim());
       }
       if (headings.length > 0) {
-        const rel = path.relative(repoRoot, skillFile).split(path.sep).join("/");
+        const rel = path
+          .relative(repoRoot, skillFile)
+          .split(path.sep)
+          .join("/");
         sources.push(rel);
         parts.push(
           `## Slash-command headings in ${rel}\n\n${headings.join("\n")}\n`,
@@ -559,7 +577,9 @@ const _BOOTSTRAP_FILE_CANDIDATES: readonly string[] = [
  * Makefile, etc.). Gives the LLM enough raw material to produce a
  * numbered first-run walkthrough for new users.
  */
-export function assembleGettingStartedInputs(repoRoot: string): SynthesisBundle {
+export function assembleGettingStartedInputs(
+  repoRoot: string,
+): SynthesisBundle {
   const sources: string[] = [];
   const parts: string[] = [];
   const notes: string[] = [];
@@ -636,10 +656,11 @@ const _CONFIGURATION_FILE_GLOBS: ReadonlyArray<RegExp> = [
   /^application\.(properties|ya?ml)$/i,
 ];
 
-const _CONFIGURATION_DIR_PATTERNS: ReadonlyArray<{ dir: string; rx: RegExp }> = [
-  { dir: "config", rx: /\.(ya?ml|json|toml|conf|ini|properties)$/i },
-  { dir: ".connectors", rx: /\.ya?ml$/i },
-];
+const _CONFIGURATION_DIR_PATTERNS: ReadonlyArray<{ dir: string; rx: RegExp }> =
+  [
+    { dir: "config", rx: /\.(ya?ml|json|toml|conf|ini|properties)$/i },
+    { dir: ".connectors", rx: /\.ya?ml$/i },
+  ];
 
 /**
  * Assemble the input for `wiki/configuration.md` synthesis: top-level
@@ -692,7 +713,9 @@ function _isErrorEvent(rec: Record<string, unknown>): boolean {
  * drift report (if present). Gives the LLM symptom signals the page can
  * organize into symptom → cause → fix triplets.
  */
-export function assembleTroubleshootingInputs(wikiRoot: string): SynthesisBundle {
+export function assembleTroubleshootingInputs(
+  wikiRoot: string,
+): SynthesisBundle {
   const sources: string[] = [];
   const parts: string[] = [];
   const notes: string[] = [];
@@ -714,13 +737,20 @@ export function assembleTroubleshootingInputs(wikiRoot: string): SynthesisBundle
     ) {
       const line = lines[i];
       if (!line) continue;
+
+      // Fast-path: skip JSON parse overhead if this line cannot be an error event
+      if (!line.includes('"error"') && !line.includes('"failed"')) {
+        continue;
+      }
+
       let parsed: unknown;
       try {
         parsed = JSON.parse(line);
       } catch {
         continue;
       }
-      if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) continue;
+      if (!parsed || typeof parsed !== "object" || Array.isArray(parsed))
+        continue;
       const rec = parsed as Record<string, unknown>;
       if (_isErrorEvent(rec)) {
         errors.push({ raw: line, parsed: rec });
@@ -734,7 +764,9 @@ export function assembleTroubleshootingInputs(wikiRoot: string): SynthesisBundle
       for (const e of [...errors].reverse()) parts.push(e.raw);
       parts.push("```\n");
     } else {
-      notes.push("no error events in events.jsonl — troubleshooting will be sparse");
+      notes.push(
+        "no error events in events.jsonl — troubleshooting will be sparse",
+      );
     }
   } else {
     notes.push("no log/events.jsonl found");
@@ -926,12 +958,17 @@ export function main(argv: readonly string[] = process.argv.slice(2)): number {
   }
   const wikiRoot = parsed.values["wikiRoot"];
   const repoRoot =
-    typeof parsed.values["repoRoot"] === "string" && parsed.values["repoRoot"].length > 0
+    typeof parsed.values["repoRoot"] === "string" &&
+    parsed.values["repoRoot"].length > 0
       ? parsed.values["repoRoot"]
       : process.cwd();
 
   // Subcommands that need --wiki-root.
-  if (sub === "overview" || sub === "integrations" || sub === "troubleshooting") {
+  if (
+    sub === "overview" ||
+    sub === "integrations" ||
+    sub === "troubleshooting"
+  ) {
     if (typeof wikiRoot !== "string" || wikiRoot.length === 0) {
       process.stderr.write("--wiki-root is required\n");
       return 2;


### PR DESCRIPTION
💡 What: Implemented a fast-path `.includes()` check in `assembleTroubleshootingInputs` inside `agents/lib/atlas_synthesize.ts` to skip `JSON.parse` overhead for lines that do not contain `"error"` or `"failed"`.

🎯 Why: Reading a large append-only `events.jsonl` log file and unconditionally parsing every line backwards to find error events is computationally expensive. By pre-filtering lines with a quick string search, we avoid parsing irrelevant JSON lines, significantly speeding up the troubleshooting synthesis process.

📊 Impact: Reduces CPU and memory usage significantly during log extraction, eliminating unnecessary JSON parses for non-error events. This brings performance in line with the `.includes()` optimizations found in `atlas_orchestrator.ts`.

🔬 Measurement: Use `node event_logger.js stats` or synthesize troubleshooting with a large `events.jsonl` file to verify faster execution times without errors.

---
*PR created automatically by Jules for task [3033308282913161057](https://jules.google.com/task/3033308282913161057) started by @rfv-code*