### PR TITLE
fix(benchmark): runnable-test gates + workspace-aware grading

### DIFF
--- a/benchmark/METHODOLOGY.md
+++ b/benchmark/METHODOLOGY.md
@@ -4,7 +4,7 @@
 
 **Design:** paired two-arm runs per ticket (baseline / wiki) — identical container, model (`claude-sonnet-4-6`, pinned full ID), prompt, and flags; the only delta is the presence of the pre-built wiki + `CLAUDE.md` in the checkout (committed before the session so the agent's diff contains only its own work). Grading: the real fix PR's tests, overlaid onto the agent's diff (SWE-bench style). Pass = all overlaid tests pass; a pass that needed the configured single retry is recorded distinctly (`tests-passed-on-retry`).
 
-**Ticket eligibility:** closed issue with a merged linked fix PR touching both test and non-test source, <400 changed lines, natural-language body ≥200 chars, human author, merged after the repo's `ticket_after` floor. The committed `tickets/<repo>.json` is the exact set, including every exclusion and its reason.
+**Ticket eligibility:** closed issue with a merged linked fix PR touching both test and non-test source, <400 changed lines, natural-language body ≥200 chars, human author, merged after the repo's `ticket_after` floor. The fix PR must include at least one *runnable* test entry point (per-repo `run_patterns`) — test-side support files (configs, fixtures, utils) are overlaid at grade time but never executed directly. Tickets whose runnable tests need toolchains absent from the grade container (per-repo `exclude_test_paths`, e.g. vitest's Playwright-backed `test/browser/**` and `test/ui/**` suites) are excluded up front. The committed `tickets/<repo>.json` is the exact set, including every exclusion and its reason.
 
 **Contamination controls:**
 1. *Fix leak:* the wiki is built at `wiki_commit`, verified (`git merge-base --is-ancestor`) to predate every ticket's base commit.

--- a/benchmark/harness/docker/grade.sh
+++ b/benchmark/harness/docker/grade.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 # Grade one run. env: BENCH_BASE_COMMIT, BENCH_FIX_COMMIT, BENCH_TEST_FILES, BENCH_TEST_COMMAND, BENCH_RETRIES
+#   BENCH_TEST_FILES = ALL test-side files from the fix PR (overlaid onto the workdir);
+#   BENCH_RUN_FILES  = runnable subset substituted into {test_files} (defaults to BENCH_TEST_FILES).
 # Local mode (tests/e2e): BENCH_BARE_DIR + BENCH_OUT_DIR override /bare and /out.
 # Modes via BENCH_GRADE_MODE: grade (default) | calibrate-base | calibrate-fix
 # exit: 0 tests-passed | 5 tests-passed-on-retry | 10 apply-failed | 20 tests-failed | 64 setup error
@@ -15,7 +17,7 @@ cd "$work" || exit 64
 
 # NOTE: word-splitting is load-bearing (multi-file lists); test paths must not contain spaces.
 run_tests() {
-  local cmd="${BENCH_TEST_COMMAND//\{test_files\}/$BENCH_TEST_FILES}"
+  local cmd="${BENCH_TEST_COMMAND//\{test_files\}/${BENCH_RUN_FILES:-$BENCH_TEST_FILES}}"
   bash -ec "$cmd"
 }
 

