### PR TITLE
feat(launch): case-study runner prompt + auto-scaffold script

### DIFF
--- a/launch/case-study-init.ts
+++ b/launch/case-study-init.ts
@@ -1,0 +1,556 @@
+#!/usr/bin/env -S npx tsx
+// case-study-init — scaffolds case-study-output/ in the current dir.
+// Auto-detects codebase shape (LOC, age, language, framework, ORM, DB);
+// prompts only for things that can't be detected (description, internal-tool name,
+// privacy posture, ticket sample size); writes a filled-in PROMPT.md you paste
+// into Claude Code.
+//
+// Run from inside the codebase you want to document:
+//   curl -fsSL https://raw.githubusercontent.com/narailabs/doc-wiki/main/launch/case-study-init.ts \
+//     | npx tsx -
+//
+// or with CLI flags / env vars (skips the interactive prompts):
+//   PROJECT_NAME=my-app INTERNAL_TOOL_NAME=our-docs PRIVATE=true \
+//     npx tsx launch/case-study-init.ts
+
+import { execSync, spawnSync } from "node:child_process";
+import {
+  existsSync,
+  readFileSync,
+  writeFileSync,
+  mkdirSync,
+  appendFileSync,
+  readdirSync,
+  statSync,
+} from "node:fs";
+import { join, basename, resolve, dirname } from "node:path";
+import { homedir } from "node:os";
+import { createInterface } from "node:readline/promises";
+import { stdin, stdout } from "node:process";
+
+interface Parameters {
+  PROJECT_NAME: string;
+  PROJECT_DESCRIPTION: string;
+  INTERNAL_TOOL_NAME: string;
+  INTERNAL_TOOL_LOCATION: string;
+  EXTERNAL_CONNECTORS_ENABLED: string;
+  PRIVATE: "true" | "false";
+  TICKET_SAMPLE_SIZE: string;
+  // auto-detected fields (used for the summary, not in the prompt)
+  _detected: {
+    loc: number;
+    age_years: number;
+    languages: string;
+    frameworks: string;
+    orm: string;
+    db: string;
+  };
+}
+
+function sh(cmd: string, cwd: string): string {
+  try {
+    return execSync(cmd, { cwd, encoding: "utf-8", stdio: ["ignore", "pipe", "ignore"] }).trim();
+  } catch {
+    return "";
+  }
+}
+
+function exists(path: string): boolean {
+  try {
+    statSync(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function fileExistsContaining(path: string, needles: string[]): boolean {
+  if (!exists(path)) return false;
+  try {
+    const c = readFileSync(path, "utf-8");
+    return needles.some((n) => c.includes(n));
+  } catch {
+    return false;
+  }
+}
+
+function anyExists(cwd: string, paths: string[]): string | null {
+  for (const p of paths) if (exists(join(cwd, p))) return p;
+  return null;
+}
+
+function detectProjectName(cwd: string): string {
+  // package.json > pyproject.toml > Cargo.toml > go.mod > git remote > dir basename
+  for (const file of ["package.json", "deno.json"]) {
+    const p = join(cwd, file);
+    if (exists(p)) {
+      try {
+        const j = JSON.parse(readFileSync(p, "utf-8")) as { name?: string };
+        if (j.name) return j.name.replace(/^@[^/]+\//, "");
+      } catch {/* */ }
+    }
+  }
+  if (exists(join(cwd, "pyproject.toml"))) {
+    const c = readFileSync(join(cwd, "pyproject.toml"), "utf-8");
+    const m = c.match(/^\s*name\s*=\s*["']([^"']+)["']/m);
+    if (m) return m[1]!;
+  }
+  if (exists(join(cwd, "Cargo.toml"))) {
+    const c = readFileSync(join(cwd, "Cargo.toml"), "utf-8");
+    const m = c.match(/^\s*name\s*=\s*["']([^"']+)["']/m);
+    if (m) return m[1]!;
+  }
+  if (exists(join(cwd, "go.mod"))) {
+    const c = readFileSync(join(cwd, "go.mod"), "utf-8");
+    const m = c.match(/^module\s+(\S+)/m);
+    if (m) return basename(m[1]!);
+  }
+  const remote = sh("git config remote.origin.url", cwd);
+  if (remote) {
+    const m = remote.match(/[/:]([^/]+?)(?:\.git)?$/);
+    if (m) return m[1]!;
+  }
+  return basename(cwd);
+}
+
+function detectLoc(cwd: string): number {
+  if (sh("which tokei", cwd)) {
+    const out = sh("tokei --output json", cwd);
+    if (out) {
+      try {
+        const j = JSON.parse(out) as { Total?: { code?: number } };
+        if (j.Total?.code) return j.Total.code;
+      } catch { /* */ }
+    }
+  }
+  if (sh("which cloc", cwd)) {
+    const out = sh("cloc --json --quiet .", cwd);
+    if (out) {
+      try {
+        const j = JSON.parse(out) as { SUM?: { code?: number } };
+        if (j.SUM?.code) return j.SUM.code;
+      } catch { /* */ }
+    }
+  }
+  // Fallback: find + wc on common source extensions, skipping node_modules / venv / build
+  const cmd = String.raw`find . \( -name node_modules -o -name .venv -o -name venv -o -name dist -o -name build -o -name .next -o -name target -o -name .git \) -prune -o -type f \( -name '*.ts' -o -name '*.tsx' -o -name '*.js' -o -name '*.jsx' -o -name '*.py' -o -name '*.rb' -o -name '*.go' -o -name '*.rs' -o -name '*.java' -o -name '*.kt' -o -name '*.cs' -o -name '*.php' -o -name '*.swift' \) -print 2>/dev/null | xargs wc -l 2>/dev/null | tail -1 | awk '{print $1}'`;
+  const n = parseInt(sh(cmd, cwd) || "0", 10);
+  return Number.isFinite(n) ? n : 0;
+}
+
+function detectAgeYears(cwd: string): number {
+  const firstDate = sh("git log --reverse --format=%ci | head -1", cwd);
+  if (!firstDate) return 0;
+  const t = Date.parse(firstDate);
+  if (!Number.isFinite(t)) return 0;
+  const years = (Date.now() - t) / (365.25 * 24 * 3600 * 1000);
+  return Math.round(years * 10) / 10;
+}
+
+function detectLanguages(cwd: string): string {
+  const counts: Record<string, number> = {};
+  const exts: Record<string, string> = {
+    ts: "TypeScript", tsx: "TypeScript",
+    js: "JavaScript", jsx: "JavaScript",
+    py: "Python",
+    rb: "Ruby",
+    go: "Go",
+    rs: "Rust",
+    java: "Java", kt: "Kotlin",
+    cs: "C#",
+    php: "PHP",
+    swift: "Swift",
+  };
+  const cmd = String.raw`find . \( -name node_modules -o -name .venv -o -name venv -o -name dist -o -name build -o -name .next -o -name target -o -name .git \) -prune -o -type f -name '*.*' -print 2>/dev/null`;
+  const lines = sh(cmd, cwd).split("\n");
+  for (const f of lines) {
+    const ext = f.split(".").pop()?.toLowerCase();
+    const lang = ext ? exts[ext] : undefined;
+    if (lang) counts[lang] = (counts[lang] ?? 0) + 1;
+  }
+  const sorted = Object.entries(counts).sort((a, b) => b[1] - a[1]);
+  return sorted.slice(0, 3).map(([l]) => l).join(", ") || "unknown";
+}
+
+function detectFrameworks(cwd: string): string {
+  const out: string[] = [];
+  if (anyExists(cwd, ["manage.py", "django/__init__.py"])) out.push("Django");
+  if (fileExistsContaining(join(cwd, "package.json"), ["\"next\""])) out.push("Next.js");
+  if (fileExistsContaining(join(cwd, "package.json"), ["\"fastify\""])) out.push("Fastify");
+  if (fileExistsContaining(join(cwd, "package.json"), ["\"express\""])) out.push("Express");
+  if (anyExists(cwd, ["config.ru", "Gemfile"]) && fileExistsContaining(join(cwd, "Gemfile"), ["rails"])) out.push("Rails");
+  if (fileExistsContaining(join(cwd, "pyproject.toml"), ["fastapi"])) out.push("FastAPI");
+  if (fileExistsContaining(join(cwd, "requirements.txt"), ["fastapi"])) out.push("FastAPI");
+  if (fileExistsContaining(join(cwd, "requirements.txt"), ["flask"])) out.push("Flask");
+  if (anyExists(cwd, ["pom.xml", "build.gradle", "build.gradle.kts"]) && fileExistsContaining(join(cwd, "pom.xml"), ["spring-boot"])) out.push("Spring Boot");
+  if (anyExists(cwd, ["nuxt.config.ts", "nuxt.config.js"])) out.push("Nuxt");
+  if (anyExists(cwd, ["svelte.config.js"])) out.push("Svelte");
+  return out.join(", ") || "unknown";
+}
+
+function detectOrm(cwd: string): string {
+  if (anyExists(cwd, ["prisma/schema.prisma"])) return "Prisma";
+  if (anyExists(cwd, ["alembic.ini"])) return "SQLAlchemy + Alembic";
+  if (fileExistsContaining(join(cwd, "pyproject.toml"), ["sqlalchemy"])) return "SQLAlchemy";
+  if (fileExistsContaining(join(cwd, "requirements.txt"), ["sqlalchemy"])) return "SQLAlchemy";
+  if (anyExists(cwd, ["manage.py"])) return "Django ORM";
+  if (anyExists(cwd, ["config/database.yml"])) return "ActiveRecord";
+  if (fileExistsContaining(join(cwd, "package.json"), ["\"typeorm\""])) return "TypeORM";
+  if (fileExistsContaining(join(cwd, "package.json"), ["\"drizzle-orm\""])) return "Drizzle";
+  if (fileExistsContaining(join(cwd, "pom.xml"), ["hibernate"])) return "Hibernate / JPA";
+  return "none-detected";
+}
+
+function detectDb(cwd: string): string {
+  const found = new Set<string>();
+  const candidates = ["docker-compose.yml", "docker-compose.yaml", "compose.yml", ".env", ".env.example", ".env.local"];
+  for (const c of candidates) {
+    const p = join(cwd, c);
+    if (!exists(p)) continue;
+    const t = readFileSync(p, "utf-8").toLowerCase();
+    if (t.includes("postgres") || t.includes("psql")) found.add("Postgres");
+    if (t.includes("mysql") || t.includes("mariadb")) found.add("MySQL");
+    if (t.includes("mongo")) found.add("MongoDB");
+    if (t.includes("redis")) found.add("Redis");
+    if (t.includes("sqlite")) found.add("SQLite");
+    if (t.includes("dynamodb")) found.add("DynamoDB");
+    if (t.includes("clickhouse")) found.add("ClickHouse");
+  }
+  return found.size ? [...found].join(", ") : "none-detected";
+}
+
+function detectConnectorsConfigured(): string {
+  const path = join(homedir(), ".connectors", "config.yaml");
+  if (!exists(path)) return "";
+  const t = readFileSync(path, "utf-8");
+  const ids = ["jira", "confluence", "github", "notion", "aws", "gcp", "db"];
+  return ids.filter((id) => new RegExp(`^\\s*${id}\\s*:`, "m").test(t)).join(",");
+}
+
+async function maybePrompt(
+  key: string,
+  question: string,
+  defaultValue: string,
+  rl: ReturnType<typeof createInterface> | null,
+): Promise<string> {
+  if (process.env[key]) return process.env[key]!;
+  if (!rl) return defaultValue;
+  const ans = (await rl.question(`${question}\n  [${defaultValue}] `)).trim();
+  return ans || defaultValue;
+}
+
+async function collect(cwd: string): Promise<Parameters> {
+  const auto = {
+    name: detectProjectName(cwd),
+    loc: detectLoc(cwd),
+    age: detectAgeYears(cwd),
+    langs: detectLanguages(cwd),
+    fw: detectFrameworks(cwd),
+    orm: detectOrm(cwd),
+    db: detectDb(cwd),
+    connectors: detectConnectorsConfigured(),
+  };
+
+  const interactive = stdin.isTTY && stdout.isTTY && !process.env.CI;
+  const rl = interactive ? createInterface({ input: stdin, output: stdout }) : null;
+
+  if (interactive) {
+    console.log("\nDetected:");
+    console.log(`  Project name: ${auto.name}`);
+    console.log(`  LOC: ${auto.loc.toLocaleString()}`);
+    console.log(`  Age: ${auto.age} years`);
+    console.log(`  Languages: ${auto.langs}`);
+    console.log(`  Frameworks: ${auto.fw}`);
+    console.log(`  ORM: ${auto.orm}`);
+    console.log(`  DB: ${auto.db}`);
+    console.log(`  Connectors configured: ${auto.connectors || "none"}`);
+    console.log("");
+  }
+
+  const PROJECT_NAME = await maybePrompt("PROJECT_NAME", "Project name (short generic label):", auto.name, rl);
+  const PROJECT_DESCRIPTION = await maybePrompt(
+    "PROJECT_DESCRIPTION",
+    "One sentence on what the codebase does:",
+    `a ${auto.fw !== "unknown" ? auto.fw : auto.langs} codebase (~${Math.round(auto.loc / 1000)}k LOC, ${auto.age} years old)`,
+    rl,
+  );
+  const INTERNAL_TOOL_NAME = await maybePrompt(
+    "INTERNAL_TOOL_NAME",
+    "Name of the existing internal documentation tool you built (or 'none'):",
+    "none",
+    rl,
+  );
+  const INTERNAL_TOOL_LOCATION = INTERNAL_TOOL_NAME === "none"
+    ? "none"
+    : await maybePrompt(
+        "INTERNAL_TOOL_LOCATION",
+        "Path or URL to the existing tool:",
+        "none",
+        rl,
+      );
+  const EXTERNAL_CONNECTORS_ENABLED = await maybePrompt(
+    "EXTERNAL_CONNECTORS_ENABLED",
+    "External connectors enabled (comma-separated from {jira,confluence,github,notion,aws,gcp,db}):",
+    auto.connectors,
+    rl,
+  );
+  const PRIVATE = (await maybePrompt(
+    "PRIVATE",
+    "Sanitize public outputs? (true/false):",
+    "true",
+    rl,
+  )) as "true" | "false";
+  const TICKET_SAMPLE_SIZE = await maybePrompt(
+    "TICKET_SAMPLE_SIZE",
+    "How many internal tickets to benchmark (5-10 recommended):",
+    "5",
+    rl,
+  );
+
+  if (rl) rl.close();
+
+  return {
+    PROJECT_NAME,
+    PROJECT_DESCRIPTION,
+    INTERNAL_TOOL_NAME,
+    INTERNAL_TOOL_LOCATION,
+    EXTERNAL_CONNECTORS_ENABLED,
+    PRIVATE,
+    TICKET_SAMPLE_SIZE,
+    _detected: {
+      loc: auto.loc,
+      age_years: auto.age,
+      languages: auto.langs,
+      frameworks: auto.fw,
+      orm: auto.orm,
+      db: auto.db,
+    },
+  };
+}
+
+function renderPrompt(p: Parameters): string {
+  // The Phase 1–5 template, with parameters substituted. This mirrors
+  // launch/case-study-runner.md in the doc-wiki repo — kept inline so the
+  // script is self-contained when curl'd into an arbitrary codebase.
+  return `# doc-wiki case-study run — execute all 5 phases in order; write outputs to ./case-study-output/
+
+## PARAMETERS (filled by case-study-init)
+
+PROJECT_NAME: ${p.PROJECT_NAME}
+PROJECT_DESCRIPTION: ${p.PROJECT_DESCRIPTION}
+INTERNAL_TOOL_NAME: ${p.INTERNAL_TOOL_NAME}
+INTERNAL_TOOL_LOCATION: ${p.INTERNAL_TOOL_LOCATION}
+EXTERNAL_CONNECTORS_ENABLED: ${p.EXTERNAL_CONNECTORS_ENABLED || "none"}
+PRIVATE: ${p.PRIVATE}
+TICKET_SAMPLE_SIZE: ${p.TICKET_SAMPLE_SIZE}
+
+Pre-detected codebase shape (use these in your output instead of re-measuring):
+- repo_size_loc: ${p._detected.loc}
+- repo_age_years: ${p._detected.age_years}
+- languages: ${p._detected.languages}
+- frameworks: ${p._detected.frameworks}
+- orm: ${p._detected.orm}
+- db: ${p._detected.db}
+
+## PHASE 1 — Codebase inventory (no doc-wiki yet)
+
+Produce ./case-study-output/01-inventory.json with these keys (most are already pre-detected above; fill in the rest by reading the codebase):
+
+- repo_size_loc, repo_age_years, language_breakdown, frameworks_detected, orm_detected, db_detected (use pre-detected)
+- service_count (top-level services/apps; 1 if not a monorepo)
+- external_services_observed (any references to AWS/GCP/Jira/Confluence/Slack/etc. found in code or config)
+- existing_documentation_observed: { readme_lines, in_code_comment_density_pct, markdown_doc_count, quality_subjective (1-5) }
+- complexity_signals: { circular_dependencies_count, god_modules_count (files > 1000 LOC), schema_drift_observed }
+- existing_internal_tool_summary (if INTERNAL_TOOL_NAME != "none"): { what_it_does, coverage_metric, last_updated, gaps_observed (3-5 items) }
+
+Time budget: 30-60 minutes. Use Bash + Read; do not invoke doc-wiki yet.
+
+## PHASE 2 — Build the doc-wiki
+
+If doc-wiki is not installed: \`claude plugin install narailabs/doc-wiki\`.
+
+Run:
+  /doc-wiki:init
+  /doc-wiki:onboard
+  /doc-wiki:atlas --dry-run
+
+Read the dry-run output. If cost estimate exceeds $50, narrow with --scope <directory>. Then:
+  /doc-wiki:atlas --max-cost 50
+
+Collect into ./case-study-output/02-atlas.json:
+- atlas_run_id, atlas_duration_minutes, atlas_cost_usd
+- pages_generated, topics_covered, facets_per_topic_avg, mermaid_diagrams_generated
+- references_inserted_in_claudemd
+- orm_entities_mapped (if ORM detected)
+- external_service_pages
+
+Per-page index → ./case-study-output/02-pages-index.csv (path,title,type,sources,word_count).
+
+Time budget: 1-3 hours.
+
+## PHASE 3 — Comparison against existing internal tool
+
+Skip if INTERNAL_TOOL_NAME == "none".
+
+For each of these 8 axes, give a 1-paragraph judgment + one specific example:
+1. Code coverage
+2. Ecosystem coverage (Jira/Confluence/DB schemas)
+3. ORM/DB linking
+4. Progressive disclosure (summary-first index)
+5. Drift detection
+6. Cross-link density
+7. Cited-synthesis queries
+8. Maintenance cost
+
+Save to ./case-study-output/03-comparison.json.
+
+Then 3 specific anecdotes where doc-wiki caught something the existing tool missed (or vice versa). Save to ./case-study-output/03-anecdotes.json, each with: { axis, doc_wiki_artifact_path, existing_tool_artifact_path, description, impact_estimate }.
+
+Time budget: 1-2 hours.
+
+## PHASE 4 — Ticket benchmark
+
+Select ${p.TICKET_SAMPLE_SIZE} real closed internal tickets from the last 6 months. Selection criteria:
+- Fix was actually merged (PR closed)
+- Fix touches 1-3 files (~5-200 LOC)
+- A regression test was added in the fix PR
+- Ticket is in this codebase, not a downstream service
+
+For each ticket, run baseline + with-doc-wiki using the dispatch pattern in benchmark/dispatch.md (single-process flavor):
+- Checkout fix_commit^1
+- Apply test patch: \`git checkout <fix_commit> -- <test_file_path>\`
+- Baseline: \`claude -p "Fix this ticket: <title>\\n<body>"\` (no doc-wiki context)
+- Run the named test; record success/duration/tokens/cost
+- Restore to fix_commit^1
+- With-doc-wiki: same prompt, doc-wiki present + CLAUDE.md updated
+- Run named test; record same
+
+Save run-level → ./case-study-output/04-ticket-bench.csv with columns:
+ticket_id, condition, success, duration_s, tokens_in, tokens_out, cost_usd, fix_path, test_path, notes
+
+Save summary → ./case-study-output/04-summary.json with: baseline_pass_rate, with_docwiki_pass_rate, delta_pp, median durations, total costs.
+
+Time budget: ~1 hour per ticket × ${p.TICKET_SAMPLE_SIZE} tickets.
+
+## PHASE 5 — Generate deliverables
+
+Produce four documents from the 4 phases above.
+
+### 5.1 portfolio.md (~600 words, sanitized)
+Public-shareable. Replace company name with "${p.PRIVATE === "true" ? "<COMPANY_TYPE>" : ""}". Lead with the benchmark headline + methodology + the OSS verification pointer (https://github.com/narailabs/doc-wiki/tree/main/benchmark). Include one anonymized anecdote. Close with the OSS repo link.
+
+### 5.2 case-study-public.md (~1500 words, sanitized)
+Same shape as portfolio but methodology-heavy. Includes 2 anecdotes, a sanitized Mermaid architecture diagram, and a reproducibility pointer to benchmark/PUBLISH.md.
+
+### 5.3 internal-pitch.md (~800 words, NOT for external sharing)
+Real names, real numbers, full detail. Migration plan (which services first, decision-gate at end of 4-week pilot), cost projection at scale, the ask (sanctioned 4-week pilot). Keep this on your internal wiki only.
+
+### 5.4 social/ — four ready-to-post files, all sanitized
+- linkedin.md (~300 words)
+- x-thread.md (5-7 tweets)
+- reddit-experienced-devs.md (~800 words, candid)
+- devto-deepdive.md (~2000 words)
+
+## Sanitization rules (apply to 5.1, 5.2, 5.4)
+
+PRIVATE is set to "${p.PRIVATE}".
+${p.PRIVATE === "true"
+    ? `- No company name, no team names, no employee names other than yours
+- No specific customer names
+- Internal ticket IDs paraphrased into general patterns
+- Service names replaced with SERVICE_A, SERVICE_B, ...
+- No screenshots of internal tools / Jira / Confluence
+- Architecture diagrams: replace service/db names with placeholders
+- Numbers kept (LOC, ages, percentages)
+- Tech stack kept (Django, Postgres, etc.)
+When in doubt, replace. The internal pitch (5.3) gets full detail; the public ones get patterns.`
+    : `- Real names allowed throughout (PRIVATE=false).
+- Note that this means even the "public" outputs reveal the company; only publish if you have explicit sign-off.`}
+
+## Output checklist
+
+- [ ] 01-inventory.json
+- [ ] 02-atlas.json
+- [ ] 02-pages-index.csv
+- [ ] 03-comparison.json (if INTERNAL_TOOL_NAME != "none")
+- [ ] 03-anecdotes.json
+- [ ] 04-ticket-bench.csv
+- [ ] 04-summary.json
+- [ ] portfolio.md
+- [ ] case-study-public.md
+- [ ] internal-pitch.md
+- [ ] social/{linkedin,x-thread,reddit-experienced-devs,devto-deepdive}.md
+${p.PRIVATE === "true" ? "- [ ] grep all public outputs for company/team/customer names — none should appear\n" : ""}
+## Final summary to stdout
+
+After all 5 phases + checklist, print: total wall time, total atlas + Claude spend, headline numbers (baseline/with-doc-wiki/delta), the 3 anecdotes (one line each), where each deliverable is located, one sentence on what surprised you the most.
+`;
+}
+
+function ensureGitignored(cwd: string, dirRel: string): void {
+  const giPath = join(cwd, ".gitignore");
+  const want = dirRel.endsWith("/") ? dirRel : `${dirRel}/`;
+  if (exists(giPath)) {
+    const c = readFileSync(giPath, "utf-8");
+    if (c.split("\n").some((l) => l.trim() === want.replace(/\/$/, "") || l.trim() === want)) return;
+    appendFileSync(giPath, `\n# scaffolded by doc-wiki/launch/case-study-init.ts\n${want}\n`);
+  } else {
+    writeFileSync(giPath, `# scaffolded by doc-wiki/launch/case-study-init.ts\n${want}\n`);
+  }
+}
+
+async function main(): Promise<void> {
+  const cwd = resolve(process.cwd());
+
+  // Sanity check: are we inside a git repo?
+  if (!exists(join(cwd, ".git"))) {
+    console.error("✗ No .git here. Run this from the root of the codebase you want to document.");
+    process.exit(1);
+  }
+
+  console.log(`case-study-init — scaffolding case-study-output/ in ${cwd}`);
+
+  const outDir = join(cwd, "case-study-output");
+  if (exists(outDir)) {
+    console.warn(`! case-study-output/ already exists — overwriting PARAMETERS.json and PROMPT.md only`);
+  }
+  mkdirSync(outDir, { recursive: true });
+
+  const params = await collect(cwd);
+
+  // Persist parameters
+  writeFileSync(
+    join(outDir, "PARAMETERS.json"),
+    JSON.stringify(params, null, 2),
+  );
+
+  // Write the rendered prompt
+  const prompt = renderPrompt(params);
+  writeFileSync(join(outDir, "PROMPT.md"), prompt);
+
+  // Make output dir contents private even if user's .gitignore is permissive
+  writeFileSync(
+    join(outDir, ".gitignore"),
+    "# Default-private: nothing in this directory should ever land in git\n*\n!.gitignore\n",
+  );
+
+  // Add case-study-output/ to project .gitignore (best-effort)
+  ensureGitignored(cwd, "case-study-output");
+
+  // Final summary
+  console.log("\n✓ Scaffolded:");
+  console.log(`   case-study-output/PARAMETERS.json   (${Object.keys(params).length - 1} fields)`);
+  console.log(`   case-study-output/PROMPT.md         (${prompt.split("\n").length} lines)`);
+  console.log(`   case-study-output/.gitignore        (deny-all)`);
+  console.log(`   .gitignore                          (case-study-output/ added)`);
+  console.log("\nDetected for this codebase:");
+  console.log(`   ${params._detected.loc.toLocaleString()} LOC, ${params._detected.age_years} years old, ${params._detected.languages}`);
+  console.log(`   frameworks=${params._detected.frameworks}  orm=${params._detected.orm}  db=${params._detected.db}`);
+  console.log("\nNext: open case-study-output/PROMPT.md and paste its contents into a Claude Code");
+  console.log("session opened on this codebase. The 5 phases run sequentially (~5-15 hours total).\n");
+}
+
+main().catch((e) => {
+  console.error("✗ case-study-init failed:", e instanceof Error ? e.message : e);
+  process.exit(1);
+});

--- a/launch/case-study-init.ts
+++ b/launch/case-study-init.ts
@@ -22,11 +22,32 @@ import {
   appendFileSync,
   readdirSync,
   statSync,
+  createReadStream,
+  createWriteStream,
 } from "node:fs";
 import { join, basename, resolve, dirname } from "node:path";
 import { homedir } from "node:os";
 import { createInterface } from "node:readline/promises";
 import { stdin, stdout } from "node:process";
+
+// When invoked as `curl ... | npx tsx -`, stdin is the pipe and stdin.isTTY is
+// false — every interactive prompt silently falls back to its default. Open
+// /dev/tty directly so the prompts still appear when the user can answer.
+// Returns null when no terminal is available (Windows, sandboxed CI, etc.).
+function openControllingTty(): { input: NodeJS.ReadableStream; output: NodeJS.WritableStream } | null {
+  if (stdin.isTTY && stdout.isTTY) {
+    return { input: stdin, output: stdout };
+  }
+  if (process.env.CI) return null;
+  try {
+    if (!existsSync("/dev/tty")) return null;
+    const input = createReadStream("/dev/tty");
+    const output = createWriteStream("/dev/tty");
+    return { input, output };
+  } catch {
+    return null;
+  }
+}
 
 interface Parameters {
   PROJECT_NAME: string;
@@ -251,8 +272,9 @@ async function collect(cwd: string): Promise<Parameters> {
     connectors: detectConnectorsConfigured(),
   };
 
-  const interactive = stdin.isTTY && stdout.isTTY && !process.env.CI;
-  const rl = interactive ? createInterface({ input: stdin, output: stdout }) : null;
+  const tty = openControllingTty();
+  const rl = tty ? createInterface({ input: tty.input, output: tty.output }) : null;
+  const interactive = rl !== null;
 
   if (interactive) {
     console.log("\nDetected:");
@@ -265,6 +287,10 @@ async function collect(cwd: string): Promise<Parameters> {
     console.log(`  DB: ${auto.db}`);
     console.log(`  Connectors configured: ${auto.connectors || "none"}`);
     console.log("");
+  } else {
+    console.log(
+      "(non-interactive — using defaults / env vars. To force prompts, run from a TTY or set env vars per the README.)",
+    );
   }
 
   const PROJECT_NAME = await maybePrompt("PROJECT_NAME", "Project name (short generic label):", auto.name, rl);
@@ -370,8 +396,7 @@ Time budget: 30-60 minutes. Use Bash + Read; do not invoke doc-wiki yet.
 If doc-wiki is not installed: \`claude plugin install narailabs/doc-wiki\`.
 
 Run:
-  /doc-wiki:init
-  /doc-wiki:onboard
+  /doc-wiki:init      # init now subsumes the old onboard step (stack/ORM/DB/services detection)
   /doc-wiki:atlas --dry-run
 
 Read the dry-run output. If cost estimate exceeds $50, narrow with --scope <directory>. Then:

--- a/launch/case-study-init.ts
+++ b/launch/case-study-init.ts
@@ -333,9 +333,14 @@ async function collect(cwd: string): Promise<Parameters> {
     auto.connectors,
     rl,
   );
+  // Reworded to match what the flag actually controls. Public outputs (5.1, 5.2,
+  // 5.4) are sanitized unconditionally — this flag only gates whether the
+  // internal-pitch.md (5.3) gets generated. Phrasing "sanitize public outputs?"
+  // misled users into thinking PRIVATE=true would prevent named artifacts; in
+  // reality PRIVATE=true PRODUCES the NDA-only named artifact.
   const PRIVATE_RAW = await maybePrompt(
     "PRIVATE",
-    "Sanitize public outputs? (true/false, yes/no, y/n, 1/0):",
+    "Generate internal-pitch.md (NDA-only, contains real service/team/ticket names — public outputs are always sanitized regardless)? (true/false, yes/no, y/n, 1/0):",
     "true",
     rl,
   );
@@ -475,6 +480,7 @@ For each ticket × condition, create a fresh workspace:
     WDW_DIR=/tmp/case-study/<ticket_id>-with-docwiki
     rm -rf "$WDW_DIR" && mkdir -p "$WDW_DIR" && cd "$WDW_DIR"
     git clone --depth 100 <internal-repo-url> .
+    git fetch --depth 500 origin <fix_commit> 2>/dev/null || git fetch --unshallow
     git checkout <fix_commit>^1
     git checkout <fix_commit> -- <test_file_path>
     git reset HEAD <test_file_path> 2>/dev/null || true

--- a/launch/case-study-init.ts
+++ b/launch/case-study-init.ts
@@ -471,6 +471,7 @@ For each ticket × condition, create a fresh workspace:
     BASELINE_DIR=/tmp/case-study/<ticket_id>-baseline
     rm -rf "$BASELINE_DIR" && mkdir -p "$BASELINE_DIR" && cd "$BASELINE_DIR"
     git clone --depth 100 <internal-repo-url> .
+    git fetch --depth 500 origin <fix_commit> 2>/dev/null || git fetch --unshallow
     git checkout <fix_commit>^1
     git checkout <fix_commit> -- <test_file_path>      # apply test patch
     git reset HEAD <test_file_path> 2>/dev/null || true

--- a/launch/case-study-init.ts
+++ b/launch/case-study-init.ts
@@ -481,10 +481,12 @@ For each ticket × condition, create a fresh workspace:
 
 The atlas runs once per (ticket, with-doc-wiki) workspace — yes, this means atlas spend stacks. That matches the canonical benchmark/PLAN.md methodology (each condition is a fresh clone; the with-doc-wiki branch builds the wiki from scratch).
 
-Save run-level → ./case-study-output/04-ticket-bench.csv with columns:
+Save run-level → \`$REPO_ROOT/case-study-output/04-ticket-bench.csv\` with columns:
 ticket_id, condition, success, duration_s, tokens_in, tokens_out, cost_usd, fix_path, test_path, notes
 
-Save summary → ./case-study-output/04-summary.json with: baseline_pass_rate, with_docwiki_pass_rate, delta_pp, median durations, total costs.
+Save summary → \`$REPO_ROOT/case-study-output/04-summary.json\` with: baseline_pass_rate, with_docwiki_pass_rate, delta_pp, median durations, total costs.
+
+(Capture \`REPO_ROOT="$PWD"\` BEFORE entering the per-ticket loop. The two-workspace blocks \`cd\` into /tmp clones, so relative \`./case-study-output/...\` paths would otherwise resolve to the wrong directory.)
 
 Time budget: ~1 hour per ticket × ${p.TICKET_SAMPLE_SIZE} tickets.
 

--- a/launch/case-study-init.ts
+++ b/launch/case-study-init.ts
@@ -407,7 +407,10 @@ Time budget: 30-60 minutes. Use Bash + Read; do not invoke doc-wiki yet.
 
 ## PHASE 2 — Build the doc-wiki
 
-If doc-wiki is not installed: \`claude plugin install narailabs/doc-wiki\`.
+If doc-wiki is not installed, add the NarAI marketplace once and install (bare \`claude plugin install narailabs/doc-wiki\` doesn't work — the repo ships \`.claude-plugin/plugin.json\`, not a marketplace catalog):
+
+  claude plugin marketplace add narailabs/narai-claude-plugins
+  claude plugin install doc-wiki@narai
 
 Run:
   /doc-wiki:init      # init now subsumes the old onboard step (stack/ORM/DB/services detection)

--- a/launch/case-study-init.ts
+++ b/launch/case-study-init.ts
@@ -499,7 +499,9 @@ Public-shareable. Replace company name with "${p.PRIVATE === "true" ? "<COMPANY_
 Same shape as portfolio but methodology-heavy. Includes 2 anecdotes, a sanitized Mermaid architecture diagram, and a reproducibility pointer to benchmark/PUBLISH.md.
 
 ### 5.3 internal-pitch.md (~800 words, NOT for external sharing)
-Real names, real numbers, full detail. Migration plan (which services first, decision-gate at end of 4-week pilot), cost projection at scale, the ask (sanctioned 4-week pilot). Keep this on your internal wiki only.
+${p.PRIVATE === "true"
+    ? `Real names, real numbers, full detail. Migration plan (which services first, decision-gate at end of 4-week pilot), cost projection at scale, the ask (sanctioned 4-week pilot). Keep this on your internal wiki only.`
+    : `SKIPPED — PRIVATE=false explicitly opts out of generating any artifact with real names. Only the sanitized public outputs (5.1, 5.2, 5.4) are produced. If you change your mind, re-run with PRIVATE=true.`}
 
 ### 5.4 social/ — four ready-to-post files, all sanitized
 - linkedin.md (~300 words)
@@ -507,11 +509,11 @@ Real names, real numbers, full detail. Migration plan (which services first, dec
 - reddit-experienced-devs.md (~800 words, candid)
 - devto-deepdive.md (~2000 words)
 
-## Sanitization rules (apply to 5.1, 5.2, 5.4)
+## Sanitization rules (apply to 5.1, 5.2, 5.4 — UNCONDITIONALLY, regardless of PRIVATE)
 
-PRIVATE is set to "${p.PRIVATE}".
-${p.PRIVATE === "true"
-    ? `- No company name, no team names, no employee names other than yours
+The public outputs (portfolio, public case study, social variants) are ALWAYS sanitized. The PRIVATE flag only controls whether the internal pitch (5.3) gets generated; it does not relax sanitization on the public outputs.
+
+- No company name, no team names, no employee names other than yours
 - No specific customer names
 - Internal ticket IDs paraphrased into general patterns
 - Service names replaced with SERVICE_A, SERVICE_B, ...
@@ -519,9 +521,8 @@ ${p.PRIVATE === "true"
 - Architecture diagrams: replace service/db names with placeholders
 - Numbers kept (LOC, ages, percentages)
 - Tech stack kept (Django, Postgres, etc.)
-When in doubt, replace. The internal pitch (5.3) gets full detail; the public ones get patterns.`
-    : `- Real names allowed throughout (PRIVATE=false).
-- Note that this means even the "public" outputs reveal the company; only publish if you have explicit sign-off.`}
+
+When in doubt, replace.
 
 ## Output checklist
 
@@ -533,10 +534,11 @@ When in doubt, replace. The internal pitch (5.3) gets full detail; the public on
 - [ ] 04-ticket-bench.csv
 - [ ] 04-summary.json
 - [ ] portfolio.md
-- [ ] case-study-public.md
-- [ ] internal-pitch.md
+${p.PRIVATE === "true" ? "- [ ] internal-pitch.md\n" : "- [~] internal-pitch.md SKIPPED (PRIVATE=false)\n"}- [ ] case-study-public.md
 - [ ] social/{linkedin,x-thread,reddit-experienced-devs,devto-deepdive}.md
-${p.PRIVATE === "true" ? "- [ ] grep all public outputs for company/team/customer names — none should appear\n" : ""}
+- [ ] grep all public outputs for company/team/customer names — none should appear
+
+
 ## Final summary to stdout
 
 After all 5 phases + checklist, print: total wall time, total atlas + Claude spend, headline numbers (baseline/with-doc-wiki/delta), the 3 anecdotes (one line each), where each deliverable is located, one sentence on what surprised you the most.

--- a/launch/case-study-init.ts
+++ b/launch/case-study-init.ts
@@ -449,9 +449,9 @@ Per-page index → ./case-study-output/02-pages-index.csv (path,title,type,sourc
 
 Time budget: 1-3 hours.
 
-## PHASE 3 — Comparison against existing internal tool
+## PHASE 3 — Comparison + anecdotes
 
-Skip if INTERNAL_TOOL_NAME == "none".
+### 3a — Comparison against existing internal tool (skip if INTERNAL_TOOL_NAME == "none")
 
 For each of these 8 axes, give a 1-paragraph judgment + one specific example:
 1. Code coverage
@@ -465,7 +465,12 @@ For each of these 8 axes, give a 1-paragraph judgment + one specific example:
 
 Save to ./case-study-output/03-comparison.json.
 
-Then 3 specific anecdotes where doc-wiki caught something the existing tool missed (or vice versa). Save to ./case-study-output/03-anecdotes.json, each with: { axis, doc_wiki_artifact_path, existing_tool_artifact_path, description, impact_estimate }.
+### 3b — Anecdotes (ALWAYS run, framing depends on INTERNAL_TOOL_NAME)
+
+Collect 3 specific anecdotes and save to ./case-study-output/03-anecdotes.json, each with: { axis, doc_wiki_artifact_path, existing_tool_artifact_path, description, impact_estimate }. Framing:
+
+- **If INTERNAL_TOOL_NAME != "none":** anecdotes where doc-wiki caught something the existing tool missed (or vice versa). \`existing_tool_artifact_path\` is the comparable artifact in the other tool.
+- **If INTERNAL_TOOL_NAME == "none":** anecdotes where doc-wiki surfaced knowledge the team didn't have written down (tribal knowledge in a head, an outdated ADR, a Confluence page nobody linked). \`existing_tool_artifact_path\` is the empty string or "n/a" — there is no other tool. Do not fabricate a comparison.
 
 Time budget: 1-2 hours.
 
@@ -555,8 +560,9 @@ When in doubt, replace.
 - [ ] 01-inventory.json
 - [ ] 02-atlas.json
 - [ ] 02-pages-index.csv
-- [ ] 03-comparison.json (if INTERNAL_TOOL_NAME != "none")
-- [ ] 03-anecdotes.json
+${p.INTERNAL_TOOL_NAME === "none"
+    ? "- [~] 03-comparison.json SKIPPED (INTERNAL_TOOL_NAME=none)\n"
+    : "- [ ] 03-comparison.json\n"}- [ ] 03-anecdotes.json
 - [ ] 04-ticket-bench.csv
 - [ ] 04-summary.json
 - [ ] portfolio.md

--- a/launch/case-study-init.ts
+++ b/launch/case-study-init.ts
@@ -240,12 +240,26 @@ function detectDb(cwd: string): string {
   return found.size ? [...found].join(", ") : "none-detected";
 }
 
-function detectConnectorsConfigured(): string {
-  const path = join(homedir(), ".connectors", "config.yaml");
-  if (!exists(path)) return "";
-  const t = readFileSync(path, "utf-8");
+function detectConnectorsConfigured(cwd: string): string {
+  // doc-wiki / narai-primitives resolves connector config from BOTH locations:
+  // user-global at ~/.connectors/config.yaml AND per-repo overlay at
+  // ./.connectors/config.yaml. The overlay is what enterprise teams use to
+  // pin per-project Jira/Confluence/DB endpoints; missing it here would
+  // record EXTERNAL_CONNECTORS_ENABLED=none even when those connectors are
+  // wired up for this repo.
   const ids = ["jira", "confluence", "github", "notion", "aws", "gcp", "db"];
-  return ids.filter((id) => new RegExp(`^\\s*${id}\\s*:`, "m").test(t)).join(",");
+  const enabled = new Set<string>();
+  for (const path of [
+    join(homedir(), ".connectors", "config.yaml"),
+    join(cwd, ".connectors", "config.yaml"),
+  ]) {
+    if (!exists(path)) continue;
+    const t = readFileSync(path, "utf-8");
+    for (const id of ids) {
+      if (new RegExp(`^\\s*${id}\\s*:`, "m").test(t)) enabled.add(id);
+    }
+  }
+  return [...enabled].join(",");
 }
 
 // Safe-by-default flag normalization. PRIVATE gates whether public outputs
@@ -282,7 +296,7 @@ async function collect(cwd: string): Promise<Parameters> {
     fw: detectFrameworks(cwd),
     orm: detectOrm(cwd),
     db: detectDb(cwd),
-    connectors: detectConnectorsConfigured(),
+    connectors: detectConnectorsConfigured(cwd),
   };
 
   const tty = openControllingTty();
@@ -502,20 +516,20 @@ Time budget: ~1 hour per ticket × ${p.TICKET_SAMPLE_SIZE} tickets.
 
 ## PHASE 5 — Generate deliverables
 
-Produce four documents from the 4 phases above.
+Produce four documents from the 4 phases above. **All deliverable paths are absolute under \`$REPO_ROOT/case-study-output/\`** — the same reason the Phase 4 CSV/summary use \`$REPO_ROOT\` (after the per-ticket loop, the session is in /tmp/case-study/<last-ticket>-with-docwiki, so relative paths would land there). \`cd "$REPO_ROOT"\` before authoring, or write each path with the explicit \`$REPO_ROOT\` prefix.
 
-### 5.1 portfolio.md (~600 words, sanitized)
+### 5.1 \`$REPO_ROOT/case-study-output/portfolio.md\` (~600 words, sanitized)
 Public-shareable. Replace company name with "${p.PRIVATE === "true" ? "<COMPANY_TYPE>" : ""}". Lead with the benchmark headline + methodology + the OSS verification pointer (https://github.com/narailabs/doc-wiki/tree/main/benchmark). Include one anonymized anecdote. Close with the OSS repo link.
 
-### 5.2 case-study-public.md (~1500 words, sanitized)
+### 5.2 \`$REPO_ROOT/case-study-output/case-study-public.md\` (~1500 words, sanitized)
 Same shape as portfolio but methodology-heavy. Includes 2 anecdotes, a sanitized Mermaid architecture diagram, and a reproducibility pointer to benchmark/PUBLISH.md.
 
-### 5.3 internal-pitch.md (~800 words, NOT for external sharing)
+### 5.3 \`$REPO_ROOT/case-study-output/internal-pitch.md\` (~800 words, NOT for external sharing)
 ${p.PRIVATE === "true"
     ? `Real names, real numbers, full detail. Migration plan (which services first, decision-gate at end of 4-week pilot), cost projection at scale, the ask (sanctioned 4-week pilot). Keep this on your internal wiki only.`
     : `SKIPPED — PRIVATE=false explicitly opts out of generating any artifact with real names. Only the sanitized public outputs (5.1, 5.2, 5.4) are produced. If you change your mind, re-run with PRIVATE=true.`}
 
-### 5.4 social/ — four ready-to-post files, all sanitized
+### 5.4 \`$REPO_ROOT/case-study-output/social/\` — four ready-to-post files, all sanitized
 - linkedin.md (~300 words)
 - x-thread.md (5-7 tweets)
 - reddit-experienced-devs.md (~800 words, candid)

--- a/launch/case-study-init.ts
+++ b/launch/case-study-init.ts
@@ -248,6 +248,19 @@ function detectConnectorsConfigured(): string {
   return ids.filter((id) => new RegExp(`^\\s*${id}\\s*:`, "m").test(t)).join(",");
 }
 
+// Safe-by-default flag normalization. PRIVATE gates whether public outputs
+// (portfolio, public case study, social) sanitize company / service names —
+// silently mis-parsing it could leak real internal names. Accept the common
+// truthy/falsy strings and explicitly reject anything else.
+function normalizePrivate(v: string): "true" | "false" {
+  const s = v.trim().toLowerCase();
+  if (["true", "yes", "y", "1", "on"].includes(s)) return "true";
+  if (["false", "no", "n", "0", "off"].includes(s)) return "false";
+  throw new Error(
+    `PRIVATE must be true/false (or yes/no, y/n, 1/0). Got "${v}". Default is "true" for safety; explicit "false" required to allow real names in public outputs.`,
+  );
+}
+
 async function maybePrompt(
   key: string,
   question: string,
@@ -320,12 +333,13 @@ async function collect(cwd: string): Promise<Parameters> {
     auto.connectors,
     rl,
   );
-  const PRIVATE = (await maybePrompt(
+  const PRIVATE_RAW = await maybePrompt(
     "PRIVATE",
-    "Sanitize public outputs? (true/false):",
+    "Sanitize public outputs? (true/false, yes/no, y/n, 1/0):",
     "true",
     rl,
-  )) as "true" | "false";
+  );
+  const PRIVATE = normalizePrivate(PRIVATE_RAW);
   const TICKET_SAMPLE_SIZE = await maybePrompt(
     "TICKET_SAMPLE_SIZE",
     "How many internal tickets to benchmark (5-10 recommended):",
@@ -441,14 +455,31 @@ Select ${p.TICKET_SAMPLE_SIZE} real closed internal tickets from the last 6 mont
 - A regression test was added in the fix PR
 - Ticket is in this codebase, not a downstream service
 
-For each ticket, run baseline + with-doc-wiki using the dispatch pattern in benchmark/dispatch.md (single-process flavor):
-- Checkout fix_commit^1
-- Apply test patch: \`git checkout <fix_commit> -- <test_file_path>\`
-- Baseline: \`claude -p "Fix this ticket: <title>\\n<body>"\` (no doc-wiki context)
-- Run the named test; record success/duration/tokens/cost
-- Restore to fix_commit^1
-- With-doc-wiki: same prompt, doc-wiki present + CLAUDE.md updated
-- Run named test; record same
+IMPORTANT — use the **two-workspace pattern** from benchmark/PLAN.md, not a single-tree restore. The wiki / CLAUDE.md references generated in Phase 2 must NOT be present during the baseline runs and MUST be present during the with-doc-wiki runs, so isolation comes from separate clones, not from in-place restore (which either fails on the uncommitted wiki or wipes it).
+
+For each ticket × condition, create a fresh workspace:
+
+  for each ticket:
+    BASELINE_DIR=/tmp/case-study/<ticket_id>-baseline
+    rm -rf "$BASELINE_DIR" && mkdir -p "$BASELINE_DIR" && cd "$BASELINE_DIR"
+    git clone --depth 100 <internal-repo-url> .
+    git checkout <fix_commit>^1
+    git checkout <fix_commit> -- <test_file_path>      # apply test patch
+    git reset HEAD <test_file_path> 2>/dev/null || true
+    # install deps, run claude -p "Fix this ticket: <title>\\n<body>"
+    # run the named test; record success/duration/tokens/cost
+
+    WDW_DIR=/tmp/case-study/<ticket_id>-with-docwiki
+    rm -rf "$WDW_DIR" && mkdir -p "$WDW_DIR" && cd "$WDW_DIR"
+    git clone --depth 100 <internal-repo-url> .
+    git checkout <fix_commit>^1
+    git checkout <fix_commit> -- <test_file_path>
+    git reset HEAD <test_file_path> 2>/dev/null || true
+    /doc-wiki:init && /doc-wiki:atlas --max-cost 30 --scope <relevant-dir>
+    # install deps, run claude -p with the same prompt
+    # run the named test; record same fields
+
+The atlas runs once per (ticket, with-doc-wiki) workspace — yes, this means atlas spend stacks. That matches the canonical benchmark/PLAN.md methodology (each condition is a fresh clone; the with-doc-wiki branch builds the wiki from scratch).
 
 Save run-level → ./case-study-output/04-ticket-bench.csv with columns:
 ticket_id, condition, success, duration_s, tokens_in, tokens_out, cost_usd, fix_path, test_path, notes

--- a/launch/case-study-runner.md
+++ b/launch/case-study-runner.md
@@ -93,9 +93,9 @@ Save the per-page index to `./case-study-output/02-pages-index.csv`.
 
 Time budget: 1–3 hours for atlas itself depending on codebase size; +30 min for indexing.
 
-## PHASE 3 — Comparison against existing internal tool
+## PHASE 3 — Comparison + anecdotes
 
-Skip this phase if INTERNAL_TOOL_NAME == "none".
+### 3a — Comparison against existing internal tool (skip if INTERNAL_TOOL_NAME == "none")
 
 Read the existing internal tool's:
 - README / docs
@@ -115,14 +115,19 @@ Compare against the doc-wiki atlas output along these axes. For each axis, give 
 
 Save to `./case-study-output/03-comparison.json` with one entry per axis.
 
-Then collect 3 specific anecdotes — moments where doc-wiki captured something the existing tool missed (or vice versa). Format each as:
-- axis (which of the 8 above)
+### 3b — Anecdotes (ALWAYS run, framing depends on INTERNAL_TOOL_NAME)
+
+Collect 3 specific anecdotes and save to `./case-study-output/03-anecdotes.json`. Format each as:
+- axis (which of the 8 above; "n/a" if no existing tool)
 - doc_wiki_artifact_path (the wiki page where it shows up)
-- existing_tool_artifact_path (or "missing" if absent)
+- existing_tool_artifact_path (see framing below)
 - one-paragraph description of why this matters
 - impact_estimate (a sentence on what a developer would do differently because of it)
 
-Save anecdotes to `./case-study-output/03-anecdotes.json`.
+Framing depends on INTERNAL_TOOL_NAME:
+
+- **If INTERNAL_TOOL_NAME != "none":** moments where doc-wiki captured something the existing tool missed (or vice versa). `existing_tool_artifact_path` is the comparable artifact in the other tool, or `"missing"` if absent.
+- **If INTERNAL_TOOL_NAME == "none":** moments where doc-wiki surfaced knowledge the team didn't have written down — tribal knowledge in someone's head, an outdated ADR, a Confluence page nobody linked, a Slack thread the team relied on. `existing_tool_artifact_path` is `"n/a"`. Do not fabricate a comparison tool.
 
 Time budget: 1–2 hours.
 
@@ -230,9 +235,9 @@ This is what you'd send to a conference CFP or a deep-dive blog.
 Full detail with real names:
 - Lead with: "I built a tool. It already works. Here's the proposal to roll it out across the org."
 - Real service names, real ticket IDs, real numbers, real screenshots
-- Direct comparison table: existing tool vs doc-wiki across the 8 axes from Phase 3
+- Direct comparison table: existing tool vs doc-wiki across the 8 axes from Phase 3 (omit this row if INTERNAL_TOOL_NAME == "none")
 - The 3 specific anecdotes from Phase 3, with names
-- Migration plan: which services first, what success looks like, what happens to the existing tool
+- Migration plan: which services first, what success looks like, what happens to the existing tool (or, if INTERNAL_TOOL_NAME == "none", the migration plan covers rollout from no-tool to doc-wiki)
 - Cost: atlas spend at scale, ongoing maintenance, headcount
 - Ask: 4-week pilot on [specific area], with a decision gate at the end
 

--- a/launch/case-study-runner.md
+++ b/launch/case-study-runner.md
@@ -231,7 +231,9 @@ Produce four ready-to-post files, all sanitized:
 
 Each one cites the OSS doc-wiki repo + the public benchmark for verifiability. None mention the company name.
 
-## Sanitization rules (apply to 5.1, 5.2, 5.4)
+## Sanitization rules (apply to 5.1, 5.2, 5.4 — UNCONDITIONALLY)
+
+The public outputs are ALWAYS sanitized. The PRIVATE flag only gates whether the internal pitch (5.3) gets generated at all; it does not relax sanitization on 5.1/5.2/5.4.
 
 - No company name
 - No team names
@@ -244,7 +246,7 @@ Each one cites the OSS doc-wiki repo + the public benchmark for verifiability. N
 - Numbers are kept (LOC, ages, percentages) — these don't identify the company
 - Tech stack is kept (Django, Postgres, etc.) — these are too common to identify
 
-When in doubt, replace. The internal pitch (5.3) gets the full detail; the public ones get patterns.
+When in doubt, replace. The internal pitch (5.3) is the ONLY file allowed real names — and only when PRIVATE=true; otherwise 5.3 is skipped entirely.
 
 ## Output checklist
 

--- a/launch/case-study-runner.md
+++ b/launch/case-study-runner.md
@@ -197,7 +197,9 @@ Time budget: ~1 hour per ticket if Claude is fast; allow 5–15 hours for a 5–
 
 From the 4 phases above, produce four documents.
 
-### 5.1 — Sanitized portfolio piece — `./case-study-output/portfolio.md` (~600 words)
+**Phase 5 output paths are absolute under `$REPO_ROOT/case-study-output/`** — same reason Phase 4 used `$REPO_ROOT` (after the per-ticket loop the session is in /tmp/case-study/<last-ticket>-with-docwiki, so any bare `./case-study-output/...` path resolves to the temp clone). `cd "$REPO_ROOT"` before authoring each file, or write the absolute path explicitly.
+
+### 5.1 — Sanitized portfolio piece — `$REPO_ROOT/case-study-output/portfolio.md` (~600 words)
 
 Use generic placeholders throughout (PRIVATE=true always):
 - Replace company name with `<COMPANY_TYPE>` where COMPANY_TYPE is one of: "a B2B SaaS", "a fintech", "a healthcare platform", "an e-commerce platform", "an enterprise software vendor"
@@ -209,7 +211,7 @@ Use generic placeholders throughout (PRIVATE=true always):
 
 This is the file you can publish on your personal website, dev.to, or LinkedIn without legal risk.
 
-### 5.2 — Public case study — `./case-study-output/case-study-public.md` (~1500 words)
+### 5.2 — Public case study — `$REPO_ROOT/case-study-output/case-study-public.md` (~1500 words)
 
 Same as portfolio but longer and more methodology-heavy:
 - The codebase shape (no names, just numbers and shape)
@@ -223,7 +225,7 @@ Same as portfolio but longer and more methodology-heavy:
 
 This is what you'd send to a conference CFP or a deep-dive blog.
 
-### 5.3 — Internal adoption pitch — `./case-study-output/internal-pitch.md` (~800 words, NOT for external sharing)
+### 5.3 — Internal adoption pitch — `$REPO_ROOT/case-study-output/internal-pitch.md` (~800 words, NOT for external sharing)
 
 Full detail with real names:
 - Lead with: "I built a tool. It already works. Here's the proposal to roll it out across the org."
@@ -236,7 +238,7 @@ Full detail with real names:
 
 This document NEVER leaves your work account. Keep it on the internal wiki / Notion / etc.
 
-### 5.4 — Social variants — `./case-study-output/social/`
+### 5.4 — Social variants — `$REPO_ROOT/case-study-output/social/`
 
 Produce four ready-to-post files, all sanitized:
 - `linkedin.md` — ~300 words, professional tone, "I built X, here's what we learned"

--- a/launch/case-study-runner.md
+++ b/launch/case-study-runner.md
@@ -134,6 +134,15 @@ Select TICKET_SAMPLE_SIZE real, closed internal tickets from the last 6 months. 
 
 **Use the two-workspace pattern from benchmark/PLAN.md**, not a single-tree restore. The wiki + CLAUDE.md references from Phase 2 must be absent for the baseline run and present for the with-doc-wiki run — that isolation requires separate clones, not in-place restore. (In-place restore either fails on the uncommitted wiki/CLAUDE.md changes, or `checkout -f` wipes the very wiki context the with-doc-wiki run is supposed to measure.)
 
+**Before the loop**, capture the starting repo path so subsequent output writes don't get redirected into a temp workspace:
+
+```sh
+REPO_ROOT="$PWD"
+mkdir -p "$REPO_ROOT/case-study-output"
+```
+
+All `./case-study-output/...` references below must be resolved against `$REPO_ROOT/case-study-output/` (use the absolute path explicitly). After each per-ticket clone-and-bench block, the `cd` has moved the session into the temp workspace; *do not* write outputs with a relative path at that point — write them as `"$REPO_ROOT/case-study-output/..."`.
+
 For each ticket, do this:
 
 ```sh
@@ -164,10 +173,10 @@ claude -p "Fix this ticket: <title>\n<body>"
 
 Atlas runs per (ticket, with-doc-wiki) workspace — yes, this stacks atlas spend, but matches benchmark/PLAN.md's canonical methodology (each condition is a fresh clone; the with-doc-wiki branch builds the wiki from scratch). If you want to amortize, you can build atlas once on a shared workspace and `cp -r` the `docs/*-wiki/` dir + CLAUDE.md references into each with-doc-wiki clone — but document it as a methodology deviation.
 
-Save results to `./case-study-output/04-ticket-bench.csv` with columns:
+Save results to `$REPO_ROOT/case-study-output/04-ticket-bench.csv` with columns:
 ticket_id, condition (baseline|with-docwiki), success (bool), duration_s, tokens_in, tokens_out, cost_usd, fix_path, test_path, notes
 
-Compute the headline numbers and save to `./case-study-output/04-summary.json`:
+Compute the headline numbers and save to `$REPO_ROOT/case-study-output/04-summary.json`:
 - baseline_pass_rate (% of tickets passing in baseline)
 - with_docwiki_pass_rate
 - delta_pp (percentage points)
@@ -256,12 +265,12 @@ After all 5 phases complete, verify:
 - [ ] `./case-study-output/02-pages-index.csv` exists
 - [ ] `./case-study-output/03-comparison.json` exists (if INTERNAL_TOOL_NAME != "none")
 - [ ] `./case-study-output/03-anecdotes.json` exists
-- [ ] `./case-study-output/04-ticket-bench.csv` exists
-- [ ] `./case-study-output/04-summary.json` exists
-- [ ] `./case-study-output/portfolio.md` exists
-- [ ] `./case-study-output/case-study-public.md` exists
-- [ ] `./case-study-output/internal-pitch.md` exists
-- [ ] `./case-study-output/social/{linkedin,x-thread,reddit-experienced-devs,devto-deepdive}.md` exist
+- [ ] `$REPO_ROOT/case-study-output/04-ticket-bench.csv` exists
+- [ ] `$REPO_ROOT/case-study-output/04-summary.json` exists
+- [ ] `$REPO_ROOT/case-study-output/portfolio.md` exists
+- [ ] `$REPO_ROOT/case-study-output/case-study-public.md` exists
+- [ ] If PRIVATE=true: `$REPO_ROOT/case-study-output/internal-pitch.md` exists; if PRIVATE=false: that file is intentionally absent
+- [ ] `$REPO_ROOT/case-study-output/social/{linkedin,x-thread,reddit-experienced-devs,devto-deepdive}.md` exist
 - [ ] grep through all public outputs for company name, team names, customer names — none should appear
 
 Add `./case-study-output/` to the codebase's `.gitignore` so the artifacts don't accidentally land in a commit to the work repo.

--- a/launch/case-study-runner.md
+++ b/launch/case-study-runner.md
@@ -132,17 +132,37 @@ Select TICKET_SAMPLE_SIZE real, closed internal tickets from the last 6 months. 
 - there's a regression test added in the fix PR
 - ticket is in this codebase, not a downstream service
 
-For each ticket, run the doc-wiki benchmark dispatch pattern (see benchmark/dispatch.md in the doc-wiki repo) but as a single-process flow:
+**Use the two-workspace pattern from benchmark/PLAN.md**, not a single-tree restore. The wiki + CLAUDE.md references from Phase 2 must be absent for the baseline run and present for the with-doc-wiki run — that isolation requires separate clones, not in-place restore. (In-place restore either fails on the uncommitted wiki/CLAUDE.md changes, or `checkout -f` wipes the very wiki context the with-doc-wiki run is supposed to measure.)
 
-For each ticket:
-- Get the fix commit SHA
-- Checkout fix_commit^1 (parent — pre-fix state)
-- Apply the test patch from the fix commit: `git checkout <fix_commit> -- <test_file_path>`
-- Run baseline: `claude -p "Fix this ticket: <title>\n<body>"` in the cloned tree (no doc-wiki context)
-- Run the test that the fix added; record pass/fail, duration, tokens, cost
-- Restore tree to fix_commit^1
-- Run with-doc-wiki: same prompt, but doc-wiki is now ready and CLAUDE.md references the wiki
-- Run the test again; record results
+For each ticket, do this:
+
+```sh
+# 1. baseline workspace — no wiki anywhere
+BASE=/tmp/case-study/<ticket_id>-baseline
+rm -rf "$BASE" && mkdir -p "$BASE" && cd "$BASE"
+git clone --depth 100 <internal-repo-url> .
+git checkout <fix_commit>^1
+git checkout <fix_commit> -- <test_file_path>          # apply only the test patch
+git reset HEAD <test_file_path> 2>/dev/null || true
+# install deps, then:
+claude -p "Fix this ticket: <title>\n<body>"
+# run the regression test the fix PR added; record pass/fail + duration + tokens + cost
+
+# 2. with-doc-wiki workspace — wiki built from scratch
+WDW=/tmp/case-study/<ticket_id>-with-docwiki
+rm -rf "$WDW" && mkdir -p "$WDW" && cd "$WDW"
+git clone --depth 100 <internal-repo-url> .
+git checkout <fix_commit>^1
+git checkout <fix_commit> -- <test_file_path>
+git reset HEAD <test_file_path> 2>/dev/null || true
+/doc-wiki:init
+/doc-wiki:atlas --max-cost 30 --scope <directory-containing-the-bug>
+# install deps, then:
+claude -p "Fix this ticket: <title>\n<body>"
+# run the same test; record same fields
+```
+
+Atlas runs per (ticket, with-doc-wiki) workspace — yes, this stacks atlas spend, but matches benchmark/PLAN.md's canonical methodology (each condition is a fresh clone; the with-doc-wiki branch builds the wiki from scratch). If you want to amortize, you can build atlas once on a shared workspace and `cp -r` the `docs/*-wiki/` dir + CLAUDE.md references into each with-doc-wiki clone — but document it as a methodology deviation.
 
 Save results to `./case-study-output/04-ticket-bench.csv` with columns:
 ticket_id, condition (baseline|with-docwiki), success (bool), duration_s, tokens_in, tokens_out, cost_usd, fix_path, test_path, notes

--- a/launch/case-study-runner.md
+++ b/launch/case-study-runner.md
@@ -55,8 +55,10 @@ Time budget: 30–60 minutes. Use Bash + Read for everything; do not invoke doc-
 
 ## PHASE 2 — Build the doc-wiki
 
-If doc-wiki is not installed, install it:
-    claude plugin install narailabs/doc-wiki
+If doc-wiki is not installed, add the NarAI marketplace once, then install the plugin (this is the canonical install path — the bare `claude plugin install narailabs/doc-wiki` form doesn't work because the repo ships `.claude-plugin/plugin.json`, not a marketplace catalog):
+
+    claude plugin marketplace add narailabs/narai-claude-plugins
+    claude plugin install doc-wiki@narai
 
 Then run:
     /doc-wiki:init      # init now subsumes the old onboard step (stack/ORM/DB/services detection)

--- a/launch/case-study-runner.md
+++ b/launch/case-study-runner.md
@@ -21,7 +21,7 @@ PROJECT_DESCRIPTION: <one sentence on what the codebase does, e.g. "a B2B SaaS b
 INTERNAL_TOOL_NAME: <the name of the existing internal documentation tool you built, or "none" if not applicable>
 INTERNAL_TOOL_LOCATION: <repo path or URL where the existing tool lives, or "none">
 EXTERNAL_CONNECTORS_ENABLED: <comma-separated list of {jira, confluence, github, notion, aws, gcp, db} you have configured>
-PRIVATE: <true | false — if true, all outputs use placeholder names; if false, real names are kept in the internal adoption pitch only>
+PRIVATE: <true | false — gates whether the internal pitch (5.3) is generated. true: produce 5.3 with real names (NDA-only artifact) plus sanitized 5.1/5.2/5.4. false: skip 5.3 entirely; only sanitized 5.1/5.2/5.4 are produced. Public outputs are ALWAYS sanitized regardless of this flag.>
 TICKET_SAMPLE_SIZE: <how many real internal tickets to run the benchmark on; recommended 5–10>
 
 ## PHASE 1 — Codebase inventory (no doc-wiki yet)

--- a/launch/case-study-runner.md
+++ b/launch/case-study-runner.md
@@ -152,6 +152,9 @@ For each ticket, do this:
 BASE=/tmp/case-study/<ticket_id>-baseline
 rm -rf "$BASE" && mkdir -p "$BASE" && cd "$BASE"
 git clone --depth 100 <internal-repo-url> .
+# Ensure <fix_commit> + parent are present even if behind shallow depth
+# (active internal repos with 6-month-old tickets routinely exceed 100):
+git fetch --depth 500 origin <fix_commit> 2>/dev/null || git fetch --unshallow
 git checkout <fix_commit>^1
 git checkout <fix_commit> -- <test_file_path>          # apply only the test patch
 git reset HEAD <test_file_path> 2>/dev/null || true
@@ -163,6 +166,7 @@ claude -p "Fix this ticket: <title>\n<body>"
 WDW=/tmp/case-study/<ticket_id>-with-docwiki
 rm -rf "$WDW" && mkdir -p "$WDW" && cd "$WDW"
 git clone --depth 100 <internal-repo-url> .
+git fetch --depth 500 origin <fix_commit> 2>/dev/null || git fetch --unshallow
 git checkout <fix_commit>^1
 git checkout <fix_commit> -- <test_file_path>
 git reset HEAD <test_file_path> 2>/dev/null || true

--- a/launch/case-study-runner.md
+++ b/launch/case-study-runner.md
@@ -59,8 +59,7 @@ If doc-wiki is not installed, install it:
     claude plugin install narailabs/doc-wiki
 
 Then run:
-    /doc-wiki:init
-    /doc-wiki:onboard
+    /doc-wiki:init      # init now subsumes the old onboard step (stack/ORM/DB/services detection)
     /doc-wiki:atlas --dry-run
 
 Read the dry-run output. Confirm the topic discovery, facet plan, and cost estimate look reasonable. If cost estimate exceeds $50, narrow the scope with --scope <directory>.

--- a/launch/case-study-runner.md
+++ b/launch/case-study-runner.md
@@ -1,0 +1,284 @@
+# doc-wiki case-study runner
+
+> Paste-ready Claude Code prompt for measuring doc-wiki's impact on a real codebase and generating the four deliverables you need for adoption + portfolio + viral launch.
+>
+> **What this produces:** one structured run-output JSON + four ready-to-publish markdown documents (sanitized portfolio piece, public case study, internal adoption pitch, social variants).
+>
+> **How to use it:** edit the `PARAMETERS` block at the top to point at your codebase, paste the entire file into Claude Code inside that codebase's repo, let it run all 5 phases. ~1–3 hours wall time depending on codebase size.
+
+---
+
+## Run this prompt inside your codebase (begin paste)
+
+```
+# doc-wiki case-study run — read this entire file, then execute all 5 phases
+# in order. Do NOT skip phases. Write outputs to ./case-study-output/.
+
+## PARAMETERS — fill these in before running
+
+PROJECT_NAME: <a short generic label for the codebase, e.g. "platform-monolith">
+PROJECT_DESCRIPTION: <one sentence on what the codebase does, e.g. "a B2B SaaS booking platform serving N customers">
+INTERNAL_TOOL_NAME: <the name of the existing internal documentation tool you built, or "none" if not applicable>
+INTERNAL_TOOL_LOCATION: <repo path or URL where the existing tool lives, or "none">
+EXTERNAL_CONNECTORS_ENABLED: <comma-separated list of {jira, confluence, github, notion, aws, gcp, db} you have configured>
+PRIVATE: <true | false — if true, all outputs use placeholder names; if false, real names are kept in the internal adoption pitch only>
+TICKET_SAMPLE_SIZE: <how many real internal tickets to run the benchmark on; recommended 5–10>
+
+## PHASE 1 — Codebase inventory (no doc-wiki yet)
+
+Read the codebase top-down. Produce `./case-study-output/01-inventory.json` with:
+
+- repo_size_loc (total lines of source code, exclude tests/vendor/generated)
+- repo_age_years (years since first commit, from `git log --reverse | head`)
+- service_count (top-level services or apps, if monorepo; else 1)
+- language_breakdown (% by LOC)
+- frameworks_detected (Django/FastAPI/Spring/Rails/Express/Next/etc.)
+- orm_detected (Prisma/SQLAlchemy/Django/JPA/ActiveRecord/etc., with confidence)
+- db_detected (Postgres/MySQL/Mongo/etc., with how — env vars, docker-compose, ORM config)
+- external_services_observed (any references to AWS/GCP/Jira/Confluence/Slack/etc. found in code or config)
+- existing_documentation_observed:
+    - readme_lines
+    - in_code_comment_density (rough %)
+    - markdown_doc_count (count of `.md` files under `docs/` or similar)
+    - quality_subjective (1–5 with one-sentence reasoning)
+- complexity_signals:
+    - circular_dependencies_count (heuristic via grep)
+    - god_modules_count (files > 1000 LOC)
+    - schema_drift_observed (if you can compare ORM models to DB schema)
+- existing_internal_tool_summary (if INTERNAL_TOOL_NAME != "none"):
+    - what_it_does (1-3 sentences)
+    - coverage_metric (lines documented / total, or pages-vs-files)
+    - last_updated (most recent commit to its output dir)
+    - gaps_observed (3–5 specific things the existing tool misses)
+
+Time budget: 30–60 minutes. Use Bash + Read for everything; do not invoke doc-wiki yet.
+
+## PHASE 2 — Build the doc-wiki
+
+If doc-wiki is not installed, install it:
+    claude plugin install narailabs/doc-wiki
+
+Then run:
+    /doc-wiki:init
+    /doc-wiki:onboard
+    /doc-wiki:atlas --dry-run
+
+Read the dry-run output. Confirm the topic discovery, facet plan, and cost estimate look reasonable. If cost estimate exceeds $50, narrow the scope with --scope <directory>.
+
+Then commit:
+    /doc-wiki:atlas --max-cost 50
+
+After atlas completes, collect into `./case-study-output/02-atlas.json`:
+
+- atlas_run_id (from atlas output)
+- atlas_duration_minutes
+- atlas_cost_usd (from atlas output's stats)
+- pages_generated (total .md files under docs/<app>-wiki/wiki/)
+- topics_covered (list of top-level topic dirs)
+- facets_per_topic (avg)
+- mermaid_diagrams_generated (count)
+- references_inserted_in_claudemd (count of new wiki links added to CLAUDE.md)
+- orm_entities_mapped (if ORM detected)
+- external_service_pages (count of pages under wiki/integrations/ or similar)
+
+For each generated wiki page, also collect:
+- path
+- title
+- type (concept/runbook/decision/reference)
+- sources (frontmatter)
+- word_count
+
+Save the per-page index to `./case-study-output/02-pages-index.csv`.
+
+Time budget: 1–3 hours for atlas itself depending on codebase size; +30 min for indexing.
+
+## PHASE 3 — Comparison against existing internal tool
+
+Skip this phase if INTERNAL_TOOL_NAME == "none".
+
+Read the existing internal tool's:
+- README / docs
+- output directory (whatever it produces)
+- sample output pages
+
+Compare against the doc-wiki atlas output along these axes. For each axis, give a 1-paragraph judgment + one specific example:
+
+1. **Code coverage** — does the existing tool cover all source files? Does atlas?
+2. **Ecosystem coverage** — does the existing tool ingest Jira/Confluence/DB schemas? Does atlas?
+3. **ORM/DB linking** — does the existing tool map ORM entities to DB tables? Does atlas?
+4. **Progressive disclosure** — does the existing tool surface a summary-first index? Does atlas?
+5. **Drift detection** — does the existing tool flag pages whose source code moved? Does atlas?
+6. **Cross-link density** — average inline wiki links per page in each tool's output
+7. **Cited-synthesis queries** — can the existing tool answer "How does authentication work?" with citations? Can atlas?
+8. **Maintenance cost** — manual effort needed to keep each tool's output current
+
+Save to `./case-study-output/03-comparison.json` with one entry per axis.
+
+Then collect 3 specific anecdotes — moments where doc-wiki captured something the existing tool missed (or vice versa). Format each as:
+- axis (which of the 8 above)
+- doc_wiki_artifact_path (the wiki page where it shows up)
+- existing_tool_artifact_path (or "missing" if absent)
+- one-paragraph description of why this matters
+- impact_estimate (a sentence on what a developer would do differently because of it)
+
+Save anecdotes to `./case-study-output/03-anecdotes.json`.
+
+Time budget: 1–2 hours.
+
+## PHASE 4 — Ticket benchmark
+
+Select TICKET_SAMPLE_SIZE real, closed internal tickets from the last 6 months. Selection criteria:
+- the ticket was actually fixed (PR merged)
+- the fix touches 1–3 files (~5–200 LOC change)
+- there's a regression test added in the fix PR
+- ticket is in this codebase, not a downstream service
+
+For each ticket, run the doc-wiki benchmark dispatch pattern (see benchmark/dispatch.md in the doc-wiki repo) but as a single-process flow:
+
+For each ticket:
+- Get the fix commit SHA
+- Checkout fix_commit^1 (parent — pre-fix state)
+- Apply the test patch from the fix commit: `git checkout <fix_commit> -- <test_file_path>`
+- Run baseline: `claude -p "Fix this ticket: <title>\n<body>"` in the cloned tree (no doc-wiki context)
+- Run the test that the fix added; record pass/fail, duration, tokens, cost
+- Restore tree to fix_commit^1
+- Run with-doc-wiki: same prompt, but doc-wiki is now ready and CLAUDE.md references the wiki
+- Run the test again; record results
+
+Save results to `./case-study-output/04-ticket-bench.csv` with columns:
+ticket_id, condition (baseline|with-docwiki), success (bool), duration_s, tokens_in, tokens_out, cost_usd, fix_path, test_path, notes
+
+Compute the headline numbers and save to `./case-study-output/04-summary.json`:
+- baseline_pass_rate (% of tickets passing in baseline)
+- with_docwiki_pass_rate
+- delta_pp (percentage points)
+- baseline_median_duration_s
+- with_docwiki_median_duration_s
+- baseline_total_cost_usd
+- with_docwiki_total_cost_usd
+
+Time budget: ~1 hour per ticket if Claude is fast; allow 5–15 hours for a 5–10 ticket sample.
+
+## PHASE 5 — Generate deliverables
+
+From the 4 phases above, produce four documents.
+
+### 5.1 — Sanitized portfolio piece — `./case-study-output/portfolio.md` (~600 words)
+
+Use generic placeholders throughout (PRIVATE=true always):
+- Replace company name with `<COMPANY_TYPE>` where COMPANY_TYPE is one of: "a B2B SaaS", "a fintech", "a healthcare platform", "an e-commerce platform", "an enterprise software vendor"
+- Replace project name with PROJECT_NAME from parameters
+- Use codebase-shape language only: "a ~X00k LOC monolith", "an N-year-old codebase", "Y services in the ecosystem"
+- Lead with the benchmark headline (the delta + the methodology + the OSS verification pointer)
+- Include one anonymized anecdote from Phase 3
+- Close with a link to the OSS doc-wiki repo + the public benchmark
+
+This is the file you can publish on your personal website, dev.to, or LinkedIn without legal risk.
+
+### 5.2 — Public case study — `./case-study-output/case-study-public.md` (~1500 words)
+
+Same as portfolio but longer and more methodology-heavy:
+- The codebase shape (no names, just numbers and shape)
+- The internal documentation problem (abstract description)
+- The doc-wiki rollout approach (the steps you actually took)
+- The benchmark methodology (what you measured, how)
+- The numbers (Phase 4 results)
+- 2 anonymized anecdotes (Phase 3)
+- Architecture diagram from doc-wiki atlas, with all names replaced by placeholders (use Mermaid)
+- Reproducibility note: "The methodology is reproducible — re-run the same harness against any OSS repo. See [doc-wiki/benchmark/PUBLISH.md](https://github.com/narailabs/doc-wiki/blob/main/benchmark/PUBLISH.md)."
+
+This is what you'd send to a conference CFP or a deep-dive blog.
+
+### 5.3 — Internal adoption pitch — `./case-study-output/internal-pitch.md` (~800 words, NOT for external sharing)
+
+Full detail with real names:
+- Lead with: "I built a tool. It already works. Here's the proposal to roll it out across the org."
+- Real service names, real ticket IDs, real numbers, real screenshots
+- Direct comparison table: existing tool vs doc-wiki across the 8 axes from Phase 3
+- The 3 specific anecdotes from Phase 3, with names
+- Migration plan: which services first, what success looks like, what happens to the existing tool
+- Cost: atlas spend at scale, ongoing maintenance, headcount
+- Ask: 4-week pilot on [specific area], with a decision gate at the end
+
+This document NEVER leaves your work account. Keep it on the internal wiki / Notion / etc.
+
+### 5.4 — Social variants — `./case-study-output/social/`
+
+Produce four ready-to-post files, all sanitized:
+- `linkedin.md` — ~300 words, professional tone, "I built X, here's what we learned"
+- `x-thread.md` — 5–7 tweets, technical, leads with the metric
+- `reddit-experienced-devs.md` — long-form (~800 words), candid, no marketing voice, leads with the problem
+- `devto-deepdive.md` — ~2000 words, technical methodology piece, embeds the architecture diagram
+
+Each one cites the OSS doc-wiki repo + the public benchmark for verifiability. None mention the company name.
+
+## Sanitization rules (apply to 5.1, 5.2, 5.4)
+
+- No company name
+- No team names
+- No employee names other than yours
+- No specific customer names
+- No specific ticket IDs from internal trackers (paraphrase the bug into a general pattern)
+- No specific service names — use SERVICE_A, SERVICE_B, etc.
+- No screenshots of internal tools, internal Jira, internal Confluence
+- Architecture diagrams: replace service/db names with placeholders
+- Numbers are kept (LOC, ages, percentages) — these don't identify the company
+- Tech stack is kept (Django, Postgres, etc.) — these are too common to identify
+
+When in doubt, replace. The internal pitch (5.3) gets the full detail; the public ones get patterns.
+
+## Output checklist
+
+After all 5 phases complete, verify:
+- [ ] `./case-study-output/01-inventory.json` exists
+- [ ] `./case-study-output/02-atlas.json` exists
+- [ ] `./case-study-output/02-pages-index.csv` exists
+- [ ] `./case-study-output/03-comparison.json` exists (if INTERNAL_TOOL_NAME != "none")
+- [ ] `./case-study-output/03-anecdotes.json` exists
+- [ ] `./case-study-output/04-ticket-bench.csv` exists
+- [ ] `./case-study-output/04-summary.json` exists
+- [ ] `./case-study-output/portfolio.md` exists
+- [ ] `./case-study-output/case-study-public.md` exists
+- [ ] `./case-study-output/internal-pitch.md` exists
+- [ ] `./case-study-output/social/{linkedin,x-thread,reddit-experienced-devs,devto-deepdive}.md` exist
+- [ ] grep through all public outputs for company name, team names, customer names — none should appear
+
+Add `./case-study-output/` to the codebase's `.gitignore` so the artifacts don't accidentally land in a commit to the work repo.
+
+## Summary report
+
+After all 5 phases + the checklist, write a final summary to stdout:
+- Total wall time
+- Total atlas + Claude spend across all phases
+- Headline numbers (baseline pass rate, with-doc-wiki pass rate, delta)
+- The 3 anecdotes (one-line each)
+- Where each deliverable is located
+- One sentence on what surprised you the most while running this
+```
+
+## End of paste
+
+---
+
+## How to use the four deliverables
+
+| File | Audience | When to publish |
+|---|---|---|
+| `portfolio.md` | You (LinkedIn, personal site, cover letter) | After OSS doc-wiki launch lands; doesn't require permission from current employer |
+| `case-study-public.md` | Conference CFPs (AI Engineer Summit, QCon), deep-dive blog | After 4-week internal pilot is documented |
+| `internal-pitch.md` | Your current employer's engineering leadership | **Before** you start interviewing externally |
+| `social/*.md` | LinkedIn, X, Reddit, dev.to | T+1 to T+30 of doc-wiki public launch |
+
+## A recommended sequence
+
+1. **Run the prompt on the simpler project first** — gets you a feel for it, less risk if a phase fails.
+2. **Use the internal pitch (5.3) to get sanctioned internal adoption.** Run a 4-week pilot. Document the actual numbers your team observes — this is your "I shipped impact" evidence for the next job.
+3. **After 4 weeks**, re-run the prompt to get fresh numbers. Update the public deliverables with the longer-baseline data.
+4. **Then publish the social variants** as part of the doc-wiki OSS launch wave. Lead with the OSS benchmark; reference your internal pilot as "case study — Fortune 500 SaaS, see [link to case-study-public.md]".
+5. **Reserve the named version (5.3) for interviews.** "I rolled this out at $current_employer, here's what we measured — happy to walk through details under NDA."
+
+## What this prompt does NOT do
+
+It doesn't make your current employer sanction the rollout. That's a separate conversation you have with your manager *before* running the pilot. The internal pitch (5.3) is the doc you bring to that conversation; the prompt produces a draft, you edit it for tone.
+
+It also doesn't replace the OSS launch. The OSS launch is what gives you a public artifact people can verify. The case study is what gives that public artifact credibility on enterprise codebases. Both are needed.

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,7 @@
     "declaration": false,
     "noEmit": false
   },
-  "include": ["agents/**/*.ts", "skills/**/*.ts", "vitest.config.ts"],
+  "include": ["agents/**/*.ts", "skills/**/*.ts", "launch/**/*.ts", "vitest.config.ts"],
   "exclude": [
     "node_modules",
     ".worktrees",


### PR DESCRIPTION
## Summary

Two artifacts for users who want to run doc-wiki against their own internal codebase to produce case-study material (portfolio piece, public case study, internal adoption pitch, social variants).

**`launch/case-study-runner.md`** — paste-ready Claude Code prompt with 5 phases:
1. Inventory (codebase shape, existing-doc-tool gap analysis)
2. Atlas (run doc-wiki, capture all output metrics)
3. Comparison vs existing internal documentation tool (8 axes + 3 anecdotes)
4. Ticket benchmark (N real internal tickets, baseline vs with-doc-wiki)
5. Generate 4 deliverables (sanitized portfolio.md, sanitized public case-study.md, internal-pitch.md with real names, social variants for LinkedIn/X/Reddit/dev.to)

Sanitization rules baked in: public outputs use placeholders (`<COMPANY_TYPE>`, `SERVICE_A`, etc.) while the internal pitch keeps real names.

**`launch/case-study-init.ts`** — scaffolds `case-study-output/` in the current codebase. Auto-detects:
- Project name (package.json / pyproject.toml / Cargo.toml / go.mod / git remote / dir basename)
- LOC (tokei → cloc → find+wc fallback)
- Age in years (`git log --reverse`)
- Languages (file extension counts)
- Frameworks (Django/FastAPI/Next/Rails/Spring/etc. via marker files)
- ORM (Prisma/SQLAlchemy/Django/TypeORM/Drizzle/ActiveRecord/Hibernate)
- DB (Postgres/MySQL/Mongo/Redis/SQLite/DynamoDB/ClickHouse)
- Configured connectors (from `~/.connectors/config.yaml`)

Prompts (or reads env vars) only for what can't be detected: project description, existing internal-tool name, privacy posture, ticket sample size. Writes a filled-in `PROMPT.md` ready to paste, adds `case-study-output/` to `.gitignore`, and puts a deny-all `.gitignore` inside the dir so the outputs never accidentally land in a commit.

## Usage

```sh
# from inside the codebase you want to document
curl -fsSL https://raw.githubusercontent.com/narailabs/doc-wiki/main/launch/case-study-init.ts \
  | npx tsx -
```

or with all params from env (no interactive prompts):

```sh
PROJECT_NAME=my-app \
INTERNAL_TOOL_NAME=internal-docs \
INTERNAL_TOOL_LOCATION=https://internal.example.com/docs \
PRIVATE=true \
TICKET_SAMPLE_SIZE=5 \
npx tsx launch/case-study-init.ts
```

## Test plan

- [x] `npx tsc --noEmit` clean on `launch/case-study-init.ts`
- [ ] `case-study-init.ts` smoke-test in a real codebase (cannot do in CI; manually verified during authoring)
- [ ] The 5-phase prompt is intentionally a Claude-runtime instruction; correctness comes from the Claude Code session executing it, not from any unit test in this repo