### PR TITLE
fix(benchmark): run container as non-root node user

### DIFF
--- a/benchmark/harness/docker/Dockerfile
+++ b/benchmark/harness/docker/Dockerfile
@@ -4,10 +4,17 @@ FROM ${TOOLCHAIN}
 ARG CLAUDE_CODE_VERSION=2.1.170
 ENV DISABLE_AUTOUPDATER=1 \
     CLAUDE_CONFIG_DIR=/claude-cfg
-RUN apt-get update && apt-get install -y --no-install-recommends git iptables dnsutils ca-certificates bash \
+RUN apt-get update && apt-get install -y --no-install-recommends git iptables dnsutils ca-certificates bash sudo \
     && rm -rf /var/lib/apt/lists/* \
     && npm install -g @anthropic-ai/claude-code@${CLAUDE_CODE_VERSION} \
-    && mkdir -p /claude-cfg /out /work
+    && mkdir -p /claude-cfg /out /work \
+    # Claude Code refuses --dangerously-skip-permissions as root; run as the image's
+    # non-root user (Anthropic devcontainer pattern). The firewall still needs root —
+    # grant a single NOPASSWD sudo rule scoped to that one script.
+    && chown -R node:node /claude-cfg /out /work \
+    && echo "node ALL=(root) NOPASSWD: /usr/local/bin/init-firewall.sh" > /etc/sudoers.d/bench-firewall \
+    && chmod 440 /etc/sudoers.d/bench-firewall
 COPY entrypoint.sh grade.sh init-firewall.sh /usr/local/bin/
 RUN chmod +x /usr/local/bin/entrypoint.sh /usr/local/bin/grade.sh /usr/local/bin/init-firewall.sh
+USER node
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/benchmark/harness/docker/entrypoint.sh
+++ b/benchmark/harness/docker/entrypoint.sh
@@ -5,6 +5,11 @@
 # mounts:     /bare (ro bare clone), /out (rw artifacts), /wiki (ro overlay, wiki arm only)
 set -uo pipefail
 
+# The bind-mounted /bare is owned by the host user, not the container's node user;
+# git's dubious-ownership guard would otherwise refuse to clone it. The container is
+# ephemeral and single-purpose, so trusting all paths is safe.
+git config --global --add safe.directory '*'
+
 mode="${1:?usage: entrypoint.sh session|grade|wiki-build}"
 if [ "$mode" = "grade" ]; then
   exec /usr/local/bin/grade.sh

--- a/benchmark/harness/docker/entrypoint.sh
+++ b/benchmark/harness/docker/entrypoint.sh
@@ -48,7 +48,7 @@ if [ -d /wiki ]; then
 fi
 
 # From here on: Anthropic-only egress. The session cannot look up the real fix.
-[ "${BENCH_SKIP_FIREWALL:-0}" = "1" ] || /usr/local/bin/init-firewall.sh
+[ "${BENCH_SKIP_FIREWALL:-0}" = "1" ] || sudo /usr/local/bin/init-firewall.sh # entrypoint runs as non-root; iptables needs root (scoped NOPASSWD rule)
 
 set +e
 claude -p "$(cat /out/prompt.txt)" \


### PR DESCRIPTION
Pilot finding: Claude Code refuses `--dangerously-skip-permissions` under root, so every session mode failed at container launch (`init.err`: "cannot be used with root/sudo privileges"). The node base image defaults to root; Anthropic's devcontainer reference runs as a non-root user — which our own Task-8 security review even quoted, without noticing the Dockerfile never did it.

Fix mirrors the reference pattern: `USER node`, dirs chowned, and a single NOPASSWD sudo rule scoped to `init-firewall.sh` (iptables needs root); the entrypoint invokes the firewall via `sudo`.

Verified on the rebuilt image: `whoami` = node; a `--dangerously-skip-permissions` session authenticates and completes on subscription auth; `sudo init-firewall.sh` locks egress to the Anthropic allowlist. `bash -n` + shellcheck clean.