### PR TITLE
fix(benchmark): host timeout couldn't kill sessions whose container ignores SIGTERM

### DIFF
--- a/benchmark/harness/build_wiki.js
+++ b/benchmark/harness/build_wiki.js
@@ -20,6 +20,7 @@ export async function checkWikiIsAncestor(runner, bareDir, wikiCommit, baseCommi
 export function wikiSessionArgs(s) {
     return [
         "run", "--rm",
+        "--name", s.name,
         "-v", `${s.bareDir}:/bare:ro`,
         "-v", `${s.outDir}:/out`,
         "-v", `${s.pluginDir}:/plugin:ro`,
@@ -59,6 +60,9 @@ export async function main(argv) {
         process.stderr.write(`warning: ${ticketsPath} not found — ancestor guard skipped (mine first for full validation)\n`);
     }
     mkdirSync(outDir, { recursive: true });
+    const containerName = `bench-${repo}-wiki-build`;
+    // Clear stale crash leftovers and prevent --name collisions; result ignored.
+    await realRunner("docker", ["rm", "-f", containerName]);
     const args = wikiSessionArgs({
         image: String(values.image ?? `docwiki-bench-${repo}`),
         bareDir,
@@ -66,8 +70,13 @@ export async function main(argv) {
         pluginDir: resolve(String(values.pluginDir ?? ".")),
         wikiCommit: cfg.wiki_commit,
         model: String(values.model ?? "claude-sonnet-4-6"),
+        name: containerName,
     });
     const r = await realRunner("docker", args, { timeoutMs: 4 * 60 * 60 * 1000 });
+    // Host-side timeout SIGKILLs the docker CLI, not the container — reap it so an
+    // orphan can't keep burning quota (full egress + token) or corrupt /out on a re-run.
+    if (r.code !== 0)
+        await realRunner("docker", ["rm", "-f", containerName]);
     process.stderr.write(r.stderr);
     return r.code;
 }

--- a/benchmark/harness/build_wiki.ts
+++ b/benchmark/harness/build_wiki.ts
@@ -32,11 +32,14 @@ export interface WikiBuildSpec {
   pluginDir: string;
   wikiCommit: string;
   model: string;
+  /** Deterministic container name so a timed-out build can be pre-cleaned and reaped (same contract as run_ticket's session container). */
+  name: string;
 }
 
 export function wikiSessionArgs(s: WikiBuildSpec): string[] {
   return [
     "run", "--rm",
+    "--name", s.name,
     "-v", `${s.bareDir}:/bare:ro`,
     "-v", `${s.outDir}:/out`,
     "-v", `${s.pluginDir}:/plugin:ro`,
@@ -79,6 +82,10 @@ export async function main(argv: readonly string[]): Promise<number> {
 
   mkdirSync(outDir, { recursive: true });
 
+  const containerName = `bench-${repo}-wiki-build`;
+  // Clear stale crash leftovers and prevent --name collisions; result ignored.
+  await realRunner("docker", ["rm", "-f", containerName]);
+
   const args = wikiSessionArgs({
     image: String(values.image ?? `docwiki-bench-${repo}`),
     bareDir,
@@ -86,8 +93,12 @@ export async function main(argv: readonly string[]): Promise<number> {
     pluginDir: resolve(String(values.pluginDir ?? ".")),
     wikiCommit: cfg.wiki_commit,
     model: String(values.model ?? "claude-sonnet-4-6"),
+    name: containerName,
   });
   const r = await realRunner("docker", args, { timeoutMs: 4 * 60 * 60 * 1000 });
+  // Host-side timeout SIGKILLs the docker CLI, not the container — reap it so an
+  // orphan can't keep burning quota (full egress + token) or corrupt /out on a re-run.
+  if (r.code !== 0) await realRunner("docker", ["rm", "-f", containerName]);
   process.stderr.write(r.stderr);
   return r.code;
 }

--- a/benchmark/harness/exec.js
+++ b/benchmark/harness/exec.js
@@ -2,6 +2,12 @@ import { execFile } from "node:child_process";
 export const realRunner = (cmd, args, opts = {}) => new Promise((resolve) => {
     execFile(cmd, [...args], {
         timeout: opts.timeoutMs ?? 0,
+        // SIGKILL, not the default SIGTERM: `docker run` catches SIGTERM and proxies it to the
+        // container; a container whose PID1 defers TERM (the session entrypoint while claude runs)
+        // keeps the CLI alive, so the await would block for the container's full lifetime instead
+        // of the deadline. SIGKILL guarantees resolution at timeoutMs; the orphaned container is
+        // reaped by name by the caller (run_ticket reaps on code !== 0).
+        killSignal: "SIGKILL",
         env: opts.env ?? process.env,
         cwd: opts.cwd,
         maxBuffer: 64 * 1024 * 1024, // exceeded → code=1 with truncated stdout; no separate signal

--- a/benchmark/harness/exec.ts
+++ b/benchmark/harness/exec.ts
@@ -23,6 +23,12 @@ export const realRunner: Runner = (cmd, args, opts = {}) =>
       [...args],
       {
         timeout: opts.timeoutMs ?? 0,
+        // SIGKILL, not the default SIGTERM: `docker run` catches SIGTERM and proxies it to the
+        // container; a container whose PID1 defers TERM (the session entrypoint while claude runs)
+        // keeps the CLI alive, so the await would block for the container's full lifetime instead
+        // of the deadline. SIGKILL guarantees resolution at timeoutMs; the orphaned container is
+        // reaped by name by the caller (run_ticket reaps on code !== 0).
+        killSignal: "SIGKILL",
         env: opts.env ?? process.env,
         cwd: opts.cwd,
         maxBuffer: 64 * 1024 * 1024, // exceeded → code=1 with truncated stdout; no separate signal

--- a/benchmark/harness/tests/build_wiki.test.ts
+++ b/benchmark/harness/tests/build_wiki.test.ts
@@ -31,11 +31,21 @@ describe("wikiSessionArgs", () => {
   it("mounts the plugin and overlay dirs dirs", () => {
     const args = wikiSessionArgs({
       image: "docwiki-bench-vitest", bareDir: "/b", outDir: "/o", pluginDir: "/p",
-      wikiCommit: "cccc", model: "claude-sonnet-4-6",
+      wikiCommit: "cccc", model: "claude-sonnet-4-6", name: "bench-vitest-wiki-build",
     });
     expect(args).toContain("/p:/plugin:ro");
     expect(args).toContain("/o:/out");
     expect(args).toContain("CLAUDE_CODE_OAUTH_TOKEN"); // name-only
     expect(args[args.length - 1]).toBe("wiki-build");
+  });
+
+  it("names the container so a timed-out build can be pre-cleaned and reaped", () => {
+    const args = wikiSessionArgs({
+      image: "docwiki-bench-vitest", bareDir: "/b", outDir: "/o", pluginDir: "/p",
+      wikiCommit: "cccc", model: "claude-sonnet-4-6", name: "bench-vitest-wiki-build",
+    });
+    const i = args.indexOf("--name");
+    expect(i).toBeGreaterThan(-1);
+    expect(args[i + 1]).toBe("bench-vitest-wiki-build");
   });
 });

--- a/benchmark/harness/tests/exec.test.ts
+++ b/benchmark/harness/tests/exec.test.ts
@@ -20,3 +20,19 @@ describe("realRunner error mapping", () => {
     expect(r.code).toBe(1);
   });
 });
+
+describe("realRunner timeout", () => {
+  it("enforces timeoutMs with SIGKILL even when the child ignores SIGTERM", async () => {
+    // Without killSignal: "SIGKILL" the default SIGTERM is ignored by this child and the
+    // await blocks for its full 8s lifetime instead of the 400ms deadline (bug #108 shape:
+    // docker CLI proxying TERM to a container whose PID1 defers it).
+    const t0 = Date.now();
+    const r = await realRunner(
+      "node",
+      ["-e", 'process.on("SIGTERM", () => {}); setTimeout(() => {}, 8000);'],
+      { timeoutMs: 400 },
+    );
+    expect(Date.now() - t0).toBeLessThan(4000);
+    expect(r.code).not.toBe(0);
+  });
+});


### PR DESCRIPTION
## Why
Bug #108: a hung session container blocked its arm for the container's full lifetime instead of the host timeout. Live repro: 3s `timeoutMs` against a container whose PID1 traps SIGTERM → the await resolved after **25.7s** (the container's natural lifetime) with code 0. Cause: execFile's default `killSignal` is SIGTERM; the `docker run` CLI catches it and proxies to the container, the session entrypoint defers TERM while `claude` runs, so nothing dies and nothing escalates.

## Fix
`killSignal: "SIGKILL"` in `realRunner` — uncatchable, so the CLI dies at the deadline and the await resolves (code 1). The orphaned container is then reaped by the existing named `docker rm -f` in run_ticket (landed in #70). Live-verified: same repro resolves at **3.0s**, code 1, container reaped.

## Test
Regression test with a SIGTERM-ignoring node child: fails against the pre-fix build (await outlives the deadline), passes post-fix (<4s bound, code≠0).