### PR TITLE
fix(benchmark): enable corepack in image (non-root install)

### DIFF
--- a/benchmark/harness/docker/Dockerfile
+++ b/benchmark/harness/docker/Dockerfile
@@ -7,6 +7,11 @@ ENV DISABLE_AUTOUPDATER=1 \
 RUN apt-get update && apt-get install -y --no-install-recommends git iptables dnsutils ca-certificates bash sudo \
     && rm -rf /var/lib/apt/lists/* \
     && npm install -g @anthropic-ai/claude-code@${CLAUDE_CODE_VERSION} \
+    # Enable corepack now (as root): the pnpm/yarn shims live in the root-owned global
+    # prefix, so the non-root session user cannot run `corepack enable` itself. Per-run
+    # installs just call `pnpm`; corepack auto-provisions the packageManager-pinned version
+    # into COREPACK_HOME (node-writable) on first use, before the egress firewall comes up.
+    && corepack enable \
     && mkdir -p /claude-cfg /out /work \
     # Claude Code refuses --dangerously-skip-permissions as root; run as the image's
     # non-root user (Anthropic devcontainer pattern). The firewall still needs root —

--- a/benchmark/repos/vitest.yaml
+++ b/benchmark/repos/vitest.yaml
@@ -3,8 +3,7 @@ github: vitest-dev/vitest
 clone_url: https://github.com/vitest-dev/vitest.git
 language: typescript
 ticket_source: github
-install:
-  - "corepack enable"
+install: # corepack is enabled in the image (root); the non-root session user can't run `corepack enable`.
   - "pnpm install --frozen-lockfile"
   - "pnpm run build"
 # vitest's test/<dir> entries are standalone workspace packages; running files from the


### PR DESCRIPTION
Third and final container fix from the pilot's first session run.

`corepack enable` symlinks pnpm/yarn shims into the root-owned global node prefix (`/usr/local/bin`), so the non-root `node` session user can't run it — `corepack enable` was the first line of vitest's install, and it died under `set -e` before any agent session started (both arms errored in ~45s with no result envelope).

Fix: `corepack enable` at image-build time (as root). The per-run install just calls `pnpm`; corepack auto-provisions the `packageManager`-pinned version (11.1.2 for vitest) into node's writable cache on first use, while egress is still open (install runs before the firewall).

Verified end-to-end in the rebuilt image as `node`: corepack downloads pnpm 11.1.2, `pnpm install --frozen-lockfile` OK, `pnpm run build` OK. Full repo suite green.