### PR TITLE
fix(cross-service): exclude library nodes from service-count topology check

### DIFF
--- a/agents/lib/cross_service_pages.js
+++ b/agents/lib/cross_service_pages.js
@@ -576,20 +576,18 @@ export function renderServiceDependencies(graph, inventory) {
  * call edges are detected.
  */
 export function hasServiceTopology(graph) {
-    const serviceIds = new Set(graph.services.map((s) => s.id));
-    // ≥2 real deployable services is enough — the service list alone is genuine,
-    // true information. Count only actual services: exclude synthetic nodes AND
-    // library nodes (a lib is a dependency, not a topology service, so a
-    // 1-service + 1-library graph must NOT emit a service map).
-    const realServiceCount = graph.services.filter((s) => !isSynthetic(s.id) && s.kind !== "library").length;
-    if (realServiceCount >= 2)
+    // Real deployable services only: exclude synthetic nodes AND library nodes
+    // (a lib is a dependency, not a topology service). Used for BOTH the count
+    // and the calls-edge check, so a library→service calls edge can never make
+    // a 1-service graph emit a service map.
+    const realServiceIds = new Set(graph.services.filter((s) => !isSynthetic(s.id) && s.kind !== "library").map((s) => s.id));
+    // ≥2 real services is enough — the service list alone is genuine information.
+    if (realServiceIds.size >= 2)
         return true;
-    // Otherwise require at least one direct calls edge between two real services.
+    // Otherwise require a direct calls edge between two real (non-library) services.
     return graph.edges.some((e) => e.kind === "calls" &&
-        serviceIds.has(e.from_service) &&
-        serviceIds.has(e.to_service) &&
-        !isSynthetic(e.from_service) &&
-        !isSynthetic(e.to_service));
+        realServiceIds.has(e.from_service) &&
+        realServiceIds.has(e.to_service));
 }
 /**
  * Returns true when the inventory has ≥1 HTTP client callsite across any

--- a/agents/lib/cross_service_pages.js
+++ b/agents/lib/cross_service_pages.js
@@ -577,9 +577,11 @@ export function renderServiceDependencies(graph, inventory) {
  */
 export function hasServiceTopology(graph) {
     const serviceIds = new Set(graph.services.map((s) => s.id));
-    // ≥2 real (non-synthetic) services is enough — the service list alone is
-    // genuine, true information.
-    const realServiceCount = graph.services.filter((s) => !isSynthetic(s.id)).length;
+    // ≥2 real deployable services is enough — the service list alone is genuine,
+    // true information. Count only actual services: exclude synthetic nodes AND
+    // library nodes (a lib is a dependency, not a topology service, so a
+    // 1-service + 1-library graph must NOT emit a service map).
+    const realServiceCount = graph.services.filter((s) => !isSynthetic(s.id) && s.kind !== "library").length;
     if (realServiceCount >= 2)
         return true;
     // Otherwise require at least one direct calls edge between two real services.

--- a/agents/lib/cross_service_pages.ts
+++ b/agents/lib/cross_service_pages.ts
@@ -717,9 +717,13 @@ export function renderServiceDependencies(
 export function hasServiceTopology(graph: ServiceGraph): boolean {
   const serviceIds = new Set(graph.services.map((s) => s.id));
 
-  // ≥2 real (non-synthetic) services is enough — the service list alone is
-  // genuine, true information.
-  const realServiceCount = graph.services.filter((s) => !isSynthetic(s.id)).length;
+  // ≥2 real deployable services is enough — the service list alone is genuine,
+  // true information. Count only actual services: exclude synthetic nodes AND
+  // library nodes (a lib is a dependency, not a topology service, so a
+  // 1-service + 1-library graph must NOT emit a service map).
+  const realServiceCount = graph.services.filter(
+    (s) => !isSynthetic(s.id) && s.kind !== "library",
+  ).length;
   if (realServiceCount >= 2) return true;
 
   // Otherwise require at least one direct calls edge between two real services.

--- a/agents/lib/cross_service_pages.ts
+++ b/agents/lib/cross_service_pages.ts
@@ -715,25 +715,23 @@ export function renderServiceDependencies(
  * call edges are detected.
  */
 export function hasServiceTopology(graph: ServiceGraph): boolean {
-  const serviceIds = new Set(graph.services.map((s) => s.id));
+  // Real deployable services only: exclude synthetic nodes AND library nodes
+  // (a lib is a dependency, not a topology service). Used for BOTH the count
+  // and the calls-edge check, so a library→service calls edge can never make
+  // a 1-service graph emit a service map.
+  const realServiceIds = new Set(
+    graph.services.filter((s) => !isSynthetic(s.id) && s.kind !== "library").map((s) => s.id),
+  );
 
-  // ≥2 real deployable services is enough — the service list alone is genuine,
-  // true information. Count only actual services: exclude synthetic nodes AND
-  // library nodes (a lib is a dependency, not a topology service, so a
-  // 1-service + 1-library graph must NOT emit a service map).
-  const realServiceCount = graph.services.filter(
-    (s) => !isSynthetic(s.id) && s.kind !== "library",
-  ).length;
-  if (realServiceCount >= 2) return true;
+  // ≥2 real services is enough — the service list alone is genuine information.
+  if (realServiceIds.size >= 2) return true;
 
-  // Otherwise require at least one direct calls edge between two real services.
+  // Otherwise require a direct calls edge between two real (non-library) services.
   return graph.edges.some(
     (e) =>
       e.kind === "calls" &&
-      serviceIds.has(e.from_service) &&
-      serviceIds.has(e.to_service) &&
-      !isSynthetic(e.from_service) &&
-      !isSynthetic(e.to_service),
+      realServiceIds.has(e.from_service) &&
+      realServiceIds.has(e.to_service),
   );
 }
 

--- a/agents/lib/tests/cross_service_pages_cli.test.ts
+++ b/agents/lib/tests/cross_service_pages_cli.test.ts
@@ -244,6 +244,37 @@ describe("writeCrossServicePages", () => {
     cleanupTmpPath(wiki);
   });
 
+  it("does NOT emit topology pages for one service + a library that calls it (lib->service edge)", () => {
+    const wiki = makeTmpPath("xs-pages-lib-edge");
+    const inventory = {
+      atlas_run_id: RUN_ID,
+      services: [
+        { identity: { id: "svc-a", kind: "service" }, rest_endpoints: [], http_clients: [], queue_endpoints: [], orm_entities: [], external_sources: [], library_deps: [] },
+      ],
+    } as any;
+    const graph = {
+      services: [
+        { id: "svc-a", kind: "service", language: "java", root: "svc-a" },
+        { id: "common-lib", kind: "library", language: "java", root: "shared/common-lib" },
+      ],
+      // A library with an HTTP client can produce a calls edge from the lib to the service.
+      edges: [
+        { from_service: "common-lib", to_service: "svc-a", kind: "calls", detail: "GET /api/a/x", confidence: "high", evidence_file: "common-lib/C.java", evidence_line: 1 },
+      ],
+      generated_at: "",
+    } as any;
+    const written = writeCrossServicePages(wiki, inventory, graph);
+    const slugs = written.map((p) => path.basename(p, ".md"));
+    // The lib->service calls edge is NOT real service topology, so the topology
+    // pages must be skipped (the codex finding). client-registry is allowed —
+    // a library HTTP-client callsite is a genuine, non-fabricated callsite.
+    expect(slugs).not.toContain("service-map");
+    expect(slugs).not.toContain("service-dependencies");
+    expect(fs.existsSync(path.join(wiki, "wiki", "service-map.md"))).toBe(false);
+    expect(fs.existsSync(path.join(wiki, "wiki", "service-dependencies.md"))).toBe(false);
+    cleanupTmpPath(wiki);
+  });
+
   it("does NOT emit topology pages for one service plus a library (a lib is not a service)", () => {
     const wiki = makeTmpPath("xs-pages-svc-plus-lib");
     const inventory = {

--- a/agents/lib/tests/cross_service_pages_cli.test.ts
+++ b/agents/lib/tests/cross_service_pages_cli.test.ts
@@ -243,4 +243,29 @@ describe("writeCrossServicePages", () => {
     expect(serviceMapBody).not.toContain("client-registry.md");
     cleanupTmpPath(wiki);
   });
+
+  it("does NOT emit topology pages for one service plus a library (a lib is not a service)", () => {
+    const wiki = makeTmpPath("xs-pages-svc-plus-lib");
+    const inventory = {
+      atlas_run_id: RUN_ID,
+      services: [
+        { identity: { id: "svc-a", kind: "service" }, rest_endpoints: [], http_clients: [], queue_endpoints: [], orm_entities: [], external_sources: [], library_deps: [] },
+      ],
+    } as any;
+    const graph = {
+      services: [
+        { id: "svc-a", kind: "service", language: "java", root: "svc-a" },
+        { id: "common-lib", kind: "library", language: "java", root: "shared/common-lib" },
+      ],
+      edges: [], // no calls edges
+      generated_at: "",
+    } as any;
+    const written = writeCrossServicePages(wiki, inventory, graph);
+    // Only one real service (the library doesn't count) and no calls → no scaffolding.
+    expect(written.length).toBe(0);
+    for (const slug of ALL_SLUGS) {
+      expect(fs.existsSync(path.join(wiki, "wiki", `${slug}.md`))).toBe(false);
+    }
+    cleanupTmpPath(wiki);
+  });
 });


### PR DESCRIPTION
Fix-forward on PR #67. Codex caught a regression the widening introduced: `hasServiceTopology`'s new `≥2 real services` count excluded only synthetic IDs, so it counted **library** nodes as services. A common 1-service + 1-library `depends_on` graph then re-emitted empty `service-map.md`/`service-dependencies.md` scaffolding — exactly what #67 set out to remove.

Fix: count only non-synthetic, non-`library` nodes. A library is a dependency, not a topology service.

Test added: 1 service + 1 library, no edges → zero pages. Full cross-service suite (38 tests) + typecheck + build green; `.ts`/`.js` in sync.