### PR TITLE
fix(atlas): never emit empty cross-service scaffolding pages

### DIFF
--- a/agents/lib/cross_service_pages.js
+++ b/agents/lib/cross_service_pages.js
@@ -672,17 +672,29 @@ export function writeCrossServicePages(wikiRoot, inventory, graph) {
         { slug: "database-traces", title: "Database Traces", hasContent: hasDbTraces(inventory), render: () => renderDbTraces(inventory) },
         { slug: "shared-libraries", title: "Shared Libraries", hasContent: hasSharedLibraries(graph), render: () => renderSharedLibraryMatrix(graph, inventory) },
     ];
-    const pagesWithContent = pages.filter((pg) => pg.hasContent);
-    if (pagesWithContent.length === 0) {
-        process.stderr.write("[cross_service_pages] no cross-service structure detected; skipping all six pages\n");
-        return [];
-    }
-    fs.mkdirSync(outDir, { recursive: true });
+    // Write pages that have real content; DELETE any stale page a prior run left behind
+    // (e.g. a refresh where the graph no longer has queue edges must remove the old
+    // queue-registry.md, never leave outdated cross-service data exposed in the wiki).
+    if (pages.some((pg) => pg.hasContent))
+        fs.mkdirSync(outDir, { recursive: true });
     const written = [];
-    for (const pg of pagesWithContent) {
+    const removed = [];
+    for (const pg of pages) {
         const target = path.join(outDir, `${pg.slug}.md`);
-        fs.writeFileSync(target, _withFrontmatter(pg.title, pg.render(), evidence, inventory.atlas_run_id, pg.slug));
-        written.push(target);
+        if (pg.hasContent) {
+            fs.writeFileSync(target, _withFrontmatter(pg.title, pg.render(), evidence, inventory.atlas_run_id, pg.slug));
+            written.push(target);
+        }
+        else if (fs.existsSync(target)) {
+            fs.rmSync(target);
+            removed.push(target);
+        }
+    }
+    if (written.length === 0) {
+        process.stderr.write("[cross_service_pages] no cross-service structure detected; no pages written\n");
+    }
+    if (removed.length > 0) {
+        process.stderr.write(`[cross_service_pages] removed ${removed.length} stale page(s): ${removed.map((p) => path.basename(p)).join(", ")}\n`);
     }
     return written;
 }

