### PR TITLE
⚡ Bolt: Hoist regex literals to prevent re-evaluation in log parsing loops

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -12,3 +12,7 @@
 
 **Learning:** Inner JSON fields might mistakenly contain match substrings like dates (e.g., inside the text of the event). Utilizing a strict, anchored regex check for extracting fields like timestamps directly (`/^{"ts":"([^"\\]+)"/`) avoids both `JSON.parse` overhead and incorrect partial string matches from `String.includes()`.
 **Action:** Use an anchored regex (`/^{"ts":"([^"\\]+)"/`) and check the captured group directly before falling back to full JSON parsing.
+## 2026-06-05 - Hoisting regexes for performance
+
+**Learning:** Re-evaluating inline regex literals inside loops or frequently-called functions creates unnecessary overhead. While JS engines often optimize inline literals, explicitly hoisting them ensures zero-reallocation overhead. Furthermore, ensuring that stateless regexes (without global `g` or sticky `y` flags) are hoisted guarantees thread safety and optimal parsing speed for large log files.
+**Action:** Always extract stateless regular expressions (especially extraction filters like `/^{"ts":"([^"\\]+)"/`) to top-level constants when scanning large append-only log files.

--- a/skills/doc-wiki/scripts/daily_summary.js
+++ b/skills/doc-wiki/scripts/daily_summary.js
@@ -20,6 +20,8 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
 import { parseFlags } from "./_cli_args.js";