--- a/benchmark/harness/docker_args.js
+++ b/benchmark/harness/docker_args.js
@@ -26,6 +26,7 @@ export function gradeRunArgs(g) {
         "-e", `BENCH_BASE_COMMIT=${g.baseCommit}`,
         "-e", `BENCH_FIX_COMMIT=${g.fixCommit}`,
         "-e", `BENCH_TEST_FILES=${g.testFiles.join(" ")}`,
+        "-e", `BENCH_RUN_FILES=${(g.runFiles ?? g.testFiles).join(" ")}`,
         "-e", `BENCH_TEST_COMMAND=${g.testCommand}`,
         "-e", `BENCH_RETRIES=${g.retries}`,
         g.image, "grade",

--- a/benchmark/harness/docker_args.ts
+++ b/benchmark/harness/docker_args.ts
@@ -38,6 +38,8 @@ export interface GradeSpec {
   baseCommit: string;
   fixCommit: string;
   testFiles: string[];
+  /** Runnable subset substituted into {test_files}; defaults to testFiles. */
+  runFiles?: string[];
   testCommand: string;
   retries: number;
 }
@@ -50,6 +52,7 @@ export function gradeRunArgs(g: GradeSpec): string[] {
     "-e", `BENCH_BASE_COMMIT=${g.baseCommit}`,
     "-e", `BENCH_FIX_COMMIT=${g.fixCommit}`,
     "-e", `BENCH_TEST_FILES=${g.testFiles.join(" ")}`,
+    "-e", `BENCH_RUN_FILES=${(g.runFiles ?? g.testFiles).join(" ")}`,
     "-e", `BENCH_TEST_COMMAND=${g.testCommand}`,
     "-e", `BENCH_RETRIES=${g.retries}`,
     g.image, "grade",

--- a/benchmark/harness/grade.js
+++ b/benchmark/harness/grade.js
@@ -29,6 +29,7 @@ export async function gradeRunLocal(spec) {
             BENCH_BASE_COMMIT: spec.baseCommit,
             BENCH_FIX_COMMIT: spec.fixCommit,
             BENCH_TEST_FILES: spec.testFiles.join(" "),
+            BENCH_RUN_FILES: (spec.runFiles ?? spec.testFiles).join(" "),
             BENCH_TEST_COMMAND: spec.testCommand,
             BENCH_RETRIES: String(spec.retries),
             BENCH_GRADE_MODE: spec.mode ?? "grade",
@@ -45,7 +46,8 @@ export async function calibrateAll(cfg, ticketsPath, bareDir, opts) {
             continue;
         const common = {
             bareDir, outDir: bareDir, baseCommit: t.base_commit, fixCommit: t.fix_commit,
-            testFiles: t.test_files, testCommand: installPrefix + cfg.test_command, retries: 0, runner: opts.runner,
+            testFiles: t.test_files, runFiles: t.run_files ?? t.test_files,
+            testCommand: installPrefix + cfg.test_command, retries: 0, runner: opts.runner,
         };
         try {
             // paths_stable: every test_file exists at fix_commit (renamed/deleted test files excluded).
@@ -107,14 +109,16 @@ export async function gradeAll(cfg, ticketsPath, runsRoot, bareDir, opts) {
                 // Use the result directly — round-tripping through exit codes would lose the retry distinction.
                 graded = await gradeRunLocal({
                     bareDir, outDir, baseCommit: t.base_commit, fixCommit: t.fix_commit,
-                    testFiles: t.test_files, testCommand: installPrefix + cfg.test_command,
+                    testFiles: t.test_files, runFiles: t.run_files ?? t.test_files,
+                    testCommand: installPrefix + cfg.test_command,
                     retries: cfg.test_retries, runner: opts.runner,
                 });
             }
             else {
                 const r = await opts.runner("docker", gradeRunArgs({
                     image: opts.image, outDir, bareDir, baseCommit: t.base_commit, fixCommit: t.fix_commit,
-                    testFiles: t.test_files, testCommand: installPrefix + cfg.test_command, retries: cfg.test_retries,
+                    testFiles: t.test_files, runFiles: t.run_files ?? t.test_files,
+                    testCommand: installPrefix + cfg.test_command, retries: cfg.test_retries,
                 }));
                 graded = decideGrade(r.code);
             }

--- a/benchmark/harness/grade.ts
+++ b/benchmark/harness/grade.ts
@@ -25,6 +25,8 @@ export interface GradeLocalSpec {
   baseCommit: string;
   fixCommit: string;
   testFiles: string[];
+  /** Runnable subset substituted into {test_files}; defaults to testFiles (legacy records). */
+  runFiles?: string[];
   testCommand: string;
   retries: number;
   mode?: "grade" | "calibrate-base" | "calibrate-fix";
@@ -42,6 +44,7 @@ export async function gradeRunLocal(spec: GradeLocalSpec): Promise<Omit<GradeRec
       BENCH_BASE_COMMIT: spec.baseCommit,
       BENCH_FIX_COMMIT: spec.fixCommit,
       BENCH_TEST_FILES: spec.testFiles.join(" "),
+      BENCH_RUN_FILES: (spec.runFiles ?? spec.testFiles).join(" "),
       BENCH_TEST_COMMAND: spec.testCommand,
       BENCH_RETRIES: String(spec.retries),
       BENCH_GRADE_MODE: spec.mode ?? "grade",
@@ -58,7 +61,8 @@ export async function calibrateAll(cfg: RepoConfig, ticketsPath: string, bareDir
     if (t.calibration !== undefined || t.excluded !== undefined) continue;
     const common = {
       bareDir, outDir: bareDir, baseCommit: t.base_commit, fixCommit: t.fix_commit,
-      testFiles: t.test_files, testCommand: installPrefix + cfg.test_command, retries: 0, runner: opts.runner,
+      testFiles: t.test_files, runFiles: t.run_files ?? t.test_files,
+      testCommand: installPrefix + cfg.test_command, retries: 0, runner: opts.runner,
     };
     try {
       // paths_stable: every test_file exists at fix_commit (renamed/deleted test files excluded).
@@ -121,13 +125,15 @@ export async function gradeAll(cfg: RepoConfig, ticketsPath: string, runsRoot: s
         // Use the result directly — round-tripping through exit codes would lose the retry distinction.
         graded = await gradeRunLocal({
           bareDir, outDir, baseCommit: t.base_commit, fixCommit: t.fix_commit,
-          testFiles: t.test_files, testCommand: installPrefix + cfg.test_command,
+          testFiles: t.test_files, runFiles: t.run_files ?? t.test_files,
+          testCommand: installPrefix + cfg.test_command,
           retries: cfg.test_retries, runner: opts.runner,
         });
       } else {
         const r = await opts.runner("docker", gradeRunArgs({
           image: opts.image, outDir, bareDir, baseCommit: t.base_commit, fixCommit: t.fix_commit,
-          testFiles: t.test_files, testCommand: installPrefix + cfg.test_command, retries: cfg.test_retries,
+          testFiles: t.test_files, runFiles: t.run_files ?? t.test_files,
+          testCommand: installPrefix + cfg.test_command, retries: cfg.test_retries,
         }));
         graded = decideGrade(r.code);
       }

--- a/benchmark/harness/mine_filters.js
+++ b/benchmark/harness/mine_filters.js
@@ -27,5 +27,16 @@ export function checkEligibility(input, cfg) {
         return { ok: false, reason: "no-test-changes" };
     if (src.length === 0)
         return { ok: false, reason: "no-source-changes" };
-    return { ok: true, test_files: test, src_files: src, changed_lines: changed };
+    // Runnable subset: support files under test/ (configs, fixtures, utils) are overlaid at
+    // grade time but must not be handed to the test runner as entry points.
+    const runMatcher = ignore().add([...(cfg.run_patterns ?? cfg.test_patterns)]);
+    const run = test.filter((p) => runMatcher.ignores(p));
+    if (run.length === 0)
+        return { ok: false, reason: "no-runnable-tests" };
+    if (cfg.exclude_test_paths !== undefined && cfg.exclude_test_paths.length > 0) {
+        const excluded = ignore().add([...cfg.exclude_test_paths]);
+        if (run.some((p) => excluded.ignores(p)))
+            return { ok: false, reason: "excluded-test-paths" };
+    }
+    return { ok: true, test_files: test, src_files: src, run_files: run, changed_lines: changed };
 }

--- a/benchmark/harness/mine_filters.ts
+++ b/benchmark/harness/mine_filters.ts
@@ -34,11 +34,15 @@ export interface EligibilityInput {
 
 export interface EligibilityConfig {
   test_patterns: readonly string[];
+  /** Which test-side files are RUNNABLE (handed to the test command). Defaults to test_patterns. */
+  run_patterns?: readonly string[];
+  /** Tickets whose runnable tests touch these paths are excluded (e.g. browser-mode suites needing Playwright). */
+  exclude_test_paths?: readonly string[];
   ticket_after: string; // ISO date
 }
 
 export type Eligibility =
-  | { ok: true; test_files: string[]; src_files: string[]; changed_lines: number }
+  | { ok: true; test_files: string[]; src_files: string[]; run_files: string[]; changed_lines: number }
   | { ok: false; reason: string };
 
 export function checkEligibility(input: EligibilityInput, cfg: EligibilityConfig): Eligibility {
@@ -52,5 +56,14 @@ export function checkEligibility(input: EligibilityInput, cfg: EligibilityConfig
   const { test, src } = splitFiles(input.files, cfg.test_patterns);
   if (test.length === 0) return { ok: false, reason: "no-test-changes" };
   if (src.length === 0) return { ok: false, reason: "no-source-changes" };
-  return { ok: true, test_files: test, src_files: src, changed_lines: changed };
+  // Runnable subset: support files under test/ (configs, fixtures, utils) are overlaid at
+  // grade time but must not be handed to the test runner as entry points.
+  const runMatcher = ignore().add([...(cfg.run_patterns ?? cfg.test_patterns)]);
+  const run = test.filter((p) => runMatcher.ignores(p));
+  if (run.length === 0) return { ok: false, reason: "no-runnable-tests" };
+  if (cfg.exclude_test_paths !== undefined && cfg.exclude_test_paths.length > 0) {
+    const excluded = ignore().add([...cfg.exclude_test_paths]);
+    if (run.some((p) => excluded.ignores(p))) return { ok: false, reason: "excluded-test-paths" };
+  }
+  return { ok: true, test_files: test, src_files: src, run_files: run, changed_lines: changed };
 }

--- a/benchmark/harness/mine_tickets.js
+++ b/benchmark/harness/mine_tickets.js
@@ -83,6 +83,7 @@ export async function mineGithub(cfg, opts) {
             fix_commit: pr.mergeCommit.oid,
             test_files: verdict.test_files,
             src_files: verdict.src_files,
+            run_files: verdict.run_files,
             changed_lines: verdict.changed_lines,
             merge_parents: commit.parents.length,
             merged_at: pr.mergedAt,

--- a/benchmark/harness/mine_tickets.ts
+++ b/benchmark/harness/mine_tickets.ts
@@ -96,6 +96,7 @@ export async function mineGithub(cfg: RepoConfig, opts: MineOpts): Promise<Ticke
       fix_commit: pr.mergeCommit.oid,
       test_files: verdict.test_files,
       src_files: verdict.src_files,
+      run_files: verdict.run_files,
       changed_lines: verdict.changed_lines,
       merge_parents: commit.parents.length,
       merged_at: pr.mergedAt,

--- a/benchmark/harness/repo_config.js
+++ b/benchmark/harness/repo_config.js
@@ -46,6 +46,17 @@ export function loadRepoConfig(path) {
     if (!Number.isInteger(retries) || retries < 0) {
         throw new Error(`${path}: test_retries must be a non-negative integer`);
     }
+    const optionalPatternList = (key) => {
+        const v = cfg[key];
+        if (v === undefined)
+            return undefined;
+        if (!Array.isArray(v) || !v.every((e) => typeof e === "string")) {
+            throw new Error(`${path}: ${key} must be a list of strings`);
+        }
+        return v.map(String);
+    };
+    const runPatterns = optionalPatternList("run_patterns");
+    const excludeTestPaths = optionalPatternList("exclude_test_paths");
     return {
         id: String(cfg.id),
         github: String(cfg.github),
@@ -55,6 +66,8 @@ export function loadRepoConfig(path) {
         install: cfg.install.map(String),
         test_command: cfg.test_command,
         test_patterns: cfg.test_patterns.map(String),
+        run_patterns: runPatterns ?? cfg.test_patterns.map(String),
+        exclude_test_paths: excludeTestPaths ?? [],
         test_retries: retries,
         ticket_after: ticketAfter,
         wiki_commit: cfg.wiki_commit === undefined ? "" : String(cfg.wiki_commit),

--- a/benchmark/harness/repo_config.ts
+++ b/benchmark/harness/repo_config.ts
@@ -48,6 +48,17 @@ export function loadRepoConfig(path: string): RepoConfig {
     throw new Error(`${path}: test_retries must be a non-negative integer`);
   }
 
+  const optionalPatternList = (key: "run_patterns" | "exclude_test_paths"): string[] | undefined => {
+    const v = cfg[key];
+    if (v === undefined) return undefined;
+    if (!Array.isArray(v) || !v.every((e) => typeof e === "string")) {
+      throw new Error(`${path}: ${key} must be a list of strings`);
+    }
+    return v.map(String);
+  };
+  const runPatterns = optionalPatternList("run_patterns");
+  const excludeTestPaths = optionalPatternList("exclude_test_paths");
+
   return {
     id: String(cfg.id),
     github: String(cfg.github),
@@ -57,6 +68,8 @@ export function loadRepoConfig(path: string): RepoConfig {
     install: cfg.install.map(String),
     test_command: cfg.test_command,
     test_patterns: cfg.test_patterns.map(String),
+    run_patterns: runPatterns ?? cfg.test_patterns.map(String),
+    exclude_test_paths: excludeTestPaths ?? [],
     test_retries: retries,
     ticket_after: ticketAfter,
     wiki_commit: cfg.wiki_commit === undefined ? "" : String(cfg.wiki_commit),

--- a/benchmark/harness/tests/docker_args.test.ts
+++ b/benchmark/harness/tests/docker_args.test.ts
@@ -80,3 +80,14 @@ describe("docker argv builders", () => {
     expect(args).toContain("/o ut/dir:/out");
   });
 });
+
+describe("gradeRunArgs run files", () => {
+  it("emits BENCH_RUN_FILES (defaulting to testFiles when absent)", () => {
+    const base = {
+      image: "img", outDir: "/o", bareDir: "/b", baseCommit: "x", fixCommit: "y",
+      testFiles: ["test/a.test.ts", "test/helper.ts"], testCommand: "t {test_files}", retries: 0,
+    };
+    expect(gradeRunArgs({ ...base, runFiles: ["test/a.test.ts"] })).toContain("BENCH_RUN_FILES=test/a.test.ts");
+    expect(gradeRunArgs(base)).toContain("BENCH_RUN_FILES=test/a.test.ts test/helper.ts");
+  });
+});

--- a/benchmark/harness/tests/grade.test.ts
+++ b/benchmark/harness/tests/grade.test.ts
@@ -158,3 +158,39 @@ describe("calibrateAll (real git, no docker)", () => {
     });
   }, 20_000);
 });
+
+describe("run_files vs test_files separation", () => {
+  it("executes only the runnable subset while support files are still overlaid", async () => {
+    const src = mkdtempSync(join(tmpdir(), "benchrun-src-"));
+    const git = (...a: string[]): string => execFileSync("git", a, { cwd: src, encoding: "utf8" }).trim();
+    git("init", "-q", "-b", "main");
+    git("config", "user.email", "t@t"); git("config", "user.name", "t");
+    writeFileSync(join(src, "calc.js"), "module.exports = (a, b) => a - b;\n");
+    git("add", "-A"); git("commit", "-qm", "base");
+    const base = git("rev-parse", "HEAD");
+    writeFileSync(join(src, "calc.js"), "module.exports = (a, b) => a + b;\n");
+    mkdirSync(join(src, "test"), { recursive: true });
+    // Support file: crashes if ever executed as a test entry point; required by the real test.
+    writeFileSync(join(src, "test", "helper.js"),
+      "if (require.main === module) process.exit(1);\nmodule.exports = { expectFive: (v) => { if (v !== 5) process.exit(1); } };\n");
+    writeFileSync(join(src, "test", "calc.test.js"),
+      "const { expectFive } = require('./helper.js');\nconst c = require('../calc.js');\nexpectFive(c(2, 3));\n");
+    git("add", "-A"); git("commit", "-qm", "fix");
+    const fix = git("rev-parse", "HEAD");
+    const bare = `${mkdtempSync(join(tmpdir(), "benchrun-bare-"))}/repo.git`;
+    execFileSync("git", ["clone", "-q", "--bare", src, bare]);
+
+    const outDir = mkdtempSync(join(tmpdir(), "benchrun-out-"));
+    const goodDiff = execFileSync("git", ["diff", "--binary", base, fix, "--", "calc.js"], { cwd: bare, encoding: "utf8" });
+    writeFileSync(join(outDir, "diff.patch"), goodDiff);
+    const both = { bareDir: bare, outDir, baseCommit: base, fixCommit: fix, testCommand: String.raw`for f in {test_files}; do node "$f" || exit 1; done`, retries: 0 };
+
+    // With run_files scoped to the real test: passes (helper overlaid but not executed).
+    const scoped = await gradeRunLocal({ ...both, testFiles: ["test/calc.test.js", "test/helper.js"], runFiles: ["test/calc.test.js"] });
+    expect(scoped).toEqual({ outcome: "passed", detail: "tests-passed" });
+
+    // Legacy fallback (no runFiles): the helper is executed as an entry point and fails the run.
+    const legacy = await gradeRunLocal({ ...both, testFiles: ["test/calc.test.js", "test/helper.js"] });
+    expect(legacy).toEqual({ outcome: "failed", detail: "tests-failed" });
+  });
+});

--- a/benchmark/harness/tests/mine_filters.test.ts
+++ b/benchmark/harness/tests/mine_filters.test.ts
@@ -117,3 +117,23 @@ describe("runnable-test gates", () => {
     if (r.ok) expect(r.run_files).toEqual(r.test_files);
   });
 });
+
+describe("vitest pilot run_patterns shape", () => {
+  it("requires a workspace level: root-level test files are not runnable", () => {
+    const cfg = {
+      test_patterns: ["test/**"],
+      run_patterns: ["test/*/**/*.test.ts", "test/*/**/*.spec.ts"],
+      ticket_after: "2025-06-01",
+    };
+    const root = checkEligibility({ ...BASE, files: [
+      { path: "test/foo.test.ts", additions: 10, deletions: 0 },
+      { path: "src/x.ts", additions: 20, deletions: 0 },
+    ]}, cfg);
+    expect(root).toEqual({ ok: false, reason: "no-runnable-tests" });
+    const ws = checkEligibility({ ...BASE, files: [
+      { path: "test/e2e/test/feature.test.ts", additions: 10, deletions: 0 },
+      { path: "src/x.ts", additions: 20, deletions: 0 },
+    ]}, cfg);
+    expect(ws.ok).toBe(true);
+  });
+});

--- a/benchmark/harness/tests/mine_filters.test.ts
+++ b/benchmark/harness/tests/mine_filters.test.ts
@@ -73,3 +73,47 @@ describe("checkEligibility boundaries", () => {
     expect(r.ok).toBe(true);
   });
 });
+
+describe("runnable-test gates", () => {
+  const RUN_CFG = {
+    test_patterns: ["test/**", "**/*.test.ts"],
+    run_patterns: ["test/**/*.test.ts"],
+    exclude_test_paths: ["test/browser/**"],
+    ticket_after: "2025-06-01",
+  };
+
+  it("separates runnable tests from support files and returns run_files", () => {
+    const r = checkEligibility({ ...BASE, files: [
+      { path: "test/e2e/fixtures/x/vitest.config.ts", additions: 5, deletions: 0 },
+      { path: "test/e2e/test/feature.test.ts", additions: 10, deletions: 0 },
+      { path: "src/x.ts", additions: 20, deletions: 0 },
+    ]}, RUN_CFG);
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.run_files).toEqual(["test/e2e/test/feature.test.ts"]);
+      expect(r.test_files).toContain("test/e2e/fixtures/x/vitest.config.ts");
+    }
+  });
+
+  it("rejects tickets whose test-side changes have no runnable entry point", () => {
+    const r = checkEligibility({ ...BASE, files: [
+      { path: "test/test-utils/index.ts", additions: 5, deletions: 0 },
+      { path: "src/x.ts", additions: 20, deletions: 0 },
+    ]}, RUN_CFG);
+    expect(r).toEqual({ ok: false, reason: "no-runnable-tests" });
+  });
+
+  it("rejects tickets whose runnable tests live under excluded paths", () => {
+    const r = checkEligibility({ ...BASE, files: [
+      { path: "test/browser/specs/locator.test.ts", additions: 10, deletions: 0 },
+      { path: "src/x.ts", additions: 20, deletions: 0 },
+    ]}, RUN_CFG);
+    expect(r).toEqual({ ok: false, reason: "excluded-test-paths" });
+  });
+
+  it("defaults run_patterns to test_patterns (legacy behavior preserved)", () => {
+    const r = checkEligibility(BASE, CFG);
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.run_files).toEqual(r.test_files);
+  });
+});

--- a/benchmark/harness/tests/repo_config.test.ts
+++ b/benchmark/harness/tests/repo_config.test.ts
@@ -60,3 +60,18 @@ describe("loadRepoConfig", () => {
     expect(() => loadRepoConfig(writeCfg(VALID + 'test_retries: "abc"\n'))).toThrow(/test_retries/);
   });
 });
+
+describe("runnable-test config fields", () => {
+  it("defaults run_patterns to test_patterns and exclude_test_paths to []", () => {
+    const cfg = loadRepoConfig(writeCfg(VALID));
+    expect(cfg.run_patterns).toEqual(cfg.test_patterns);
+    expect(cfg.exclude_test_paths).toEqual([]);
+  });
+
+  it("accepts explicit lists and rejects non-string entries", () => {
+    const cfg = loadRepoConfig(writeCfg(`${VALID}run_patterns: ["**/*.test.ts"]\nexclude_test_paths: ["test/browser/**"]\n`));
+    expect(cfg.run_patterns).toEqual(["**/*.test.ts"]);
+    expect(cfg.exclude_test_paths).toEqual(["test/browser/**"]);
+    expect(() => loadRepoConfig(writeCfg(`${VALID}run_patterns: [{a: 1}]\n`))).toThrow(/run_patterns/);
+  });
+});

--- a/benchmark/harness/types.ts
+++ b/benchmark/harness/types.ts
@@ -18,8 +18,10 @@ export interface RepoConfig {
   language: string;
   ticket_source: "github" | "trac-commits";
   install: string[];
-  test_command: string; // must contain "{test_files}"
+  test_command: string; // must contain "{test_files}" (substituted with the RUNNABLE files)
   test_patterns: string[];
+  run_patterns: string[]; // runnable-test subset of test_patterns; defaults to test_patterns
+  exclude_test_paths: string[]; // tickets whose runnable tests touch these paths are excluded at mining
   test_retries: number;
   ticket_after: string; // ISO date floor (training-data contamination control)
   wiki_commit: string; // "" until the wiki is built
@@ -43,8 +45,9 @@ export interface TicketRecord {
   fix_pr_url: string;
   base_commit: string; // fix PR parent — what the agent gets
   fix_commit: string; // fix PR merge commit
-  test_files: string[];
+  test_files: string[]; // all test-side files from the fix PR — overlaid at grade time
   src_files: string[];
+  run_files?: string[]; // runnable subset of test_files handed to the test command; absent in legacy records (fall back to test_files)
   changed_lines: number;
   merge_parents?: number; // parents of the merge commit; >1 = true merge, base_commit may predate the PR
   merged_at: string; // ISO timestamp, published for contamination audit

--- a/benchmark/repos/vitest.yaml
+++ b/benchmark/repos/vitest.yaml
@@ -7,15 +7,27 @@ install:
   - "corepack enable"
   - "pnpm install --frozen-lockfile"
   - "pnpm run build"
-test_command: "pnpm vitest run {test_files}"
+# vitest's test/<dir> entries are standalone workspace packages; running files from the
+# repo root resolves the wrong config (verified: 1/13 fails at root, 13/13 passes in-workspace).
+test_command: |
+  for ws in $(printf '%s\n' {test_files} | cut -d/ -f1-2 | sort -u); do
+    files=$(printf '%s\n' {test_files} | grep "^$ws/" | sed "s|^$ws/||" | tr '\n' ' ')
+    (cd "$ws" && pnpm vitest run $files) || exit 1
+  done
 test_patterns:
   - "test/**"
   - "**/*.test.ts"
   - "**/*.spec.ts"
   - "**/__tests__/**"
+run_patterns: # runnable entry points only — configs/fixtures/utils under test/ are overlaid but never executed directly
+  - "test/**/*.test.ts"
+  - "test/**/*.spec.ts"
+exclude_test_paths: # suites needing Playwright browsers — not installed in the grade container
+  - "test/browser/**"
+  - "test/ui/**"
 test_retries: 1
 ticket_after: "2025-06-01"
-wiki_commit: ""
+wiki_commit: "32bb9037caae50cb8d0b02f9dd472d655d88ad65" # parent of the octopus merge-base of all 30 mined base_commits (2026-04-27)
 toolchain:
   - "node:22"
 services: []

--- a/benchmark/repos/vitest.yaml
+++ b/benchmark/repos/vitest.yaml
@@ -19,9 +19,11 @@ test_patterns:
   - "**/*.test.ts"
   - "**/*.spec.ts"
   - "**/__tests__/**"
-run_patterns: # runnable entry points only — configs/fixtures/utils under test/ are overlaid but never executed directly
-  - "test/**/*.test.ts"
-  - "test/**/*.spec.ts"
+run_patterns: # runnable entry points only — configs/fixtures/utils under test/ are overlaid but never executed directly.
+  # Requires at least one workspace level (test/<dir>/...): the test_command cd's into the
+  # workspace, so a hypothetical root-level test/foo.test.ts must not be eligible.
+  - "test/*/**/*.test.ts"
+  - "test/*/**/*.spec.ts"
 exclude_test_paths: # suites needing Playwright browsers — not installed in the grade container
   - "test/browser/**"
   - "test/ui/**"


### PR DESCRIPTION
## What

First live calibration sweep of the vitest pilot failed systematically (all tickets `failsOnBase=true passesOnFix=false`). Three root causes, each verified empirically against the real repo:

1. **Support files executed as tests.** `{test_files}` included configs/fixtures/utils under `test/` (the `test/**` overlay pattern matches everything). New per-repo `run_patterns` defines the runnable subset, recorded per ticket as `run_files`; support files are still overlaid at grade time but never executed. Tickets with no runnable entry point are now ineligible.
2. **Wrong config context.** vitest's `test/<dir>` entries are standalone workspace packages — running test files from the repo root resolves the wrong vitest config (verified: 1/13 fails at root, 13/13 passes in-workspace). `vitest.yaml`'s `test_command` is now a per-workspace loop (pure config; no harness special-casing).
3. **Playwright suites.** `test/browser/**` and `test/ui/**` need browsers absent from the grade container. New per-repo `exclude_test_paths` drops those tickets at mining with an attributable reason (8 browser + 2 ui of the 30 mined).

Also pins the pilot's `wiki_commit` (parent of the octopus merge-base of all 30 mined base commits, ancestor-verified against every base) and documents the new gates in METHODOLOGY.md.

## Verification
- 99 benchmark tests green (8 new: runnable/exclusion gates, config defaults + validation, run-vs-overlay separation on real git, docker argv)
- Full suite 1670 passed / 20 skipped; typecheck + build clean; shellcheck clean
- Root-vs-workspace behavior verified on ticket #10326's fix commit