--- a/agents/lib/cross_service_pages.js
+++ b/agents/lib/cross_service_pages.js
@@ -570,12 +570,19 @@ export function renderServiceDependencies(graph, inventory) {
 // ── Content predicates ──────────────────────────────────────────────
 /**
  * Returns true when there is enough data to emit a meaningful service-map or
- * service-dependencies page (≥1 calls edge between two real, non-synthetic
- * services OR ≥2 real services in the graph).
+ * service-dependencies page: either ≥2 real (non-synthetic) services in the
+ * graph, OR ≥1 calls edge between two real services. A service map listing
+ * two or more real services is true information worth emitting even before any
+ * call edges are detected.
  */
 export function hasServiceTopology(graph) {
     const serviceIds = new Set(graph.services.map((s) => s.id));
-    // At least one direct calls edge between two real services is sufficient.
+    // ≥2 real (non-synthetic) services is enough — the service list alone is
+    // genuine, true information.
+    const realServiceCount = graph.services.filter((s) => !isSynthetic(s.id)).length;
+    if (realServiceCount >= 2)
+        return true;
+    // Otherwise require at least one direct calls edge between two real services.
     return graph.edges.some((e) => e.kind === "calls" &&
         serviceIds.has(e.from_service) &&
         serviceIds.has(e.to_service) &&

--- a/agents/lib/cross_service_pages.js
+++ b/agents/lib/cross_service_pages.js
@@ -567,6 +567,61 @@ export function renderServiceDependencies(graph, inventory) {
         extCrossLink,
     ].join("\n");
 }
+// ── Content predicates ──────────────────────────────────────────────
+/**
+ * Returns true when there is enough data to emit a meaningful service-map or
+ * service-dependencies page (≥1 calls edge between two real, non-synthetic
+ * services OR ≥2 real services in the graph).
+ */
+export function hasServiceTopology(graph) {
+    const serviceIds = new Set(graph.services.map((s) => s.id));
+    // At least one direct calls edge between two real services is sufficient.
+    return graph.edges.some((e) => e.kind === "calls" &&
+        serviceIds.has(e.from_service) &&
+        serviceIds.has(e.to_service) &&
+        !isSynthetic(e.from_service) &&
+        !isSynthetic(e.to_service));
+}
+/**
+ * Returns true when the inventory has ≥1 HTTP client callsite across any
+ * service — i.e. there is something substantive to show in client-registry.
+ */
+export function hasClientData(graph) {
+    return graph.edges.some((e) => e.kind === "calls" &&
+        !isSynthetic(e.from_service) &&
+        !isSynthetic(e.to_service));
+}
+/**
+ * Returns true when there is ≥1 produces or consumes edge involving a
+ * `queue:` synthetic node — i.e. there are actual queues to register.
+ */
+export function hasQueueData(graph) {
+    return graph.edges.some((e) => (e.kind === "produces" && e.to_service.startsWith("queue:")) ||
+        (e.kind === "consumes" && e.from_service.startsWith("queue:")));
+}
+/**
+ * Returns true when ≥1 service in the inventory has ORM entities — i.e.
+ * there are DB traces worth documenting.
+ */
+export function hasDbTraces(inventory) {
+    return (inventory.services ?? []).some((svc) => (svc.orm_entities ?? []).length > 0);
+}
+/**
+ * Returns true when ≥1 library node in the graph has `depends_on` edges
+ * from two or more different (non-synthetic) services — i.e. there are
+ * genuinely *shared* libraries.
+ */
+export function hasSharedLibraries(graph) {
+    const consumersPerLib = new Map();
+    for (const e of graph.edges) {
+        if (e.kind !== "depends_on" || isSynthetic(e.from_service))
+            continue;
+        const set = consumersPerLib.get(e.to_service) ?? new Set();
+        set.add(e.from_service);
+        consumersPerLib.set(e.to_service, set);
+    }
+    return [...consumersPerLib.values()].some((consumers) => consumers.size >= 2);
+}
 /**
  * Wrap a rendered body with atlas YAML frontmatter.
  * `atlas_facet: architecture` → default `audience: contributor` (compilation.md table).
@@ -591,28 +646,40 @@ function _withFrontmatter(title, body, sources, atlasRunId, slug) {
     return fm + body.trimStart() + "\n";
 }
 /**
- * Render + write all six cross-service pages under `<wikiRoot>/wiki/`.
- * Returns the absolute paths written (deterministic order).
+ * Render + write cross-service pages under `<wikiRoot>/wiki/`.
+ * Only pages with substantive content are emitted — pages whose predicate
+ * returns false are silently skipped (no file written, not included in the
+ * returned array). Returns the absolute paths actually written, in
+ * deterministic order.
+ *
+ * When no page has content (e.g. a plain monorepo with no cross-service
+ * structure), the returned array is empty and nothing is written to disk.
  */
 export function writeCrossServicePages(wikiRoot, inventory, graph) {
     const outDir = path.join(wikiRoot, "wiki");
-    fs.mkdirSync(outDir, { recursive: true });
     // Collect unique evidence files from the graph edges as source provenance.
     const evidence = [
         ...new Set(graph.edges
             .map((e) => e.evidence_file ?? "")
             .filter((f) => f.length > 0)),
     ].sort();
+    const serviceTopology = hasServiceTopology(graph);
     const pages = [
-        { slug: "service-map", title: "Service Map", render: () => renderServiceMap(graph, inventory) },
-        { slug: "service-dependencies", title: "Service Dependencies", render: () => renderServiceDependencies(graph, inventory) },
-        { slug: "client-registry", title: "Service Client Registry", render: () => renderClientRegistry(graph, inventory) },
-        { slug: "queue-registry", title: "Message Queue Registry", render: () => renderQueueRegistry(graph, inventory) },
-        { slug: "database-traces", title: "Database Traces", render: () => renderDbTraces(inventory) },
-        { slug: "shared-libraries", title: "Shared Libraries", render: () => renderSharedLibraryMatrix(graph, inventory) },
+        { slug: "service-map", title: "Service Map", hasContent: serviceTopology, render: () => renderServiceMap(graph, inventory) },
+        { slug: "service-dependencies", title: "Service Dependencies", hasContent: serviceTopology, render: () => renderServiceDependencies(graph, inventory) },
+        { slug: "client-registry", title: "Service Client Registry", hasContent: hasClientData(graph), render: () => renderClientRegistry(graph, inventory) },
+        { slug: "queue-registry", title: "Message Queue Registry", hasContent: hasQueueData(graph), render: () => renderQueueRegistry(graph, inventory) },
+        { slug: "database-traces", title: "Database Traces", hasContent: hasDbTraces(inventory), render: () => renderDbTraces(inventory) },
+        { slug: "shared-libraries", title: "Shared Libraries", hasContent: hasSharedLibraries(graph), render: () => renderSharedLibraryMatrix(graph, inventory) },
     ];
+    const pagesWithContent = pages.filter((pg) => pg.hasContent);
+    if (pagesWithContent.length === 0) {
+        process.stderr.write("[cross_service_pages] no cross-service structure detected; skipping all six pages\n");
+        return [];
+    }
+    fs.mkdirSync(outDir, { recursive: true });
     const written = [];
-    for (const pg of pages) {
+    for (const pg of pagesWithContent) {
         const target = path.join(outDir, `${pg.slug}.md`);
         fs.writeFileSync(target, _withFrontmatter(pg.title, pg.render(), evidence, inventory.atlas_run_id, pg.slug));
         written.push(target);

--- a/agents/lib/cross_service_pages.ts
+++ b/agents/lib/cross_service_pages.ts
@@ -853,21 +853,30 @@ export function writeCrossServicePages(
     { slug: "shared-libraries",     title: "Shared Libraries",        hasContent: hasSharedLibraries(graph), render: () => renderSharedLibraryMatrix(graph, inventory) },
   ];
 
-  const pagesWithContent = pages.filter((pg) => pg.hasContent);
-  if (pagesWithContent.length === 0) {
-    process.stderr.write(
-      "[cross_service_pages] no cross-service structure detected; skipping all six pages\n",
-    );
-    return [];
-  }
-
-  fs.mkdirSync(outDir, { recursive: true });
+  // Write pages that have real content; DELETE any stale page a prior run left behind
+  // (e.g. a refresh where the graph no longer has queue edges must remove the old
+  // queue-registry.md, never leave outdated cross-service data exposed in the wiki).
+  if (pages.some((pg) => pg.hasContent)) fs.mkdirSync(outDir, { recursive: true });
 
   const written: string[] = [];
-  for (const pg of pagesWithContent) {
+  const removed: string[] = [];
+  for (const pg of pages) {
     const target = path.join(outDir, `${pg.slug}.md`);
-    fs.writeFileSync(target, _withFrontmatter(pg.title, pg.render(), evidence, inventory.atlas_run_id, pg.slug));
-    written.push(target);
+    if (pg.hasContent) {
+      fs.writeFileSync(target, _withFrontmatter(pg.title, pg.render(), evidence, inventory.atlas_run_id, pg.slug));
+      written.push(target);
+    } else if (fs.existsSync(target)) {
+      fs.rmSync(target);
+      removed.push(target);
+    }
+  }
+  if (written.length === 0) {
+    process.stderr.write("[cross_service_pages] no cross-service structure detected; no pages written\n");
+  }
+  if (removed.length > 0) {
+    process.stderr.write(
+      `[cross_service_pages] removed ${removed.length} stale page(s): ${removed.map((p) => path.basename(p)).join(", ")}\n`,
+    );
   }
   return written;
 }

--- a/agents/lib/cross_service_pages.ts
+++ b/agents/lib/cross_service_pages.ts
@@ -709,12 +709,20 @@ export function renderServiceDependencies(
 
 /**
  * Returns true when there is enough data to emit a meaningful service-map or
- * service-dependencies page (≥1 calls edge between two real, non-synthetic
- * services OR ≥2 real services in the graph).
+ * service-dependencies page: either ≥2 real (non-synthetic) services in the
+ * graph, OR ≥1 calls edge between two real services. A service map listing
+ * two or more real services is true information worth emitting even before any
+ * call edges are detected.
  */
 export function hasServiceTopology(graph: ServiceGraph): boolean {
   const serviceIds = new Set(graph.services.map((s) => s.id));
-  // At least one direct calls edge between two real services is sufficient.
+
+  // ≥2 real (non-synthetic) services is enough — the service list alone is
+  // genuine, true information.
+  const realServiceCount = graph.services.filter((s) => !isSynthetic(s.id)).length;
+  if (realServiceCount >= 2) return true;
+
+  // Otherwise require at least one direct calls edge between two real services.
   return graph.edges.some(
     (e) =>
       e.kind === "calls" &&

--- a/agents/lib/cross_service_pages.ts
+++ b/agents/lib/cross_service_pages.ts
@@ -705,11 +705,83 @@ export function renderServiceDependencies(
   ].join("\n");
 }
 
+// ── Content predicates ──────────────────────────────────────────────
+
+/**
+ * Returns true when there is enough data to emit a meaningful service-map or
+ * service-dependencies page (≥1 calls edge between two real, non-synthetic
+ * services OR ≥2 real services in the graph).
+ */
+export function hasServiceTopology(graph: ServiceGraph): boolean {
+  const serviceIds = new Set(graph.services.map((s) => s.id));
+  // At least one direct calls edge between two real services is sufficient.
+  return graph.edges.some(
+    (e) =>
+      e.kind === "calls" &&
+      serviceIds.has(e.from_service) &&
+      serviceIds.has(e.to_service) &&
+      !isSynthetic(e.from_service) &&
+      !isSynthetic(e.to_service),
+  );
+}
+
+/**
+ * Returns true when the inventory has ≥1 HTTP client callsite across any
+ * service — i.e. there is something substantive to show in client-registry.
+ */
+export function hasClientData(graph: ServiceGraph): boolean {
+  return graph.edges.some(
+    (e) =>
+      e.kind === "calls" &&
+      !isSynthetic(e.from_service) &&
+      !isSynthetic(e.to_service),
+  );
+}
+
+/**
+ * Returns true when there is ≥1 produces or consumes edge involving a
+ * `queue:` synthetic node — i.e. there are actual queues to register.
+ */
+export function hasQueueData(graph: ServiceGraph): boolean {
+  return graph.edges.some(
+    (e) =>
+      (e.kind === "produces" && e.to_service.startsWith("queue:")) ||
+      (e.kind === "consumes" && e.from_service.startsWith("queue:")),
+  );
+}
+
+/**
+ * Returns true when ≥1 service in the inventory has ORM entities — i.e.
+ * there are DB traces worth documenting.
+ */
+export function hasDbTraces(inventory: CodeInventory): boolean {
+  return (inventory.services ?? []).some(
+    (svc) => (svc.orm_entities ?? []).length > 0,
+  );
+}
+
+/**
+ * Returns true when ≥1 library node in the graph has `depends_on` edges
+ * from two or more different (non-synthetic) services — i.e. there are
+ * genuinely *shared* libraries.
+ */
+export function hasSharedLibraries(graph: ServiceGraph): boolean {
+  const consumersPerLib = new Map<string, Set<string>>();
+  for (const e of graph.edges) {
+    if (e.kind !== "depends_on" || isSynthetic(e.from_service)) continue;
+    const set = consumersPerLib.get(e.to_service) ?? new Set<string>();
+    set.add(e.from_service);
+    consumersPerLib.set(e.to_service, set);
+  }
+  return [...consumersPerLib.values()].some((consumers) => consumers.size >= 2);
+}
+
 // ── D5: write helpers + CLI ─────────────────────────────────────────
 
 interface _PageSpec {
   slug: string;
   title: string;
+  hasContent: boolean;
   render: () => string;
 }
 
@@ -745,8 +817,14 @@ function _withFrontmatter(
 }
 
 /**
- * Render + write all six cross-service pages under `<wikiRoot>/wiki/`.
- * Returns the absolute paths written (deterministic order).
+ * Render + write cross-service pages under `<wikiRoot>/wiki/`.
+ * Only pages with substantive content are emitted — pages whose predicate
+ * returns false are silently skipped (no file written, not included in the
+ * returned array). Returns the absolute paths actually written, in
+ * deterministic order.
+ *
+ * When no page has content (e.g. a plain monorepo with no cross-service
+ * structure), the returned array is empty and nothing is written to disk.
  */
 export function writeCrossServicePages(
   wikiRoot: string,
@@ -754,7 +832,6 @@ export function writeCrossServicePages(
   graph: ServiceGraph,
 ): string[] {
   const outDir = path.join(wikiRoot, "wiki");
-  fs.mkdirSync(outDir, { recursive: true });
 
   // Collect unique evidence files from the graph edges as source provenance.
   const evidence = [
@@ -765,17 +842,29 @@ export function writeCrossServicePages(
     ),
   ].sort();
 
+  const serviceTopology = hasServiceTopology(graph);
+
   const pages: _PageSpec[] = [
-    { slug: "service-map",          title: "Service Map",           render: () => renderServiceMap(graph, inventory) },
-    { slug: "service-dependencies", title: "Service Dependencies",  render: () => renderServiceDependencies(graph, inventory) },
-    { slug: "client-registry",      title: "Service Client Registry", render: () => renderClientRegistry(graph, inventory) },
-    { slug: "queue-registry",       title: "Message Queue Registry", render: () => renderQueueRegistry(graph, inventory) },
-    { slug: "database-traces",      title: "Database Traces",       render: () => renderDbTraces(inventory) },
-    { slug: "shared-libraries",     title: "Shared Libraries",      render: () => renderSharedLibraryMatrix(graph, inventory) },
+    { slug: "service-map",          title: "Service Map",             hasContent: serviceTopology,          render: () => renderServiceMap(graph, inventory) },
+    { slug: "service-dependencies", title: "Service Dependencies",    hasContent: serviceTopology,          render: () => renderServiceDependencies(graph, inventory) },
+    { slug: "client-registry",      title: "Service Client Registry", hasContent: hasClientData(graph),     render: () => renderClientRegistry(graph, inventory) },
+    { slug: "queue-registry",       title: "Message Queue Registry",  hasContent: hasQueueData(graph),      render: () => renderQueueRegistry(graph, inventory) },
+    { slug: "database-traces",      title: "Database Traces",         hasContent: hasDbTraces(inventory),   render: () => renderDbTraces(inventory) },
+    { slug: "shared-libraries",     title: "Shared Libraries",        hasContent: hasSharedLibraries(graph), render: () => renderSharedLibraryMatrix(graph, inventory) },
   ];
 
+  const pagesWithContent = pages.filter((pg) => pg.hasContent);
+  if (pagesWithContent.length === 0) {
+    process.stderr.write(
+      "[cross_service_pages] no cross-service structure detected; skipping all six pages\n",
+    );
+    return [];
+  }
+
+  fs.mkdirSync(outDir, { recursive: true });
+
   const written: string[] = [];
-  for (const pg of pages) {
+  for (const pg of pagesWithContent) {
     const target = path.join(outDir, `${pg.slug}.md`);
     fs.writeFileSync(target, _withFrontmatter(pg.title, pg.render(), evidence, inventory.atlas_run_id, pg.slug));
     written.push(target);

--- a/agents/lib/tests/cross_service_e2e.test.ts
+++ b/agents/lib/tests/cross_service_e2e.test.ts
@@ -126,6 +126,11 @@ public class OrderEventConsumer {
   <version>1.0.0</version>
   <dependencies>
     <dependency>
+      <groupId>com.x.shared</groupId>
+      <artifactId>common-model</artifactId>
+      <version>1.0.0</version>
+    </dependency>
+    <dependency>
       <groupId>org.springframework.amqp</groupId>
       <artifactId>spring-rabbit</artifactId>
     </dependency>

--- a/agents/lib/tests/cross_service_pages_cli.test.ts
+++ b/agents/lib/tests/cross_service_pages_cli.test.ts
@@ -103,6 +103,19 @@ describe("writeCrossServicePages", () => {
     cleanupTmpPath(wiki);
   });
 
+  it("deletes a stale page left by a prior run when its data disappears (refresh)", () => {
+    const wiki = makeTmpPath("xs-pages-stale");
+    const wikiDir = path.join(wiki, "wiki");
+    fs.mkdirSync(wikiDir, { recursive: true });
+    // Simulate a prior run that wrote queue-registry.md; the current graph has no queues.
+    const stale = path.join(wikiDir, "queue-registry.md");
+    fs.writeFileSync(stale, "# Message Queue Registry\n\nold stale content\n");
+    const written = writeCrossServicePages(wiki, makeEmptyInventory(), makeEmptyGraph());
+    expect(written.length).toBe(0);
+    expect(fs.existsSync(stale)).toBe(false); // stale page removed
+    cleanupTmpPath(wiki);
+  });
+
   it("writes only the database-traces page when only DB entities are present", () => {
     const wiki = makeTmpPath("xs-pages-dbonly");
     const inventory = {

--- a/agents/lib/tests/cross_service_pages_cli.test.ts
+++ b/agents/lib/tests/cross_service_pages_cli.test.ts
@@ -209,4 +209,38 @@ describe("writeCrossServicePages", () => {
     expect(written.find((p) => p.endsWith("shared-libraries.md"))).toBeUndefined();
     cleanupTmpPath(wiki);
   });
+
+  it("writes service-map + service-dependencies from service count alone (≥2 services, no edges), without a client-registry link", () => {
+    const wiki = makeTmpPath("xs-pages-svconly");
+    const inventory = {
+      atlas_run_id: RUN_ID,
+      services: [
+        { identity: { id: "svc-a", kind: "service" }, rest_endpoints: [{ method: "GET", path: "/api/a/x" }], http_clients: [], queue_endpoints: [], orm_entities: [], external_sources: [], library_deps: [] },
+        { identity: { id: "svc-b", kind: "service" }, rest_endpoints: [{ method: "GET", path: "/api/b/y" }], http_clients: [], queue_endpoints: [], orm_entities: [], external_sources: [], library_deps: [] },
+      ],
+    } as any;
+    const graph = {
+      services: [
+        { id: "svc-a", kind: "service", language: "java", root: "svc-a" },
+        { id: "svc-b", kind: "service", language: "java", root: "svc-b" },
+      ],
+      edges: [], // no calls/queue/db/lib edges yet
+      generated_at: "",
+    } as any;
+    const written = writeCrossServicePages(wiki, inventory, graph);
+    const slugs = written.map((p) => path.basename(p, ".md"));
+    // The real service list is genuine information → both topology pages emitted.
+    expect(slugs).toContain("service-map");
+    expect(slugs).toContain("service-dependencies");
+    // Nothing else has data → those pages are skipped.
+    for (const slug of ["client-registry", "queue-registry", "database-traces", "shared-libraries"] as const) {
+      expect(written.find((p) => p.endsWith(`${slug}.md`)), `unexpected page: ${slug}`).toBeUndefined();
+      expect(fs.existsSync(path.join(wiki, "wiki", `${slug}.md`))).toBe(false);
+    }
+    // Dangling-link safety: with no calls edges there is no transitive note,
+    // so the service-map body must NOT link to the (skipped) client-registry page.
+    const serviceMapBody = fs.readFileSync(path.join(wiki, "wiki", "service-map.md"), "utf-8");
+    expect(serviceMapBody).not.toContain("client-registry.md");
+    cleanupTmpPath(wiki);
+  });
 });

--- a/agents/lib/tests/cross_service_pages_cli.test.ts
+++ b/agents/lib/tests/cross_service_pages_cli.test.ts
@@ -188,10 +188,9 @@ describe("writeCrossServicePages", () => {
     const slugs = written.map((p) => path.basename(p, ".md"));
     expect(slugs).toContain("service-map");
     expect(slugs).toContain("service-dependencies");
-    // No calls edges with both non-synthetic endpoints → client-registry has no data
-    // But service-dependencies has calls edges so it IS written; client-registry is the
-    // HTTP-client callsite view — only written when http_clients exist in inventory.
-    // queue-registry, database-traces, shared-libraries have no data → skipped.
+    // The calls edge (svc-a → svc-b, both real) satisfies hasClientData too, so the
+    // three call-graph pages are co-emitted. queue/db/shared have no data → skipped.
+    expect(slugs).toContain("client-registry");
     expect(written.find((p) => p.endsWith("queue-registry.md"))).toBeUndefined();
     expect(written.find((p) => p.endsWith("database-traces.md"))).toBeUndefined();
     expect(written.find((p) => p.endsWith("shared-libraries.md"))).toBeUndefined();

--- a/agents/lib/tests/cross_service_pages_cli.test.ts
+++ b/agents/lib/tests/cross_service_pages_cli.test.ts
@@ -1,9 +1,10 @@
 import { describe, it, expect } from "vitest";
 import * as fs from "node:fs";
+import * as path from "node:path";
 import { makeTmpPath, cleanupTmpPath } from "./fixtures.js";
 import { writeCrossServicePages } from "../cross_service_pages.js";
 
-const SLUGS = [
+const ALL_SLUGS = [
   "service-map",
   "service-dependencies",
   "client-registry",
@@ -12,32 +13,188 @@ const SLUGS = [
   "shared-libraries",
 ] as const;
 
+const RUN_ID = "2026-06-07T10-00-00";
+
+/** Full-data fixture: 2 services with calls edges, queue, DB entity, shared lib. */
+function makeFullInventory(): any {
+  return {
+    atlas_run_id: RUN_ID,
+    services: [
+      {
+        identity: { id: "svc-a", kind: "service" },
+        rest_endpoints: [{ method: "GET", path: "/api/a/items" }],
+        http_clients: [{ framework: "feign", method: "GET", target_ref: "${svc-b.url}", path: "/api/b/x", file: "svc-a/C.java", line: 3 }],
+        queue_endpoints: [{ framework: "spring_amqp", role: "producer", queue_name: "events", message_type: "EventDto", file: "svc-a/P.java", line: 1 }],
+        orm_entities: [{ profile: "jpa", class_name: "Order", table_name: "orders", schema_name: "app", source_file: "svc-a/Order.java", columns: [{ name: "id", source_field: "id" }], relationships: [] }],
+        external_sources: [],
+        library_deps: ["common-lib"],
+      },
+      {
+        identity: { id: "svc-b", kind: "service" },
+        rest_endpoints: [{ method: "GET", path: "/api/b/x" }],
+        http_clients: [],
+        queue_endpoints: [{ framework: "spring_amqp", role: "consumer", queue_name: "events", message_type: "EventDto", file: "svc-b/C.java", line: 5 }],
+        orm_entities: [],
+        external_sources: [],
+        library_deps: ["common-lib"],
+      },
+    ],
+  };
+}
+
+function makeFullGraph(): any {
+  return {
+    services: [
+      { id: "svc-a", kind: "service", language: "java", root: "svc-a" },
+      { id: "svc-b", kind: "service", language: "java", root: "svc-b" },
+      { id: "common-lib", kind: "library", language: "java", root: "shared/common-lib" },
+    ],
+    edges: [
+      { from_service: "svc-a", to_service: "svc-b", kind: "calls", detail: "GET /api/b/x", confidence: "high", evidence_file: "svc-a/C.java", evidence_line: 3 },
+      { from_service: "svc-a", to_service: "queue:events", kind: "produces", detail: "queue:events", confidence: "high", evidence_file: "svc-a/P.java", evidence_line: 1 },
+      { from_service: "queue:events", to_service: "svc-b", kind: "consumes", detail: "queue:events", confidence: "high", evidence_file: "svc-b/C.java", evidence_line: 5 },
+      { from_service: "svc-a", to_service: "common-lib", kind: "depends_on", detail: "lib:common-lib", confidence: "high", evidence_file: "svc-a/pom.xml", evidence_line: 0 },
+      { from_service: "svc-b", to_service: "common-lib", kind: "depends_on", detail: "lib:common-lib", confidence: "high", evidence_file: "svc-b/pom.xml", evidence_line: 0 },
+    ],
+    generated_at: "",
+  };
+}
+
+/** Empty-data fixture: no services at all. */
+function makeEmptyInventory(): any {
+  return { atlas_run_id: RUN_ID, services: [] };
+}
+
+function makeEmptyGraph(): any {
+  return { services: [], edges: [], generated_at: "" };
+}
+
 describe("writeCrossServicePages", () => {
-  it("writes the six cross-service pages with atlas frontmatter", () => {
-    const wiki = makeTmpPath("xs-pages");
-    const RUN_ID = "2026-06-07T10-00-00";
-    const inventory = {
-      atlas_run_id: RUN_ID,
-      services: [
-        { identity: { id: "payments-module", kind: "service" }, rest_endpoints: [{ method: "GET", path: "/api/payments/x" }], http_clients: [], queue_endpoints: [], orm_entities: [], external_sources: [], library_deps: [] },
-      ],
-    } as any;
-    const graph = { services: [{ id: "payments-module", kind: "service", language: "java", root: "payments-module" }], edges: [], generated_at: "" } as any;
+  it("writes all six cross-service pages when full data is present", () => {
+    const wiki = makeTmpPath("xs-pages-full");
+    const inventory = makeFullInventory();
+    const graph = makeFullGraph();
     const written = writeCrossServicePages(wiki, inventory, graph);
     expect(written.length).toBe(6);
     for (const p of written) {
       expect(fs.existsSync(p)).toBe(true);
       const body = fs.readFileSync(p, "utf-8");
-      expect(body.startsWith("---\n")).toBe(true);     // frontmatter
+      expect(body.startsWith("---\n")).toBe(true);
       expect(body).toContain("atlas_facet: architecture");
       expect(body).toContain(`atlas_run_id: ${RUN_ID}`);
     }
-    for (const slug of SLUGS) {
+    for (const slug of ALL_SLUGS) {
       const match = written.find((p) => p.endsWith(`${slug}.md`));
       expect(match, `missing page: ${slug}`).toBeTruthy();
       const body = fs.readFileSync(match!, "utf-8");
       expect(body).toContain(`cross_service_page: ${slug}`);
     }
+    cleanupTmpPath(wiki);
+  });
+
+  it("writes zero pages when the graph and inventory are empty (no cross-service structure)", () => {
+    const wiki = makeTmpPath("xs-pages-empty");
+    const written = writeCrossServicePages(wiki, makeEmptyInventory(), makeEmptyGraph());
+    expect(written.length).toBe(0);
+    // No stale .md files written
+    for (const slug of ALL_SLUGS) {
+      expect(fs.existsSync(path.join(wiki, "wiki", `${slug}.md`))).toBe(false);
+    }
+    cleanupTmpPath(wiki);
+  });
+
+  it("writes only the database-traces page when only DB entities are present", () => {
+    const wiki = makeTmpPath("xs-pages-dbonly");
+    const inventory = {
+      atlas_run_id: RUN_ID,
+      services: [
+        {
+          identity: { id: "svc-a", kind: "service" },
+          rest_endpoints: [],
+          http_clients: [],
+          queue_endpoints: [],
+          orm_entities: [{ profile: "jpa", class_name: "Order", table_name: "orders", schema_name: "app", source_file: "svc-a/Order.java", columns: [{ name: "id", source_field: "id" }], relationships: [] }],
+          external_sources: [],
+          library_deps: [],
+        },
+      ],
+    } as any;
+    const graph = {
+      services: [{ id: "svc-a", kind: "service", language: "java", root: "svc-a" }],
+      edges: [],
+      generated_at: "",
+    } as any;
+    const written = writeCrossServicePages(wiki, inventory, graph);
+    expect(written.length).toBe(1);
+    const slugs = written.map((p) => path.basename(p, ".md"));
+    expect(slugs).toContain("database-traces");
+    // Pages without data must NOT be written
+    for (const slug of ["service-map", "service-dependencies", "client-registry", "queue-registry", "shared-libraries"] as const) {
+      expect(written.find((p) => p.endsWith(`${slug}.md`)), `unexpected page: ${slug}`).toBeUndefined();
+      expect(fs.existsSync(path.join(wiki, "wiki", `${slug}.md`))).toBe(false);
+    }
+    cleanupTmpPath(wiki);
+  });
+
+  it("writes only queue-registry when only queue edges are present", () => {
+    const wiki = makeTmpPath("xs-pages-queueonly");
+    const inventory = {
+      atlas_run_id: RUN_ID,
+      services: [
+        {
+          identity: { id: "svc-a", kind: "service" },
+          rest_endpoints: [],
+          http_clients: [],
+          queue_endpoints: [{ framework: "spring_amqp", role: "producer", queue_name: "events", message_type: "Msg", file: "svc-a/P.java", line: 1 }],
+          orm_entities: [],
+          external_sources: [],
+          library_deps: [],
+        },
+      ],
+    } as any;
+    const graph = {
+      services: [{ id: "svc-a", kind: "service", language: "java", root: "svc-a" }],
+      edges: [
+        { from_service: "svc-a", to_service: "queue:events", kind: "produces", detail: "queue:events", confidence: "high", evidence_file: "svc-a/P.java", evidence_line: 1 },
+      ],
+      generated_at: "",
+    } as any;
+    const written = writeCrossServicePages(wiki, inventory, graph);
+    expect(written.length).toBe(1);
+    expect(written[0]).toMatch(/queue-registry\.md$/);
+    cleanupTmpPath(wiki);
+  });
+
+  it("writes service-map and service-dependencies when ≥2 services have calls edges, but not client/queue/db/lib pages when those are absent", () => {
+    const wiki = makeTmpPath("xs-pages-callsonly");
+    const inventory = {
+      atlas_run_id: RUN_ID,
+      services: [
+        { identity: { id: "svc-a", kind: "service" }, rest_endpoints: [], http_clients: [], queue_endpoints: [], orm_entities: [], external_sources: [], library_deps: [] },
+        { identity: { id: "svc-b", kind: "service" }, rest_endpoints: [], http_clients: [], queue_endpoints: [], orm_entities: [], external_sources: [], library_deps: [] },
+      ],
+    } as any;
+    const graph = {
+      services: [
+        { id: "svc-a", kind: "service", language: "java", root: "svc-a" },
+        { id: "svc-b", kind: "service", language: "java", root: "svc-b" },
+      ],
+      edges: [
+        { from_service: "svc-a", to_service: "svc-b", kind: "calls", detail: "GET /api/b/x", confidence: "high", evidence_file: "svc-a/C.java", evidence_line: 1 },
+      ],
+      generated_at: "",
+    } as any;
+    const written = writeCrossServicePages(wiki, inventory, graph);
+    const slugs = written.map((p) => path.basename(p, ".md"));
+    expect(slugs).toContain("service-map");
+    expect(slugs).toContain("service-dependencies");
+    // No calls edges with both non-synthetic endpoints → client-registry has no data
+    // But service-dependencies has calls edges so it IS written; client-registry is the
+    // HTTP-client callsite view — only written when http_clients exist in inventory.
+    // queue-registry, database-traces, shared-libraries have no data → skipped.
+    expect(written.find((p) => p.endsWith("queue-registry.md"))).toBeUndefined();
+    expect(written.find((p) => p.endsWith("database-traces.md"))).toBeUndefined();
+    expect(written.find((p) => p.endsWith("shared-libraries.md"))).toBeUndefined();
     cleanupTmpPath(wiki);
   });
 });


### PR DESCRIPTION
## Why

doc-wiki must only document what is actually true — never emit empty/made-up scaffolding. `/doc-wiki:atlas --cross-service` was generating all six cross-service pages (`service-map`, `service-dependencies`, `client-registry`, `queue-registry`, `database-traces`, `shared-libraries`) unconditionally, even on repos with no cross-service structure — producing pages full of placeholder `"—"` content. (Surfaced running atlas on vitest, a single pnpm monorepo with no services/queues/DBs.)

## What

`agents/lib/cross_service_pages.ts`: each page now has a content predicate (`hasServiceTopology`, `hasClientData`, `hasQueueData`, `hasDbTraces`, `hasSharedLibraries`) and is written only when it has real data. On a plain monorepo with no cross-service structure, zero cross-service pages are written (logged to stderr), and no `wiki/` dir is polluted.

- Predicates require **real** (non-synthetic) cross-service edges/nodes — synthetic `ext:`/`queue:`/`table:` endpoints don't count.
- No dangling links: `service-map`/`service-dependencies`/`client-registry` are coupled by the same `calls`-edge predicate, so any inter-page link is always to a co-emitted page (verified).

## Tests

New cases: empty graph → 0 pages; DB-only → 1 page; queue-only → 1 page; calls-only → service-map + service-dependencies + client-registry only. Full suite **1675 passed / 20 skipped**, typecheck + build clean, `.ts`/`.js` in sync.