+// ── Regex Helpers ───────────────────────────────────────────────────
+const TS_EXTRACT_RE = /^{"ts":"([^"\\]+)"/;
 // ── Helpers ─────────────────────────────────────────────────────────
 /**
  * Read events from `<wikiRoot>/log/events.jsonl`, keeping only entries whose
@@ -40,7 +42,7 @@ function readEvents(wikiRoot, dateStr) {
         // Fast-path: skip JSON parse overhead if this line cannot match our date
         if (!line.includes(dateStr))
             continue;
-        const match = line.match(/^{"ts":"([^"\\]+)"/);
+        const match = line.match(TS_EXTRACT_RE);
         if (match && match[1] && !match[1].startsWith(dateStr))
             continue;
         let entry;

--- a/skills/doc-wiki/scripts/daily_summary.ts
+++ b/skills/doc-wiki/scripts/daily_summary.ts
@@ -21,6 +21,10 @@ import * as path from "node:path";
 import { fileURLToPath } from "node:url";
 import { parseFlags } from "./_cli_args.js";
 
+// ── Regex Helpers ───────────────────────────────────────────────────
+
+const TS_EXTRACT_RE = /^{"ts":"([^"\\]+)"/;
+
 // ── Helpers ─────────────────────────────────────────────────────────
 
 /**
@@ -44,7 +48,7 @@ function readEvents(
 
     // Fast-path: skip JSON parse overhead if this line cannot match our date
     if (!line.includes(dateStr)) continue;
-    const match = line.match(/^{"ts":"([^"\\]+)"/);
+    const match = line.match(TS_EXTRACT_RE);
     if (match && match[1] && !match[1].startsWith(dateStr)) continue;
 
     let entry: unknown;

--- a/skills/doc-wiki/scripts/event_logger.js
+++ b/skills/doc-wiki/scripts/event_logger.js
@@ -19,6 +19,11 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
+// ── Regex Helpers ───────────────────────────────────────────────────
+const TS_EXTRACT_RE = /^{"ts":"([^"\\]+)"/;
+const RELATIVE_SINCE_EXTRACT_RE = /^(\d+)([dhm])$/;
+const RELATIVE_SINCE_TEST_RE = /^\d+[dhm]$/;
+const ABSOLUTE_SINCE_TEST_RE = /^\d{4}-\d{2}-\d{2}/;
 // ── Timestamp helpers ───────────────────────────────────────────────
 /**
  * Produce a Python-compatible `datetime.now(timezone.utc).isoformat()`
@@ -156,7 +161,7 @@ function _readEvents(wikiRoot, since = null) {
             // leading whitespace. The character class excludes both `"` and `\` so
             // any ts containing a JSON escape (like `\+` for `+`) misses the regex
             // and safely falls through to the slow path for proper decoding.
-            const m = line.match(/^{"ts":"([^"\\]+)"/);
+            const m = line.match(TS_EXTRACT_RE);
             if (m) {
                 const entryMs = parsePythonIsoformat(m[1]);
                 // G-EVENTS-TS-STRICT: when --since is active, drop events whose
@@ -195,7 +200,7 @@ function _readEvents(wikiRoot, since = null) {
  * it does not match the `N[dhm]` shape, matching the Python helper.
  */
 export function parseRelativeSince(sinceStr) {
-    const match = sinceStr.match(/^(\d+)([dhm])$/);
+    const match = sinceStr.match(RELATIVE_SINCE_EXTRACT_RE);
     if (!match) {
         return sinceStr;
     }
@@ -549,8 +554,8 @@ export function main(argv = process.argv.slice(2)) {
         // else exits non-zero with a clear error so the caller knows their
         // filter was ignored rather than silently returning all events.
         if (args.since !== null && args.since !== undefined) {
-            const isRelative = /^\d+[dhm]$/.test(args.since);
-            const isAbsolute = /^\d{4}-\d{2}-\d{2}/.test(args.since);
+            const isRelative = RELATIVE_SINCE_TEST_RE.test(args.since);
+            const isAbsolute = ABSOLUTE_SINCE_TEST_RE.test(args.since);
             if (!isRelative && !isAbsolute) {
                 process.stderr.write(`[event_logger] error: --since value ${JSON.stringify(args.since)} is not a valid relative duration (e.g. 7d, 24h, 15m) or absolute ISO timestamp (YYYY-MM-DD...)\n`);
                 return 2;

--- a/skills/doc-wiki/scripts/event_logger.ts
+++ b/skills/doc-wiki/scripts/event_logger.ts
@@ -20,6 +20,13 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
 
+// ── Regex Helpers ───────────────────────────────────────────────────
+
+const TS_EXTRACT_RE = /^{"ts":"([^"\\]+)"/;
+const RELATIVE_SINCE_EXTRACT_RE = /^(\d+)([dhm])$/;
+const RELATIVE_SINCE_TEST_RE = /^\d+[dhm]$/;
+const ABSOLUTE_SINCE_TEST_RE = /^\d{4}-\d{2}-\d{2}/;
+
 // ── Timestamp helpers ───────────────────────────────────────────────
 
 /**
@@ -201,7 +208,7 @@ function _readEvents(
       // leading whitespace. The character class excludes both `"` and `\` so
       // any ts containing a JSON escape (like `\+` for `+`) misses the regex
       // and safely falls through to the slow path for proper decoding.
-      const m = line.match(/^{"ts":"([^"\\]+)"/);
+      const m = line.match(TS_EXTRACT_RE);
       if (m) {
         const entryMs = parsePythonIsoformat(m[1] as string);
         // G-EVENTS-TS-STRICT: when --since is active, drop events whose
@@ -245,7 +252,7 @@ function _readEvents(
  * it does not match the `N[dhm]` shape, matching the Python helper.
  */
 export function parseRelativeSince(sinceStr: string): string {
-  const match = sinceStr.match(/^(\d+)([dhm])$/);
+  const match = sinceStr.match(RELATIVE_SINCE_EXTRACT_RE);
   if (!match) {
     return sinceStr;
   }
@@ -642,8 +649,8 @@ export function main(argv: readonly string[] = process.argv.slice(2)): number {
     // else exits non-zero with a clear error so the caller knows their
     // filter was ignored rather than silently returning all events.
     if (args.since !== null && args.since !== undefined) {
-      const isRelative = /^\d+[dhm]$/.test(args.since);
-      const isAbsolute = /^\d{4}-\d{2}-\d{2}/.test(args.since);
+      const isRelative = RELATIVE_SINCE_TEST_RE.test(args.since);
+      const isAbsolute = ABSOLUTE_SINCE_TEST_RE.test(args.since);
       if (!isRelative && !isAbsolute) {
         process.stderr.write(
           `[event_logger] error: --since value ${JSON.stringify(


### PR DESCRIPTION
💡 What: Hoisted inline regular expression literals to top-level constants in `skills/doc-wiki/scripts/event_logger.ts` and `skills/doc-wiki/scripts/daily_summary.ts`.
🎯 Why: Re-evaluating regex literals inside a loop (or in frequently called functions) can cause unnecessary object reallocation or re-compilation in JS, slowing down the fast-path extraction logic for large `events.jsonl` files.
📊 Impact: Expected to reduce the overhead of regex evaluation in parsing large `events.jsonl` logs.
🔬 Measurement: Verify using `npm run test` or observe execution time for scripts parsing large `events.jsonl` files via `--since` options.

---
*PR created automatically by Jules for task [1749262626056592023](https://jules.google.com/task/1749262626056592023) started by @rfv-code*