### PR TITLE
feat(benchmark): PR-as-ticket fallback for repos without linked issues

### DIFF
--- a/benchmark/harness/mine_tickets.js
+++ b/benchmark/harness/mine_tickets.js
@@ -4,7 +4,7 @@ import { parseFlags } from "../../skills/doc-wiki/scripts/_cli_args.js";
 import { realRunner } from "./exec.js";
 import { checkEligibility } from "./mine_filters.js";
 import { loadRepoConfig } from "./repo_config.js";
-import { sanitizeIssueBody } from "./sanitize.js";
+import { sanitizeIssueBody, stripPrTemplate } from "./sanitize.js";
 async function ghJson(runner, args) {
     const r = await runner("gh", args);
     if (r.code !== 0) {
@@ -22,6 +22,7 @@ async function ghJson(runner, args) {
 export async function mineGithub(cfg, opts) {
     const tickets = [];
     const seenIssues = new Set();
+    const seenPrs = new Set();
     const prs = await ghJson(opts.runner, [
         "pr", "list", "--repo", cfg.github, "--state", "merged",
         "--search", `merged:>=${cfg.ticket_after}`,
@@ -34,13 +35,18 @@ export async function mineGithub(cfg, opts) {
             break;
         const pr = await ghJson(opts.runner, [
             "pr", "view", String(entry.number), "--repo", cfg.github,
-            "--json", "number,url,title,files,closingIssuesReferences,mergeCommit,mergedAt,author",
+            "--json", "number,url,title,body,files,closingIssuesReferences,mergeCommit,mergedAt,author",
         ]);
         if (pr === undefined || pr.mergeCommit === null)
             continue;
         const issueRef = pr.closingIssuesReferences[0];
         if (issueRef === undefined) {
-            note(pr.number, "no-linked-issue");
+            // PR-as-ticket fallback: repos that don't link issues to PRs (e.g. saleor/saleor, where
+            // 0/100 recent merged PRs carry a closingIssuesReference) would otherwise yield no tickets.
+            // Build the ticket from the PR itself, through the SAME eligibility gates as the issue path.
+            const prTicket = await prAsTicket(pr, cfg, opts.runner, seenPrs);
+            if (prTicket !== undefined)
+                tickets.push(prTicket);
             continue;
         }
         if (seenIssues.has(issueRef.number)) {
@@ -72,6 +78,7 @@ export async function mineGithub(cfg, opts) {
         const sanitized = sanitizeIssueBody(body, issue.number);
         seenIssues.add(issue.number);
         tickets.push({
+            source: "issue",
             issue: issue.number,
             issue_url: issue.html_url,
             title: issue.title,
@@ -93,6 +100,67 @@ export async function mineGithub(cfg, opts) {
         }
     }
     return { schema_version: 1, repo: cfg.id, mined_at: new Date().toISOString(), tickets };
+}
+/**
+ * Build a ticket from a PR that links no issue (the PR description IS the problem statement).
+ * Returns undefined (and logs a skip note) when the PR fails the same eligibility gates as the
+ * issue path, when it's a duplicate, or when its parent commit can't be resolved.
+ */
+async function prAsTicket(pr, cfg, runner, seenPrs) {
+    if (seenPrs.has(pr.number)) {
+        note(pr.number, "duplicate-pr");
+        return undefined;
+    }
+    if (pr.mergeCommit === null) {
+        note(pr.number, "no-merge-commit");
+        return undefined;
+    }
+    // PR bodies carry repo PR-template boilerplate (HTML comments, "# Impact" checklists). Strip it
+    // first so the cleaned text is the substantive problem statement (and to minimize context leakage),
+    // THEN run the shared issue-body sanitizer on the result. The issue path's sanitization is unchanged.
+    const cleaned = stripPrTemplate(pr.body ?? "");
+    // thin-body gate for PR-tickets: the prompt the agent receives is always `${title}\n\n${body_sanitized}`
+    // (see session.ts buildPrompt), so the title is itself a meaningful problem statement. A PR whose
+    // cleaned body is short is therefore NOT useless — we gate thin-body on (title + cleaned body) length
+    // rather than the body alone, so a terse-but-titled PR still qualifies. All other gates are identical.
+    const bodyLength = pr.title.length + cleaned.length;
+    const verdict = checkEligibility({ files: pr.files, authorIsBot: pr.author?.is_bot === true, bodyLength, mergedAt: pr.mergedAt }, cfg);
+    if (!verdict.ok) {
+        note(pr.number, verdict.reason);
+        return undefined;
+    }
+    const commit = await ghJson(runner, ["api", `repos/${cfg.github}/commits/${pr.mergeCommit.oid}`]);
+    const parent = commit?.parents[0];
+    if (commit === undefined || parent === undefined) {
+        note(pr.number, "no-parent-commit");
+        return undefined;
+    }
+    if (commit.parents.length > 1) {
+        process.stderr.write(`PR #${pr.number}: multi-parent merge (kept; calibration will validate base_commit)\n`);
+    }
+    const sanitized = sanitizeIssueBody(cleaned, pr.number);
+    seenPrs.add(pr.number);
+    if (sanitized.redactions.length > 0) {
+        process.stderr.write(`PR #${pr.number}: redacted ${sanitized.redactions.join(", ")}\n`);
+    }
+    return {
+        source: "pr",
+        issue: pr.number, // the PR number serves as the ticket id
+        issue_url: pr.url,
+        title: pr.title,
+        body: pr.body ?? "",
+        body_sanitized: sanitized.text,
+        fix_pr: pr.number,
+        fix_pr_url: pr.url,
+        base_commit: parent.sha,
+        fix_commit: pr.mergeCommit.oid,
+        test_files: verdict.test_files,
+        src_files: verdict.src_files,
+        run_files: verdict.run_files,
+        changed_lines: verdict.changed_lines,
+        merge_parents: commit.parents.length,
+        merged_at: pr.mergedAt,
+    };
 }
 function note(pr, reason) {
     process.stderr.write(`PR #${pr}: skipped (${reason})\n`);

--- a/benchmark/harness/mine_tickets.ts
+++ b/benchmark/harness/mine_tickets.ts
@@ -5,7 +5,7 @@ import type { Runner } from "./exec.js";
 import { realRunner } from "./exec.js";
 import { checkEligibility } from "./mine_filters.js";
 import { loadRepoConfig } from "./repo_config.js";
-import { sanitizeIssueBody } from "./sanitize.js";
+import { sanitizeIssueBody, stripPrTemplate } from "./sanitize.js";
 import type { RepoConfig, TicketRecord, TicketsFile } from "./types.js";
 
 interface MineOpts {
@@ -31,6 +31,7 @@ async function ghJson<T>(runner: Runner, args: string[]): Promise<T | undefined>
 interface PrListEntry { number: number; url: string; mergedAt: string }
 interface PrView {
   number: number; url: string; title: string;
+  body: string | null;
   files: Array<{ path: string; additions: number; deletions: number }>;
   closingIssuesReferences: Array<{ number: number }>;
   mergeCommit: { oid: string } | null;
@@ -43,6 +44,7 @@ interface CommitView { sha: string; parents: Array<{ sha: string }> }
 export async function mineGithub(cfg: RepoConfig, opts: MineOpts): Promise<TicketsFile> {
   const tickets: TicketRecord[] = [];
   const seenIssues = new Set<number>();
+  const seenPrs = new Set<number>();
 
   const prs = await ghJson<PrListEntry[]>(opts.runner, [
     "pr", "list", "--repo", cfg.github, "--state", "merged",
@@ -56,11 +58,18 @@ export async function mineGithub(cfg: RepoConfig, opts: MineOpts): Promise<Ticke
 
     const pr = await ghJson<PrView>(opts.runner, [
       "pr", "view", String(entry.number), "--repo", cfg.github,
-      "--json", "number,url,title,files,closingIssuesReferences,mergeCommit,mergedAt,author",
+      "--json", "number,url,title,body,files,closingIssuesReferences,mergeCommit,mergedAt,author",
     ]);
     if (pr === undefined || pr.mergeCommit === null) continue;
     const issueRef = pr.closingIssuesReferences[0];
-    if (issueRef === undefined) { note(pr.number, "no-linked-issue"); continue; }
+    if (issueRef === undefined) {
+      // PR-as-ticket fallback: repos that don't link issues to PRs (e.g. saleor/saleor, where
+      // 0/100 recent merged PRs carry a closingIssuesReference) would otherwise yield no tickets.
+      // Build the ticket from the PR itself, through the SAME eligibility gates as the issue path.
+      const prTicket = await prAsTicket(pr, cfg, opts.runner, seenPrs);
+      if (prTicket !== undefined) tickets.push(prTicket);
+      continue;
+    }
     if (seenIssues.has(issueRef.number)) { note(pr.number, "duplicate-issue"); continue; }
 
     const issue = await ghJson<IssueView>(opts.runner, ["api", `repos/${cfg.github}/issues/${issueRef.number}`]);
@@ -85,6 +94,7 @@ export async function mineGithub(cfg: RepoConfig, opts: MineOpts): Promise<Ticke
     const sanitized = sanitizeIssueBody(body, issue.number);
     seenIssues.add(issue.number);
     tickets.push({
+      source: "issue",
       issue: issue.number,
       issue_url: issue.html_url,
       title: issue.title,
@@ -106,6 +116,68 @@ export async function mineGithub(cfg: RepoConfig, opts: MineOpts): Promise<Ticke
     }
   }
   return { schema_version: 1, repo: cfg.id, mined_at: new Date().toISOString(), tickets };
+}
+
+/**
+ * Build a ticket from a PR that links no issue (the PR description IS the problem statement).
+ * Returns undefined (and logs a skip note) when the PR fails the same eligibility gates as the
+ * issue path, when it's a duplicate, or when its parent commit can't be resolved.
+ */
+async function prAsTicket(
+  pr: PrView,
+  cfg: RepoConfig,
+  runner: Runner,
+  seenPrs: Set<number>,
+): Promise<TicketRecord | undefined> {
+  if (seenPrs.has(pr.number)) { note(pr.number, "duplicate-pr"); return undefined; }
+  if (pr.mergeCommit === null) { note(pr.number, "no-merge-commit"); return undefined; }
+
+  // PR bodies carry repo PR-template boilerplate (HTML comments, "# Impact" checklists). Strip it
+  // first so the cleaned text is the substantive problem statement (and to minimize context leakage),
+  // THEN run the shared issue-body sanitizer on the result. The issue path's sanitization is unchanged.
+  const cleaned = stripPrTemplate(pr.body ?? "");
+
+  // thin-body gate for PR-tickets: the prompt the agent receives is always `${title}\n\n${body_sanitized}`
+  // (see session.ts buildPrompt), so the title is itself a meaningful problem statement. A PR whose
+  // cleaned body is short is therefore NOT useless — we gate thin-body on (title + cleaned body) length
+  // rather than the body alone, so a terse-but-titled PR still qualifies. All other gates are identical.
+  const bodyLength = pr.title.length + cleaned.length;
+  const verdict = checkEligibility(
+    { files: pr.files, authorIsBot: pr.author?.is_bot === true, bodyLength, mergedAt: pr.mergedAt },
+    cfg,
+  );
+  if (!verdict.ok) { note(pr.number, verdict.reason); return undefined; }
+
+  const commit = await ghJson<CommitView>(runner, ["api", `repos/${cfg.github}/commits/${pr.mergeCommit.oid}`]);
+  const parent = commit?.parents[0];
+  if (commit === undefined || parent === undefined) { note(pr.number, "no-parent-commit"); return undefined; }
+  if (commit.parents.length > 1) {
+    process.stderr.write(`PR #${pr.number}: multi-parent merge (kept; calibration will validate base_commit)\n`);
+  }
+
+  const sanitized = sanitizeIssueBody(cleaned, pr.number);
+  seenPrs.add(pr.number);
+  if (sanitized.redactions.length > 0) {
+    process.stderr.write(`PR #${pr.number}: redacted ${sanitized.redactions.join(", ")}\n`);
+  }
+  return {
+    source: "pr",
+    issue: pr.number, // the PR number serves as the ticket id
+    issue_url: pr.url,
+    title: pr.title,
+    body: pr.body ?? "",
+    body_sanitized: sanitized.text,
+    fix_pr: pr.number,
+    fix_pr_url: pr.url,
+    base_commit: parent.sha,
+    fix_commit: pr.mergeCommit.oid,
+    test_files: verdict.test_files,
+    src_files: verdict.src_files,
+    run_files: verdict.run_files,
+    changed_lines: verdict.changed_lines,
+    merge_parents: commit.parents.length,
+    merged_at: pr.mergedAt,
+  };
 }
 
 function note(pr: number, reason: string): void {

--- a/benchmark/harness/sanitize.js
+++ b/benchmark/harness/sanitize.js
@@ -1,4 +1,29 @@
 /**
+ * Strip PR-template boilerplate from a PR description before it becomes a problem
+ * statement. PR bodies (unlike issue bodies) commonly carry repo PR-template scaffolding
+ * (e.g. saleor/saleor) that is pure noise and could leak harness/context hints:
+ * - multiline HTML comments `<!-- ... -->` (template instructions);
+ * - a trailing "# Impact" / changelog section and everything after it;
+ * - GitHub-flavoured checklist lines (`- [ ]` / `- [x]`).
+ * The remaining substantive text is collapsed (no 3+ blank-line runs) and trimmed.
+ * Applied in the PR ticket path BEFORE sanitizeIssueBody; the issue path is untouched.
+ */
+export function stripPrTemplate(body) {
+    let text = body.replace(/<!--[\s\S]*?-->/g, "");
+    // Drop a "# Impact" (or "## Impact" ...) heading and everything after it.
+    text = text.replace(/^#{1,6}\s+Impact\b[\s\S]*$/im, "");
+    // Drop any remaining task-list checklist lines (template acknowledgement boxes).
+    text = text.replace(/^[ \t]*[-*]\s+\[[ xX]\].*$/gm, "");
+    // Collapse 3+ newline runs to a paragraph break, trim trailing whitespace per line, trim ends.
+    text = text
+        .split("\n")
+        .map((line) => line.replace(/\s+$/, ""))
+        .join("\n")
+        .replace(/\n{3,}/g, "\n\n")
+        .trim();
+    return text;
+}
+/**
  * Strip references that could leak the real fix to the agent:
  * - `#N`, `owner/repo#N`, and `GH-N` cross-references where N >= the issue's
  *   own number (the fix PR is always opened after the issue);

--- a/benchmark/harness/sanitize.ts
+++ b/benchmark/harness/sanitize.ts
@@ -4,6 +4,32 @@ export interface SanitizeResult {
 }
 
 /**
+ * Strip PR-template boilerplate from a PR description before it becomes a problem
+ * statement. PR bodies (unlike issue bodies) commonly carry repo PR-template scaffolding
+ * (e.g. saleor/saleor) that is pure noise and could leak harness/context hints:
+ * - multiline HTML comments `<!-- ... -->` (template instructions);
+ * - a trailing "# Impact" / changelog section and everything after it;
+ * - GitHub-flavoured checklist lines (`- [ ]` / `- [x]`).
+ * The remaining substantive text is collapsed (no 3+ blank-line runs) and trimmed.
+ * Applied in the PR ticket path BEFORE sanitizeIssueBody; the issue path is untouched.
+ */
+export function stripPrTemplate(body: string): string {
+  let text = body.replace(/<!--[\s\S]*?-->/g, "");
+  // Drop a "# Impact" (or "## Impact" ...) heading and everything after it.
+  text = text.replace(/^#{1,6}\s+Impact\b[\s\S]*$/im, "");
+  // Drop any remaining task-list checklist lines (template acknowledgement boxes).
+  text = text.replace(/^[ \t]*[-*]\s+\[[ xX]\].*$/gm, "");
+  // Collapse 3+ newline runs to a paragraph break, trim trailing whitespace per line, trim ends.
+  text = text
+    .split("\n")
+    .map((line) => line.replace(/\s+$/, ""))
+    .join("\n")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+  return text;
+}
+
+/**
  * Strip references that could leak the real fix to the agent:
  * - `#N`, `owner/repo#N`, and `GH-N` cross-references where N >= the issue's
  *   own number (the fix PR is always opened after the issue);

--- a/benchmark/harness/tests/fixtures/gh_pr_view_99_unlinked.json
+++ b/benchmark/harness/tests/fixtures/gh_pr_view_99_unlinked.json
@@ -1,0 +1,14 @@
+{
+  "number": 99,
+  "url": "https://github.com/acme/demo/pull/99",
+  "title": "Fix discount stacking on the checkout total",
+  "body": "<!-- Thanks for your contribution! Describe your change below. -->\nThe checkout total double-counts percentage discounts when more than one voucher applies, so the order total comes out lower than it should. Steps: add two percentage vouchers to a cart and observe the total. Expected: vouchers compose multiplicatively, not additively.\n\n# Impact\n\n- [ ] New feature\n- [x] Bugfix\n- [ ] Documentation",
+  "files": [
+    { "path": "test/checkout.test.ts", "additions": 14, "deletions": 0 },
+    { "path": "src/checkout.ts", "additions": 9, "deletions": 3 }
+  ],
+  "closingIssuesReferences": [],
+  "mergeCommit": { "oid": "aaaa111122223333444455556666777788889999" },
+  "mergedAt": "2025-09-01T12:00:00Z",
+  "author": { "login": "alice", "is_bot": false }
+}

--- a/benchmark/harness/tests/mine_tickets.test.ts
+++ b/benchmark/harness/tests/mine_tickets.test.ts
@@ -58,11 +58,52 @@ describe("mineGithub", () => {
     expect(out.schema_version).toBe(1);
   });
 
-  it("skips PRs with no linked issue", async () => {
+  it("tags issue-linked tickets with source 'issue'", async () => {
+    const out = await mine(baseRoutes());
+    expect(out.tickets).toHaveLength(1);
+    expect(out.tickets[0]!.source).toBe("issue");
+  });
+
+  it("falls back to a PR-as-ticket when no issue is linked", async () => {
     const routes = baseRoutes();
-    routes["pr view 42"] = { ...fxJson<Json>("gh_pr_view_42.json"), closingIssuesReferences: [] };
+    routes["pr view 42"] = fxJson<Json>("gh_pr_view_99_unlinked.json");
+    const out = await mine(routes);
+    expect(out.tickets).toHaveLength(1);
+    const t = out.tickets[0]!;
+    expect(t.source).toBe("pr");
+    expect(t.issue).toBe(99); // PR number serves as the ticket id
+    expect(t.fix_pr).toBe(99);
+    expect(t.issue_url).toBe("https://github.com/acme/demo/pull/99");
+    expect(t.base_commit).toBe("bbbb111122223333444455556666777788880000"); // PR's first parent
+    expect(t.fix_commit).toBe("aaaa111122223333444455556666777788889999"); // PR merge commit
+    expect(t.test_files).toEqual(["test/checkout.test.ts"]);
+    expect(t.src_files).toEqual(["src/checkout.ts"]);
+    // body_sanitized has the template boilerplate stripped:
+    expect(t.body_sanitized).not.toContain("<!--");
+    expect(t.body_sanitized).not.toContain("# Impact");
+    expect(t.body_sanitized).not.toContain("[ ]");
+    expect(t.body_sanitized).not.toContain("[x]");
+    expect(t.body_sanitized).toContain("double-counts percentage discounts");
+  });
+
+  it("still filters PR-as-ticket fallbacks with no test changes", async () => {
+    const routes = baseRoutes();
+    routes["pr view 42"] = {
+      ...fxJson<Json>("gh_pr_view_99_unlinked.json"),
+      files: [{ path: "src/checkout.ts", additions: 9, deletions: 3 }],
+    };
     const out = await mine(routes);
     expect(out.tickets).toHaveLength(0);
+  });
+
+  it("dedupes a PR-as-ticket so it is not double-emitted", async () => {
+    const routes = baseRoutes();
+    const list = fxJson<Json[]>("gh_pr_list.json");
+    const entry42 = { ...(list[0] as Json), number: 99, url: "https://github.com/acme/demo/pull/99" };
+    routes["pr list"] = [entry42, { ...entry42 }];
+    routes["pr view 99"] = fxJson<Json>("gh_pr_view_99_unlinked.json");
+    const out = await mineGithub(CFG, { target: 10, limit: 200, runner: makeGh(routes) });
+    expect(out.tickets).toHaveLength(1);
   });
 
   it("skips references that are actually PRs", async () => {

--- a/benchmark/harness/tests/sanitize.test.ts
+++ b/benchmark/harness/tests/sanitize.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { sanitizeIssueBody } from "../sanitize.js";
+import { sanitizeIssueBody, stripPrTemplate } from "../sanitize.js";
 
 describe("sanitizeIssueBody", () => {
   it("strips cross-references >= the issue number, keeps earlier ones", () => {
@@ -73,5 +73,41 @@ describe("sanitizeIssueBody", () => {
     const r = sanitizeIssueBody("Duplicate of JIRA-1234567.", 50);
     expect(r.text).toBe("Duplicate of JIRA-1234567.");
     expect(r.redactions).toEqual([]);
+  });
+});
+
+describe("stripPrTemplate", () => {
+  it("removes multiline HTML comments", () => {
+    const out = stripPrTemplate(
+      "The cart total is wrong.\n<!-- Please describe\nyour changes here -->\nIt double-counts discounts.",
+    );
+    expect(out).not.toContain("<!--");
+    expect(out).not.toContain("Please describe");
+    expect(out).toContain("The cart total is wrong.");
+    expect(out).toContain("It double-counts discounts.");
+  });
+
+  it("removes a trailing '# Impact' checklist section", () => {
+    const out = stripPrTemplate(
+      "Fix the checkout race condition.\n\n# Impact\n\n- [ ] New feature\n- [x] Bugfix\n- [ ] Docs",
+    );
+    expect(out).toBe("Fix the checkout race condition.");
+    expect(out).not.toContain("Impact");
+    expect(out).not.toContain("[ ]");
+    expect(out).not.toContain("[x]");
+  });
+
+  it("removes stray checklist lines even without an Impact heading", () => {
+    const out = stripPrTemplate("Real description here.\n- [ ] I have tested\n- [x] I added tests");
+    expect(out).toBe("Real description here.");
+  });
+
+  it("collapses blank runs and trims", () => {
+    const out = stripPrTemplate("\n\n  First line.\n\n\n\nSecond line.  \n\n");
+    expect(out).toBe("First line.\n\nSecond line.");
+  });
+
+  it("leaves a clean body unchanged", () => {
+    expect(stripPrTemplate("Just a plain problem statement.")).toBe("Just a plain problem statement.");
   });
 });

--- a/benchmark/harness/types.ts
+++ b/benchmark/harness/types.ts
@@ -45,6 +45,7 @@ export interface TicketCalibration {
 }
 
 export interface TicketRecord {
+  source: "issue" | "pr"; // provenance: "issue" = linked GitHub issue body; "pr" = PR-as-ticket fallback (repo doesn't link issues)
   issue: number;
   issue_url: string;
   title: string;


### PR DESCRIPTION
## Why

Some repos don't link issues to PRs. saleor/saleor is the canonical case: **0/100** recent merged PRs carry a `closingIssuesReference`, so the miner emitted zero benchmark tickets for it (every PR hit `note(pr.number, "no-linked-issue"); continue`).

## What

When `closingIssuesReferences[0]` is undefined, the miner no longer skips. It builds the ticket from the PR itself:

- `source: "pr"`, `issue: pr.number` (the PR number is the ticket id), `issue_url: pr.url`, `title: pr.title`.
- Problem statement = the PR description, run through the **same** `checkEligibility` gates as the issue path (using `pr.files`, `pr.author?.is_bot`, body length, `pr.mergedAt`) — so PRs that are bot-authored / too-large / lack test or source changes are still filtered. A new `gh_pr_view_99_unlinked.json` fixture covers the no-test-changes case staying filtered.
- `base_commit` = the merge commit's first parent (same as the issue path), `fix_commit` = `pr.mergeCommit.oid`.
- A `seenPrs` guard mirrors `seenIssues` for de-dup. The issue-path dedup is untouched.

## `source` field

Every ticket now carries `source: "issue" | "pr"` (added to the `TicketRecord` type and both push sites) so provenance is transparent. Existing issue-path tickets are tagged `source: "issue"`; behavior is otherwise identical and all prior tests pass unchanged.

## body_sanitized for PR-tickets

PR bodies carry repo PR-template boilerplate. A new `stripPrTemplate(body)` helper runs **before** `sanitizeIssueBody` in the PR path only:
- removes multiline HTML comments `<!-- ... -->`,
- removes a trailing `# Impact` section and any `- [ ]`/`- [x]` checklist lines,
- collapses blank runs and trims.

The issue path's sanitization is unchanged.

**thin-body decision:** the prompt the agent receives is always `${title}\n\n${body_sanitized}` (session.ts `buildPrompt`), so the title is itself a meaningful problem statement. A PR-ticket is therefore NOT dropped solely for a short cleaned body — the `thin-body` gate for PR-tickets is computed on `(title.length + cleaned-body.length)` rather than the body alone. Documented inline in `prAsTicket`.

## Contamination note

The change is symmetric across both arms (the same `body_sanitized`/title prompt feeds baseline and wiki runs). Template + boilerplate is stripped and the standard forward-ref/SHA/URL sanitizer still runs on the cleaned PR body, reducing context leakage relative to the raw PR description.

## Tests

- `stripPrTemplate` unit tests (HTML comments, `# Impact` checklist, stray checklist lines, collapse/trim, clean passthrough).
- mine_tickets: PR-as-ticket fallback emits `source:"pr"` with `issue===pr.number`, base/fix commits from the PR, and template-stripped `body_sanitized`; PR with no test changes stays filtered; PR-as-ticket de-dup; issue-linked path still emits `source:"issue"`.

Full suite green (1735 passed / 20 skipped), typecheck + build clean, .ts/.js in sync.