### PR TITLE
⚡ Bolt: [performance improvement] Hoist regex in log parsing

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -12,3 +12,8 @@
 
 **Learning:** Inner JSON fields might mistakenly contain match substrings like dates (e.g., inside the text of the event). Utilizing a strict, anchored regex check for extracting fields like timestamps directly (`/^{"ts":"([^"\\]+)"/`) avoids both `JSON.parse` overhead and incorrect partial string matches from `String.includes()`.
 **Action:** Use an anchored regex (`/^{"ts":"([^"\\]+)"/`) and check the captured group directly before falling back to full JSON parsing.
+
+## 2026-05-23 - Hoisting Regex for Log Filtering
+
+**Learning:** When pre-filtering large, append-only json log streams (like `events.jsonl`) using regex checks (e.g., `/^{"ts":"([^"\\]+)"/`), instantiating `new RegExp()` or using literal regex definitions inside loops adds significant overhead that can diminish the performance benefits of bypassing `JSON.parse()`.
+**Action:** Hoist the regex literals outside of the reading loop (e.g., as a global constant `const TS_RE = ...;`) to ensure compilation happens only once, maximizing the speed of the `.exec()` fast-path check. However, be careful not to mistake substring check `.includes()` (which is significantly faster than regex) as something to replace with regex `.test()`; only hoist literal regex definitions to regex variables for `.exec()` or `.test()` calls.

--- a/skills/doc-wiki/scripts/daily_summary.js
+++ b/skills/doc-wiki/scripts/daily_summary.js
@@ -21,6 +21,7 @@ import * as path from "node:path";
 import { fileURLToPath } from "node:url";
 import { parseFlags } from "./_cli_args.js";
 // ── Helpers ─────────────────────────────────────────────────────────
+const TS_RE = /^{"ts":"([^"\\]+)"/;
 /**
  * Read events from `<wikiRoot>/log/events.jsonl`, keeping only entries whose
  * `ts` string starts with `dateStr`. Unparseable JSON lines are silently
@@ -40,7 +41,7 @@ function readEvents(wikiRoot, dateStr) {
         // Fast-path: skip JSON parse overhead if this line cannot match our date
         if (!line.includes(dateStr))
             continue;
-        const match = line.match(/^{"ts":"([^"\\]+)"/);
+        const match = TS_RE.exec(line);
         if (match && match[1] && !match[1].startsWith(dateStr))
             continue;
         let entry;

--- a/skills/doc-wiki/scripts/daily_summary.ts
+++ b/skills/doc-wiki/scripts/daily_summary.ts
@@ -23,6 +23,8 @@ import { parseFlags } from "./_cli_args.js";
 
 // ── Helpers ─────────────────────────────────────────────────────────
 
+const TS_RE = /^{"ts":"([^"\\]+)"/;
+
 /**
  * Read events from `<wikiRoot>/log/events.jsonl`, keeping only entries whose
  * `ts` string starts with `dateStr`. Unparseable JSON lines are silently
@@ -44,7 +46,7 @@ function readEvents(
 
     // Fast-path: skip JSON parse overhead if this line cannot match our date
     if (!line.includes(dateStr)) continue;
-    const match = line.match(/^{"ts":"([^"\\]+)"/);
+    const match = TS_RE.exec(line);
     if (match && match[1] && !match[1].startsWith(dateStr)) continue;
 
     let entry: unknown;

--- a/skills/doc-wiki/scripts/event_logger.js
+++ b/skills/doc-wiki/scripts/event_logger.js
@@ -128,6 +128,7 @@ export function logEvent(wikiRoot, op, details) {
     return entry;
 }
 // ── Stats ───────────────────────────────────────────────────────────
+const TS_RE = /^{"ts":"([^"\\]+)"/;
 function _readEvents(wikiRoot, since = null) {
     const p = _eventsPath(wikiRoot);
     if (!fs.existsSync(p)) {
@@ -156,7 +157,7 @@ function _readEvents(wikiRoot, since = null) {
             // leading whitespace. The character class excludes both `"` and `\` so
             // any ts containing a JSON escape (like `\+` for `+`) misses the regex
             // and safely falls through to the slow path for proper decoding.
-            const m = line.match(/^{"ts":"([^"\\]+)"/);
+            const m = TS_RE.exec(line);
             if (m) {
                 const entryMs = parsePythonIsoformat(m[1]);
                 // G-EVENTS-TS-STRICT: when --since is active, drop events whose

--- a/skills/doc-wiki/scripts/event_logger.ts
+++ b/skills/doc-wiki/scripts/event_logger.ts
@@ -162,6 +162,8 @@ export function logEvent(
 
 // ── Stats ───────────────────────────────────────────────────────────
 
+const TS_RE = /^{"ts":"([^"\\]+)"/;
+
 function _readEvents(
   wikiRoot: string,
   since: string | null = null,
@@ -201,7 +203,7 @@ function _readEvents(
       // leading whitespace. The character class excludes both `"` and `\` so
       // any ts containing a JSON escape (like `\+` for `+`) misses the regex
       // and safely falls through to the slow path for proper decoding.
-      const m = line.match(/^{"ts":"([^"\\]+)"/);
+      const m = TS_RE.exec(line);
       if (m) {
         const entryMs = parsePythonIsoformat(m[1] as string);
         // G-EVENTS-TS-STRICT: when --since is active, drop events whose


### PR DESCRIPTION
💡 What: Hoisted the timestamp extraction regex literal into a module-level constant (`TS_RE`) and replaced inline `.match()` with `TS_RE.exec()` in both `daily_summary.ts` and `event_logger.ts` (and their generated JS variants).

🎯 Why: In high-throughput parsing paths (such as reading the full history of `events.jsonl`), inline literal regular expressions cause the JS engine to redundantly evaluate the pattern. Hoisting ensures the regex is compiled only once per script execution, improving fast-path log parsing speed.

📊 Impact: Reduces overhead per-line when skipping unparsed JSON events based on timestamp constraints, leading to lower parsing latency on larger wikis with extensive event logs.

🔬 Measurement: Run `npm run test` to verify no regressions in the log ingestion logic. Time execution of `node daily_summary.js` on an environment with an oversized `events.jsonl` file.

---
*PR created automatically by Jules for task [10943982546628114522](https://jules.google.com/task/10943982546628114522) started by @rfv-code*