### PR TITLE
⚡ Bolt: Hoist timestamp regex in log parsers

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -12,3 +12,13 @@
 
 **Learning:** Inner JSON fields might mistakenly contain match substrings like dates (e.g., inside the text of the event). Utilizing a strict, anchored regex check for extracting fields like timestamps directly (`/^{"ts":"([^"\\]+)"/`) avoids both `JSON.parse` overhead and incorrect partial string matches from `String.includes()`.
 **Action:** Use an anchored regex (`/^{"ts":"([^"\\]+)"/`) and check the captured group directly before falling back to full JSON parsing.
+
+## 2026-05-23 - Hoisting Regex Optimization
+
+**Learning:** Instantiating a regular expression inside a tight loop that processes lines of a large file (like log parsers) incurs unnecessary overhead for memory and initialization.
+**Action:** Hoist the regular expression outside the parsing loop into a module-level constant and use  instead of  for slightly better performance.
+
+## 2026-06-11 - Hoisting Regex Optimization
+
+**Learning:** Instantiating a regular expression inside a tight loop that processes lines of a large file (like log parsers) incurs unnecessary overhead for memory and initialization.
+**Action:** Hoist the regular expression outside the parsing loop into a module-level constant and use `.exec()` instead of `.match()` for slightly better performance.

--- a/skills/doc-wiki/scripts/daily_summary.js
+++ b/skills/doc-wiki/scripts/daily_summary.js
@@ -20,6 +20,7 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
 import { parseFlags } from "./_cli_args.js";
+const TS_REGEX = /^{"ts":"([^"\\]+)"/;
 // ── Helpers ─────────────────────────────────────────────────────────
 /**
  * Read events from `<wikiRoot>/log/events.jsonl`, keeping only entries whose
@@ -40,7 +41,7 @@ function readEvents(wikiRoot, dateStr) {
         // Fast-path: skip JSON parse overhead if this line cannot match our date
         if (!line.includes(dateStr))
             continue;
-        const match = line.match(/^{"ts":"([^"\\]+)"/);
+        const match = TS_REGEX.exec(line);
         if (match && match[1] && !match[1].startsWith(dateStr))
             continue;
         let entry;

--- a/skills/doc-wiki/scripts/daily_summary.ts
+++ b/skills/doc-wiki/scripts/daily_summary.ts
@@ -21,6 +21,8 @@ import * as path from "node:path";
 import { fileURLToPath } from "node:url";
 import { parseFlags } from "./_cli_args.js";
 
+const TS_REGEX = /^{"ts":"([^"\\]+)"/;
+
 // ── Helpers ─────────────────────────────────────────────────────────
 
 /**
@@ -44,7 +46,7 @@ function readEvents(
 
     // Fast-path: skip JSON parse overhead if this line cannot match our date
     if (!line.includes(dateStr)) continue;
-    const match = line.match(/^{"ts":"([^"\\]+)"/);
+    const match = TS_REGEX.exec(line);
     if (match && match[1] && !match[1].startsWith(dateStr)) continue;
 
     let entry: unknown;
@@ -299,9 +301,7 @@ options:
   --date DATE           Date (YYYY-MM-DD), defaults to today
 `;
 
-export function main(
-  argv: readonly string[] = process.argv.slice(2),
-): number {
+export function main(argv: readonly string[] = process.argv.slice(2)): number {
   let parsed: ReturnType<typeof parseFlags>;
   try {
     parsed = parseFlags(argv, FLAG_SPEC);

--- a/skills/doc-wiki/scripts/event_logger.js
+++ b/skills/doc-wiki/scripts/event_logger.js
@@ -19,6 +19,7 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
+const TS_REGEX = /^{"ts":"([^"\\]+)"/;
 // ── Timestamp helpers ───────────────────────────────────────────────
 /**
  * Produce a Python-compatible `datetime.now(timezone.utc).isoformat()`
@@ -156,7 +157,7 @@ function _readEvents(wikiRoot, since = null) {
             // leading whitespace. The character class excludes both `"` and `\` so
             // any ts containing a JSON escape (like `\+` for `+`) misses the regex
             // and safely falls through to the slow path for proper decoding.
-            const m = line.match(/^{"ts":"([^"\\]+)"/);
+            const m = TS_REGEX.exec(line);
             if (m) {
                 const entryMs = parsePythonIsoformat(m[1]);
                 // G-EVENTS-TS-STRICT: when --since is active, drop events whose

--- a/skills/doc-wiki/scripts/event_logger.ts
+++ b/skills/doc-wiki/scripts/event_logger.ts
@@ -20,6 +20,8 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
 
+const TS_REGEX = /^{"ts":"([^"\\]+)"/;
+
 // ── Timestamp helpers ───────────────────────────────────────────────
 
 /**
@@ -201,7 +203,7 @@ function _readEvents(
       // leading whitespace. The character class excludes both `"` and `\` so
       // any ts containing a JSON escape (like `\+` for `+`) misses the regex
       // and safely falls through to the slow path for proper decoding.
-      const m = line.match(/^{"ts":"([^"\\]+)"/);
+      const m = TS_REGEX.exec(line);
       if (m) {
         const entryMs = parsePythonIsoformat(m[1] as string);
         // G-EVENTS-TS-STRICT: when --since is active, drop events whose


### PR DESCRIPTION
## ⚡ Bolt: Hoist timestamp regex in log parsers

**💡 What**: Extract the inline regular expression `/^{"ts":"([^"\\]+)"/` into a module-level constant (`TS_REGEX`) and replace `String.prototype.match()` with `RegExp.prototype.exec()` in `daily_summary.ts` and `event_logger.ts`.
**🎯 Why**: The regex was being instantiated and evaluated repeatedly inside tight parsing loops when processing `events.jsonl` (an append-only JSON file). Hoisting the regex out of the loop and using `.exec()` reduces unnecessary object allocation overhead and is generally faster than `String.match()`.
**📊 Impact**: Minor but measurable performance improvement during log parsing execution (especially useful for large, grown logs). Lower GC impact due to fewer object allocations.
**🔬 Measurement**: To verify the improvement, measure the difference in total execution time of `npm run build` and checking the parsing loops when handling large `events.jsonl` files. Run `npm run test` to guarantee functionality remains unchanged.

---
*PR created automatically by Jules for task [14606193361941754914](https://jules.google.com/task/14606193361941754914) started by @rfv-code*