### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Unbounded SELECT Bounding Bypass

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-06-12 - Fix Bypass of Unbounded Select with Comments
+**Vulnerability:** The DB policy's bounding check (`Policy._isUnboundedSelect`) was bypassing unbounded query checks if the SQL query contained comments with bounding keywords like `WHERE` (e.g. `SELECT * FROM users /* WHERE */`).
+**Learning:** Checking for SQL security keywords against raw strings before stripping comments can lead to attackers or users accidentally bypassing safety mechanisms.
+**Prevention:** Always strip comments or normalize queries before applying heuristic checks or regexes on SQL commands.

--- a/agents/lib/wiki_db/policy.js
+++ b/agents/lib/wiki_db/policy.js
@@ -96,7 +96,9 @@ const _EXEC_COMMENT_RE = /\/\*[A-Za-z]*!/;
  *
  * Python uses `re.IGNORECASE | re.DOTALL`; in JS we emulate with `is` flags.
  */
-const _UNBOUNDED_RE = /^\s*SELECT\s+.*\bFROM\s+\w+/is;
+// The table name may be a quoted identifier (`FROM "users"`, MySQL
+// `FROM \`users\``), so accept an opening quote as well as a word character.
+const _UNBOUNDED_RE = /^\s*SELECT\s+.*\bFROM\s+["'`\w]/is;
 // G-POLICY-CROSSJOIN: require JOIN ... ON so CROSS JOIN (which has no
 // join predicate and explodes rows) does not count as bounded. Bare
 // JOIN USING (…) also falls through to escalate — safe direction.
@@ -154,11 +156,15 @@ export class Policy {
     // Unbounded query heuristic
     // ------------------------------------------------------------------
     /**
-     * Replace the contents of single- or double-quoted string literals with spaces.
-     * This is a heuristic masker so string contents don't confuse keyword checks.
+     * Replace the contents of quoted spans with spaces so their text cannot
+     * satisfy a keyword check. Covers single and double quotes plus the
+     * MySQL/MariaDB backtick. A backtick span is an identifier rather than a
+     * string literal, but its contents are equally inert: without masking,
+     * `SELECT \`where\` FROM users` matched _BOUNDED_KEYWORDS_RE on the column
+     * name and a full-table read was classified bounded.
      */
     static _maskStringLiterals(sql) {
-        return sql.replace(/(['"])(?:(?!\1)[^\\]|\\.)*\1/g, (match) => " ".repeat(match.length));
+        return sql.replace(/(['"`])(?:(?!\1)[^\\]|\\.)*\1/g, (match) => " ".repeat(match.length));
     }
     /** Return true if the SELECT appears to lack a bounding clause. */
     static _isUnboundedSelect(sql) {
@@ -169,9 +175,14 @@ export class Policy {
         // likewise stripped here but run on the server. So evaluate the heuristic on
         // BOTH the raw and the comment-stripped text and escalate if either looks
         // unbounded; always escalate when an executable comment is present.
+        // Ask the two questions of different views of the text. "Does this read
+        // from a table?" is a question about real syntax, so it runs on the raw
+        // text: masking blanks a quoted table name (`FROM \`users\``) and left the
+        // statement looking like no FROM at all, which read as bounded. "Is there
+        // a bounding clause?" must ignore quoted spans, so it runs on the mask.
         const looksUnbounded = (text) => {
             const masked = Policy._maskStringLiterals(text);
-            return _UNBOUNDED_RE.test(masked) && !_BOUNDED_KEYWORDS_RE.test(masked);
+            return _UNBOUNDED_RE.test(text) && !_BOUNDED_KEYWORDS_RE.test(masked);
         };
         if (_EXEC_COMMENT_RE.test(sql))
             return true;

--- a/agents/lib/wiki_db/policy.js
+++ b/agents/lib/wiki_db/policy.js
@@ -89,9 +89,6 @@ export function classifySqlKeywords(sql) {
 const _LINE_COMMENT_RE = /--[^\n]*/g;
 // Python uses re.DOTALL so `.` matches newlines; in JS use the `s` flag.
 const _BLOCK_COMMENT_RE = /\/\*.*?\*\//gs;
-// MySQL/MariaDB executable comments (`/*! ... */`) run on the server, so they
-// must never be treated as inert when deciding whether a read is unbounded.
-const _EXEC_COMMENT_RE = /\/\*!/;
 /**
  * Heuristic: a SELECT is "unbounded" if it reads from a table but has
  * no WHERE, LIMIT, JOIN, or specific id filter.
@@ -157,17 +154,20 @@ export class Policy {
     // ------------------------------------------------------------------
     /** Return true if the SELECT appears to lack a bounding clause. */
     static _isUnboundedSelect(sql) {
-        // Fail closed: the regex `_stripComments` is not string-literal-aware, so a
-        // `/* ... */` that opens inside a quoted literal (e.g. `SELECT '/*' ... FROM
-        // users ... '*/'`) gets deleted along with the real `FROM users`, making an
-        // unbounded scan look bounded. MySQL executable comments (`/*! ... */`) are
-        // likewise stripped here but run on the server. So evaluate the heuristic on
-        // BOTH the raw and the comment-stripped text and escalate if either looks
-        // unbounded; always escalate when an executable comment is present.
-        const looksUnbounded = (text) => _UNBOUNDED_RE.test(text) && !_BOUNDED_KEYWORDS_RE.test(text);
-        if (_EXEC_COMMENT_RE.test(sql))
+        // MySQL executable comments (/*! ... */) run on MySQL servers. Since our
+        // naive strip drops them, we preemptively escalate to be safe.
+        if (sql.includes("/*!"))
             return true;
-        return looksUnbounded(sql) || looksUnbounded(Policy._stripComments(sql));
+        // A literal-unaware strip might delete parts of a string literal that look
+        // like comments. We run the heuristics on both raw and stripped versions
+        // and escalate if *either* looks unbounded.
+        const isUnbounded = (s) => {
+            if (!_UNBOUNDED_RE.test(s))
+                return false;
+            return !_BOUNDED_KEYWORDS_RE.test(s);
+        };
+        const cleaned = Policy._stripComments(sql);
+        return isUnbounded(sql) || isUnbounded(cleaned);
     }
     // ------------------------------------------------------------------
     // Decision logic

--- a/agents/lib/wiki_db/policy.js
+++ b/agents/lib/wiki_db/policy.js
@@ -89,42 +89,7 @@ export function classifySqlKeywords(sql) {
 const _LINE_COMMENT_RE = /--[^\n]*/g;
 // Python uses re.DOTALL so `.` matches newlines; in JS use the `s` flag.
 const _BLOCK_COMMENT_RE = /\/\*.*?\*\//gs;
-// Executable comments run on the server and must never be treated as inert:
-// MySQL uses `/*! ... */`; MariaDB also runs `/*M! ... */` (optional version).
 const _EXEC_COMMENT_RE = /\/\*[A-Za-z]*!/;
-/**
- * Replace the contents of single-, double-, and backtick-quoted string
- * literals with spaces, keeping the delimiters and overall length. Used by
- * `_isUnboundedSelect` so a bounding keyword that appears only inside a literal
- * (e.g. `SELECT 'WHERE /*' ... FROM users`) can't make a full-table scan look
- * bounded. Handles SQL-standard `''` doubling.
- */
-function _maskStringLiterals(sql) {
-    const out = sql.split("");
-    let inString = null;
-    for (let i = 0; i < sql.length; i++) {
-        const c = sql[i];
-        if (inString !== null) {
-            if (c === inString) {
-                if (i + 1 < sql.length && sql[i + 1] === inString) {
-                    out[i] = " ";
-                    out[i + 1] = " ";
-                    i++; // skip the doubled (escaped) quote
-                }
-                else {
-                    inString = null; // keep the closing delimiter
-                }
-            }
-            else {
-                out[i] = " ";
-            }
-        }
-        else if (c === "'" || c === '"' || c === "`") {
-            inString = c;
-        }
-    }
-    return out.join("");
-}
 /**
  * Heuristic: a SELECT is "unbounded" if it reads from a table but has
  * no WHERE, LIMIT, JOIN, or specific id filter.
@@ -188,29 +153,29 @@ export class Policy {
     // ------------------------------------------------------------------
     // Unbounded query heuristic
     // ------------------------------------------------------------------
+    /**
+     * Replace the contents of single- or double-quoted string literals with spaces.
+     * This is a heuristic masker so string contents don't confuse keyword checks.
+     */
+    static _maskStringLiterals(sql) {
+        return sql.replace(/(['"])(?:(?!\1)[^\\]|\\.)*\1/g, (match) => " ".repeat(match.length));
+    }
     /** Return true if the SELECT appears to lack a bounding clause. */
     static _isUnboundedSelect(sql) {
-        // Executable comments (/*! ... */, MariaDB /*M! ... */) run on the server.
-        // Our naive strip drops them, so preemptively escalate to be safe.
+        // Fail closed: the regex `_stripComments` is not string-literal-aware, so a
+        // `/* ... */` that opens inside a quoted literal (e.g. `SELECT '/*' ... FROM
+        // users ... '*/'`) gets deleted along with the real `FROM users`, making an
+        // unbounded scan look bounded. MySQL executable comments (`/*! ... */`) are
+        // likewise stripped here but run on the server. So evaluate the heuristic on
+        // BOTH the raw and the comment-stripped text and escalate if either looks
+        // unbounded; always escalate when an executable comment is present.
+        const looksUnbounded = (text) => {
+            const masked = Policy._maskStringLiterals(text);
+            return _UNBOUNDED_RE.test(masked) && !_BOUNDED_KEYWORDS_RE.test(masked);
+        };
         if (_EXEC_COMMENT_RE.test(sql))
             return true;
-        const isUnbounded = (s) => {
-            if (!_UNBOUNDED_RE.test(s))
-                return false;
-            return !_BOUNDED_KEYWORDS_RE.test(s);
-        };
-        // The regex strip is not string-literal-aware, so evaluate the heuristic on
-        // three views and escalate if ANY looks unbounded:
-        //   - raw text: catches a real `FROM` hidden when the strip deletes a
-        //     literal that contains a fake comment (`SELECT '/*' ... FROM users`);
-        //   - comment-stripped: catches a real `FROM` when a comment legitimately
-        //     hides a bounding keyword;
-        //   - literal-masked: catches a bounding keyword that appears only inside a
-        //     string literal (`SELECT 'WHERE /*' ... FROM users`), which would
-        //     otherwise make the raw text look bounded.
-        const cleaned = Policy._stripComments(sql);
-        const masked = _maskStringLiterals(sql);
-        return isUnbounded(sql) || isUnbounded(cleaned) || isUnbounded(masked);
+        return looksUnbounded(sql) || looksUnbounded(Policy._stripComments(sql));
     }
     // ------------------------------------------------------------------
     // Decision logic

--- a/agents/lib/wiki_db/policy.js
+++ b/agents/lib/wiki_db/policy.js
@@ -35,17 +35,29 @@ export const OperationType = {
 // Keyword -> OperationType mapping
 // -----------------------------------------------------------------------
 const _READ_KEYWORDS = new Set([
-    "SELECT", "EXPLAIN", "SHOW", "DESCRIBE", "DESC", "WITH",
+    "SELECT",
+    "EXPLAIN",
+    "SHOW",
+    "DESCRIBE",
+    "DESC",
+    "WITH",
 ]);
 const _DML_KEYWORDS = new Set([
-    "INSERT", "UPDATE", "DELETE", "REPLACE", "MERGE", "UPSERT",
+    "INSERT",
+    "UPDATE",
+    "DELETE",
+    "REPLACE",
+    "MERGE",
+    "UPSERT",
 ]);
 const _DDL_KEYWORDS = new Set([
-    "CREATE", "DROP", "ALTER", "TRUNCATE", "RENAME",
+    "CREATE",
+    "DROP",
+    "ALTER",
+    "TRUNCATE",
+    "RENAME",
 ]);
-const _PRIVILEGE_KEYWORDS = new Set([
-    "GRANT", "REVOKE",
-]);
+const _PRIVILEGE_KEYWORDS = new Set(["GRANT", "REVOKE"]);
 /**
  * Classify a SQL string by its leading keyword.
  *
@@ -89,7 +101,10 @@ const _UNBOUNDED_RE = /^\s*SELECT\s+.*\bFROM\s+\w+/is;
 // JOIN USING (…) also falls through to escalate — safe direction.
 const _BOUNDED_KEYWORDS_RE = /\b(WHERE|LIMIT|OFFSET|HAVING|GROUP\s+BY|JOIN\s+\S+\s+ON)\b/i;
 const _VALID_APPROVAL_MODES = new Set([
-    "auto", "confirm_once", "confirm_each", "grant_required",
+    "auto",
+    "confirm_once",
+    "confirm_each",
+    "grant_required",
 ]);
 /**
  * Stateful policy engine that gates SQL execution.
@@ -161,15 +176,19 @@ export class Policy {
     checkQuery(sql, driver) {
         const stripped = sql.trim();
         if (!stripped) {
-            const result = { decision: "deny", reason: "Empty SQL statement" };
+            const result = {
+                decision: "deny",
+                reason: "Empty SQL statement",
+            };
             _emitDeny(result.reason, null);
             return result;
         }
         let op;
         try {
-            op = driver !== undefined
-                ? driver.classifyOperation(stripped)
-                : this.classifySql(stripped);
+            op =
+                driver !== undefined
+                    ? driver.classifyOperation(stripped)
+                    : this.classifySql(stripped);
         }
         catch (exc) {
             const reason = exc.message;
@@ -352,9 +371,7 @@ function _emitPresentOnly(reason, op, formattedSql) {
     // Scrub credentials before truncation so a literal split by truncation
     // can't leak. Same helper used by audit.logQuery.
     const scrubbed = scrubSqlSecrets(formattedSql);
-    const truncated = scrubbed.length > 500
-        ? scrubbed.slice(0, 500) + "\u2026"
-        : scrubbed;
+    const truncated = scrubbed.length > 500 ? scrubbed.slice(0, 500) + "\u2026" : scrubbed;
     const details = {
         reason,
         formatted_sql: truncated,

--- a/agents/lib/wiki_db/policy.js
+++ b/agents/lib/wiki_db/policy.js
@@ -89,6 +89,42 @@ export function classifySqlKeywords(sql) {
 const _LINE_COMMENT_RE = /--[^\n]*/g;
 // Python uses re.DOTALL so `.` matches newlines; in JS use the `s` flag.
 const _BLOCK_COMMENT_RE = /\/\*.*?\*\//gs;
+// Executable comments run on the server and must never be treated as inert:
+// MySQL uses `/*! ... */`; MariaDB also runs `/*M! ... */` (optional version).
+const _EXEC_COMMENT_RE = /\/\*[A-Za-z]*!/;
+/**
+ * Replace the contents of single-, double-, and backtick-quoted string
+ * literals with spaces, keeping the delimiters and overall length. Used by
+ * `_isUnboundedSelect` so a bounding keyword that appears only inside a literal
+ * (e.g. `SELECT 'WHERE /*' ... FROM users`) can't make a full-table scan look
+ * bounded. Handles SQL-standard `''` doubling.
+ */
+function _maskStringLiterals(sql) {
+    const out = sql.split("");
+    let inString = null;
+    for (let i = 0; i < sql.length; i++) {
+        const c = sql[i];
+        if (inString !== null) {
+            if (c === inString) {
+                if (i + 1 < sql.length && sql[i + 1] === inString) {
+                    out[i] = " ";
+                    out[i + 1] = " ";
+                    i++; // skip the doubled (escaped) quote
+                }
+                else {
+                    inString = null; // keep the closing delimiter
+                }
+            }
+            else {
+                out[i] = " ";
+            }
+        }
+        else if (c === "'" || c === '"' || c === "`") {
+            inString = c;
+        }
+    }
+    return out.join("");
+}
 /**
  * Heuristic: a SELECT is "unbounded" if it reads from a table but has
  * no WHERE, LIMIT, JOIN, or specific id filter.
@@ -154,20 +190,27 @@ export class Policy {
     // ------------------------------------------------------------------
     /** Return true if the SELECT appears to lack a bounding clause. */
     static _isUnboundedSelect(sql) {
-        // MySQL executable comments (/*! ... */) run on MySQL servers. Since our
-        // naive strip drops them, we preemptively escalate to be safe.
-        if (sql.includes("/*!"))
+        // Executable comments (/*! ... */, MariaDB /*M! ... */) run on the server.
+        // Our naive strip drops them, so preemptively escalate to be safe.
+        if (_EXEC_COMMENT_RE.test(sql))
             return true;
-        // A literal-unaware strip might delete parts of a string literal that look
-        // like comments. We run the heuristics on both raw and stripped versions
-        // and escalate if *either* looks unbounded.
         const isUnbounded = (s) => {
             if (!_UNBOUNDED_RE.test(s))
                 return false;
             return !_BOUNDED_KEYWORDS_RE.test(s);
         };
+        // The regex strip is not string-literal-aware, so evaluate the heuristic on
+        // three views and escalate if ANY looks unbounded:
+        //   - raw text: catches a real `FROM` hidden when the strip deletes a
+        //     literal that contains a fake comment (`SELECT '/*' ... FROM users`);
+        //   - comment-stripped: catches a real `FROM` when a comment legitimately
+        //     hides a bounding keyword;
+        //   - literal-masked: catches a bounding keyword that appears only inside a
+        //     string literal (`SELECT 'WHERE /*' ... FROM users`), which would
+        //     otherwise make the raw text look bounded.
         const cleaned = Policy._stripComments(sql);
-        return isUnbounded(sql) || isUnbounded(cleaned);
+        const masked = _maskStringLiterals(sql);
+        return isUnbounded(sql) || isUnbounded(cleaned) || isUnbounded(masked);
     }
     // ------------------------------------------------------------------
     // Decision logic

--- a/agents/lib/wiki_db/policy.js
+++ b/agents/lib/wiki_db/policy.js
@@ -89,6 +89,9 @@ export function classifySqlKeywords(sql) {
 const _LINE_COMMENT_RE = /--[^\n]*/g;
 // Python uses re.DOTALL so `.` matches newlines; in JS use the `s` flag.
 const _BLOCK_COMMENT_RE = /\/\*.*?\*\//gs;
+// MySQL/MariaDB executable comments (`/*! ... */`) run on the server, so they
+// must never be treated as inert when deciding whether a read is unbounded.
+const _EXEC_COMMENT_RE = /\/\*!/;
 /**
  * Heuristic: a SELECT is "unbounded" if it reads from a table but has
  * no WHERE, LIMIT, JOIN, or specific id filter.
@@ -154,10 +157,17 @@ export class Policy {
     // ------------------------------------------------------------------
     /** Return true if the SELECT appears to lack a bounding clause. */
     static _isUnboundedSelect(sql) {
-        const cleaned = Policy._stripComments(sql);
-        if (!_UNBOUNDED_RE.test(cleaned))
-            return false;
-        return !_BOUNDED_KEYWORDS_RE.test(cleaned);
+        // Fail closed: the regex `_stripComments` is not string-literal-aware, so a
+        // `/* ... */` that opens inside a quoted literal (e.g. `SELECT '/*' ... FROM
+        // users ... '*/'`) gets deleted along with the real `FROM users`, making an
+        // unbounded scan look bounded. MySQL executable comments (`/*! ... */`) are
+        // likewise stripped here but run on the server. So evaluate the heuristic on
+        // BOTH the raw and the comment-stripped text and escalate if either looks
+        // unbounded; always escalate when an executable comment is present.
+        const looksUnbounded = (text) => _UNBOUNDED_RE.test(text) && !_BOUNDED_KEYWORDS_RE.test(text);
+        if (_EXEC_COMMENT_RE.test(sql))
+            return true;
+        return looksUnbounded(sql) || looksUnbounded(Policy._stripComments(sql));
     }
     // ------------------------------------------------------------------
     // Decision logic

--- a/agents/lib/wiki_db/policy.js
+++ b/agents/lib/wiki_db/policy.js
@@ -119,7 +119,12 @@ export class Policy {
     // ------------------------------------------------------------------
     // SQL classification
     // ------------------------------------------------------------------
-    /** Remove SQL comments from the statement. */
+    /**
+     * Remove SQL comments from the statement.
+     * Note: Block comments are replaced with a space (" ") rather than an empty
+     * string. This ensures that an attacker cannot synthesize a keyword to bypass
+     * checks. For example, `WHE/*x*\/RE` will become `WHE RE` instead of `WHERE`.
+     */
     static _stripComments(sql) {
         let s = sql.replace(_BLOCK_COMMENT_RE, " ");
         s = s.replace(_LINE_COMMENT_RE, "");

--- a/agents/lib/wiki_db/policy.js
+++ b/agents/lib/wiki_db/policy.js
@@ -121,8 +121,13 @@ export class Policy {
     // ------------------------------------------------------------------
     /** Remove SQL comments from the statement. */
     static _stripComments(sql) {
-        let s = sql.replace(_BLOCK_COMMENT_RE, "");
-        s = s.replace(_LINE_COMMENT_RE, "");
+        // Replace comments with a single space, not "", so that a comment
+        // wedged inside a token cannot fuse two fragments into a keyword the
+        // raw SQL never contained. Stripping to "" would turn
+        // `SELECT WHE/*x*/RE FROM t` into `SELECT WHERE FROM t`, synthesizing a
+        // bounding `WHERE` and letting an unbounded scan auto-allow.
+        let s = sql.replace(_BLOCK_COMMENT_RE, " ");
+        s = s.replace(_LINE_COMMENT_RE, " ");
         return s.trim();
     }
     /** Determine the OperationType of a raw SQL string. */

--- a/agents/lib/wiki_db/policy.js
+++ b/agents/lib/wiki_db/policy.js
@@ -121,13 +121,8 @@ export class Policy {
     // ------------------------------------------------------------------
     /** Remove SQL comments from the statement. */
     static _stripComments(sql) {
-        // Replace comments with a single space, not "", so that a comment
-        // wedged inside a token cannot fuse two fragments into a keyword the
-        // raw SQL never contained. Stripping to "" would turn
-        // `SELECT WHE/*x*/RE FROM t` into `SELECT WHERE FROM t`, synthesizing a
-        // bounding `WHERE` and letting an unbounded scan auto-allow.
         let s = sql.replace(_BLOCK_COMMENT_RE, " ");
-        s = s.replace(_LINE_COMMENT_RE, " ");
+        s = s.replace(_LINE_COMMENT_RE, "");
         return s.trim();
     }
     /** Determine the OperationType of a raw SQL string. */

--- a/agents/lib/wiki_db/policy.js
+++ b/agents/lib/wiki_db/policy.js
@@ -134,9 +134,10 @@ export class Policy {
     // ------------------------------------------------------------------
     /** Return true if the SELECT appears to lack a bounding clause. */
     static _isUnboundedSelect(sql) {
-        if (!_UNBOUNDED_RE.test(sql))
+        const cleaned = Policy._stripComments(sql);
+        if (!_UNBOUNDED_RE.test(cleaned))
             return false;
-        return !_BOUNDED_KEYWORDS_RE.test(sql);
+        return !_BOUNDED_KEYWORDS_RE.test(cleaned);
     }
     // ------------------------------------------------------------------
     // Decision logic

--- a/agents/lib/wiki_db/policy.ts
+++ b/agents/lib/wiki_db/policy.ts
@@ -97,6 +97,40 @@ export function classifySqlKeywords(sql: string): OperationType {
 const _LINE_COMMENT_RE = /--[^\n]*/g;
 // Python uses re.DOTALL so `.` matches newlines; in JS use the `s` flag.
 const _BLOCK_COMMENT_RE = /\/\*.*?\*\//gs;
+// Executable comments run on the server and must never be treated as inert:
+// MySQL uses `/*! ... */`; MariaDB also runs `/*M! ... */` (optional version).
+const _EXEC_COMMENT_RE = /\/\*[A-Za-z]*!/;
+
+/**
+ * Replace the contents of single-, double-, and backtick-quoted string
+ * literals with spaces, keeping the delimiters and overall length. Used by
+ * `_isUnboundedSelect` so a bounding keyword that appears only inside a literal
+ * (e.g. `SELECT 'WHERE /*' ... FROM users`) can't make a full-table scan look
+ * bounded. Handles SQL-standard `''` doubling.
+ */
+function _maskStringLiterals(sql: string): string {
+  const out = sql.split("");
+  let inString: string | null = null;
+  for (let i = 0; i < sql.length; i++) {
+    const c = sql[i];
+    if (inString !== null) {
+      if (c === inString) {
+        if (i + 1 < sql.length && sql[i + 1] === inString) {
+          out[i] = " ";
+          out[i + 1] = " ";
+          i++; // skip the doubled (escaped) quote
+        } else {
+          inString = null; // keep the closing delimiter
+        }
+      } else {
+        out[i] = " ";
+      }
+    } else if (c === "'" || c === '"' || c === "`") {
+      inString = c;
+    }
+  }
+  return out.join("");
+}
 
 /**
  * Heuristic: a SELECT is "unbounded" if it reads from a table but has
@@ -178,20 +212,27 @@ export class Policy {
 
   /** Return true if the SELECT appears to lack a bounding clause. */
   static _isUnboundedSelect(sql: string): boolean {
-    // MySQL executable comments (/*! ... */) run on MySQL servers. Since our
-    // naive strip drops them, we preemptively escalate to be safe.
-    if (sql.includes("/*!")) return true;
+    // Executable comments (/*! ... */, MariaDB /*M! ... */) run on the server.
+    // Our naive strip drops them, so preemptively escalate to be safe.
+    if (_EXEC_COMMENT_RE.test(sql)) return true;
 
-    // A literal-unaware strip might delete parts of a string literal that look
-    // like comments. We run the heuristics on both raw and stripped versions
-    // and escalate if *either* looks unbounded.
     const isUnbounded = (s: string) => {
       if (!_UNBOUNDED_RE.test(s)) return false;
       return !_BOUNDED_KEYWORDS_RE.test(s);
     };
 
+    // The regex strip is not string-literal-aware, so evaluate the heuristic on
+    // three views and escalate if ANY looks unbounded:
+    //   - raw text: catches a real `FROM` hidden when the strip deletes a
+    //     literal that contains a fake comment (`SELECT '/*' ... FROM users`);
+    //   - comment-stripped: catches a real `FROM` when a comment legitimately
+    //     hides a bounding keyword;
+    //   - literal-masked: catches a bounding keyword that appears only inside a
+    //     string literal (`SELECT 'WHERE /*' ... FROM users`), which would
+    //     otherwise make the raw text look bounded.
     const cleaned = Policy._stripComments(sql);
-    return isUnbounded(sql) || isUnbounded(cleaned);
+    const masked = _maskStringLiterals(sql);
+    return isUnbounded(sql) || isUnbounded(cleaned) || isUnbounded(masked);
   }
 
   // ------------------------------------------------------------------

--- a/agents/lib/wiki_db/policy.ts
+++ b/agents/lib/wiki_db/policy.ts
@@ -142,13 +142,8 @@ export class Policy {
 
   /** Remove SQL comments from the statement. */
   static _stripComments(sql: string): string {
-    // Replace comments with a single space, not "", so that a comment
-    // wedged inside a token cannot fuse two fragments into a keyword the
-    // raw SQL never contained. Stripping to "" would turn
-    // `SELECT WHE/*x*/RE FROM t` into `SELECT WHERE FROM t`, synthesizing a
-    // bounding `WHERE` and letting an unbounded scan auto-allow.
     let s = sql.replace(_BLOCK_COMMENT_RE, " ");
-    s = s.replace(_LINE_COMMENT_RE, " ");
+    s = s.replace(_LINE_COMMENT_RE, "");
     return s.trim();
   }
 

--- a/agents/lib/wiki_db/policy.ts
+++ b/agents/lib/wiki_db/policy.ts
@@ -43,17 +43,29 @@ export const OperationType = {
 // -----------------------------------------------------------------------
 
 const _READ_KEYWORDS: ReadonlySet<string> = new Set([
-  "SELECT", "EXPLAIN", "SHOW", "DESCRIBE", "DESC", "WITH",
+  "SELECT",
+  "EXPLAIN",
+  "SHOW",
+  "DESCRIBE",
+  "DESC",
+  "WITH",
 ]);
 const _DML_KEYWORDS: ReadonlySet<string> = new Set([
-  "INSERT", "UPDATE", "DELETE", "REPLACE", "MERGE", "UPSERT",
+  "INSERT",
+  "UPDATE",
+  "DELETE",
+  "REPLACE",
+  "MERGE",
+  "UPSERT",
 ]);
 const _DDL_KEYWORDS: ReadonlySet<string> = new Set([
-  "CREATE", "DROP", "ALTER", "TRUNCATE", "RENAME",
+  "CREATE",
+  "DROP",
+  "ALTER",
+  "TRUNCATE",
+  "RENAME",
 ]);
-const _PRIVILEGE_KEYWORDS: ReadonlySet<string> = new Set([
-  "GRANT", "REVOKE",
-]);
+const _PRIVILEGE_KEYWORDS: ReadonlySet<string> = new Set(["GRANT", "REVOKE"]);
 
 /**
  * Classify a SQL string by its leading keyword.
@@ -106,7 +118,10 @@ export type ApprovalMode =
   | "grant_required";
 
 const _VALID_APPROVAL_MODES: ReadonlySet<ApprovalMode> = new Set([
-  "auto", "confirm_once", "confirm_each", "grant_required",
+  "auto",
+  "confirm_once",
+  "confirm_each",
+  "grant_required",
 ]);
 
 /**
@@ -158,8 +173,9 @@ export class Policy {
 
   /** Return true if the SELECT appears to lack a bounding clause. */
   static _isUnboundedSelect(sql: string): boolean {
-    if (!_UNBOUNDED_RE.test(sql)) return false;
-    return !_BOUNDED_KEYWORDS_RE.test(sql);
+    const cleaned = Policy._stripComments(sql);
+    if (!_UNBOUNDED_RE.test(cleaned)) return false;
+    return !_BOUNDED_KEYWORDS_RE.test(cleaned);
   }
 
   // ------------------------------------------------------------------
@@ -180,16 +196,20 @@ export class Policy {
   checkQuery(sql: string, driver?: DatabaseDriver): PolicyResult {
     const stripped = sql.trim();
     if (!stripped) {
-      const result: PolicyResult = { decision: "deny", reason: "Empty SQL statement" };
+      const result: PolicyResult = {
+        decision: "deny",
+        reason: "Empty SQL statement",
+      };
       _emitDeny(result.reason, null);
       return result;
     }
 
     let op: OperationType;
     try {
-      op = driver !== undefined
-        ? driver.classifyOperation(stripped)
-        : this.classifySql(stripped);
+      op =
+        driver !== undefined
+          ? driver.classifyOperation(stripped)
+          : this.classifySql(stripped);
     } catch (exc) {
       const reason = (exc as Error).message;
       _emitDeny(reason, null);
@@ -398,9 +418,7 @@ function _emitPresentOnly(
   // can't leak. Same helper used by audit.logQuery.
   const scrubbed = scrubSqlSecrets(formattedSql);
   const truncated =
-    scrubbed.length > 500
-      ? scrubbed.slice(0, 500) + "\u2026"
-      : scrubbed;
+    scrubbed.length > 500 ? scrubbed.slice(0, 500) + "\u2026" : scrubbed;
   const details: Record<string, unknown> = {
     reason,
     formatted_sql: truncated,

--- a/agents/lib/wiki_db/policy.ts
+++ b/agents/lib/wiki_db/policy.ts
@@ -97,9 +97,6 @@ export function classifySqlKeywords(sql: string): OperationType {
 const _LINE_COMMENT_RE = /--[^\n]*/g;
 // Python uses re.DOTALL so `.` matches newlines; in JS use the `s` flag.
 const _BLOCK_COMMENT_RE = /\/\*.*?\*\//gs;
-// MySQL/MariaDB executable comments (`/*! ... */`) run on the server, so they
-// must never be treated as inert when deciding whether a read is unbounded.
-const _EXEC_COMMENT_RE = /\/\*!/;
 
 /**
  * Heuristic: a SELECT is "unbounded" if it reads from a table but has
@@ -181,17 +178,20 @@ export class Policy {
 
   /** Return true if the SELECT appears to lack a bounding clause. */
   static _isUnboundedSelect(sql: string): boolean {
-    // Fail closed: the regex `_stripComments` is not string-literal-aware, so a
-    // `/* ... */` that opens inside a quoted literal (e.g. `SELECT '/*' ... FROM
-    // users ... '*/'`) gets deleted along with the real `FROM users`, making an
-    // unbounded scan look bounded. MySQL executable comments (`/*! ... */`) are
-    // likewise stripped here but run on the server. So evaluate the heuristic on
-    // BOTH the raw and the comment-stripped text and escalate if either looks
-    // unbounded; always escalate when an executable comment is present.
-    const looksUnbounded = (text: string): boolean =>
-      _UNBOUNDED_RE.test(text) && !_BOUNDED_KEYWORDS_RE.test(text);
-    if (_EXEC_COMMENT_RE.test(sql)) return true;
-    return looksUnbounded(sql) || looksUnbounded(Policy._stripComments(sql));
+    // MySQL executable comments (/*! ... */) run on MySQL servers. Since our
+    // naive strip drops them, we preemptively escalate to be safe.
+    if (sql.includes("/*!")) return true;
+
+    // A literal-unaware strip might delete parts of a string literal that look
+    // like comments. We run the heuristics on both raw and stripped versions
+    // and escalate if *either* looks unbounded.
+    const isUnbounded = (s: string) => {
+      if (!_UNBOUNDED_RE.test(s)) return false;
+      return !_BOUNDED_KEYWORDS_RE.test(s);
+    };
+
+    const cleaned = Policy._stripComments(sql);
+    return isUnbounded(sql) || isUnbounded(cleaned);
   }
 
   // ------------------------------------------------------------------

--- a/agents/lib/wiki_db/policy.ts
+++ b/agents/lib/wiki_db/policy.ts
@@ -142,8 +142,13 @@ export class Policy {
 
   /** Remove SQL comments from the statement. */
   static _stripComments(sql: string): string {
-    let s = sql.replace(_BLOCK_COMMENT_RE, "");
-    s = s.replace(_LINE_COMMENT_RE, "");
+    // Replace comments with a single space, not "", so that a comment
+    // wedged inside a token cannot fuse two fragments into a keyword the
+    // raw SQL never contained. Stripping to "" would turn
+    // `SELECT WHE/*x*/RE FROM t` into `SELECT WHERE FROM t`, synthesizing a
+    // bounding `WHERE` and letting an unbounded scan auto-allow.
+    let s = sql.replace(_BLOCK_COMMENT_RE, " ");
+    s = s.replace(_LINE_COMMENT_RE, " ");
     return s.trim();
   }
 

--- a/agents/lib/wiki_db/policy.ts
+++ b/agents/lib/wiki_db/policy.ts
@@ -43,17 +43,29 @@ export const OperationType = {
 // -----------------------------------------------------------------------
 
 const _READ_KEYWORDS: ReadonlySet<string> = new Set([
-  "SELECT", "EXPLAIN", "SHOW", "DESCRIBE", "DESC", "WITH",
+  "SELECT",
+  "EXPLAIN",
+  "SHOW",
+  "DESCRIBE",
+  "DESC",
+  "WITH",
 ]);
 const _DML_KEYWORDS: ReadonlySet<string> = new Set([
-  "INSERT", "UPDATE", "DELETE", "REPLACE", "MERGE", "UPSERT",
+  "INSERT",
+  "UPDATE",
+  "DELETE",
+  "REPLACE",
+  "MERGE",
+  "UPSERT",
 ]);
 const _DDL_KEYWORDS: ReadonlySet<string> = new Set([
-  "CREATE", "DROP", "ALTER", "TRUNCATE", "RENAME",
+  "CREATE",
+  "DROP",
+  "ALTER",
+  "TRUNCATE",
+  "RENAME",
 ]);
-const _PRIVILEGE_KEYWORDS: ReadonlySet<string> = new Set([
-  "GRANT", "REVOKE",
-]);
+const _PRIVILEGE_KEYWORDS: ReadonlySet<string> = new Set(["GRANT", "REVOKE"]);
 
 /**
  * Classify a SQL string by its leading keyword.
@@ -106,7 +118,10 @@ export type ApprovalMode =
   | "grant_required";
 
 const _VALID_APPROVAL_MODES: ReadonlySet<ApprovalMode> = new Set([
-  "auto", "confirm_once", "confirm_each", "grant_required",
+  "auto",
+  "confirm_once",
+  "confirm_each",
+  "grant_required",
 ]);
 
 /**
@@ -140,7 +155,12 @@ export class Policy {
   // SQL classification
   // ------------------------------------------------------------------
 
-  /** Remove SQL comments from the statement. */
+  /**
+   * Remove SQL comments from the statement.
+   * Note: Block comments are replaced with a space (" ") rather than an empty
+   * string. This ensures that an attacker cannot synthesize a keyword to bypass
+   * checks. For example, `WHE/*x*\/RE` will become `WHE RE` instead of `WHERE`.
+   */
   static _stripComments(sql: string): string {
     let s = sql.replace(_BLOCK_COMMENT_RE, " ");
     s = s.replace(_LINE_COMMENT_RE, "");
@@ -181,16 +201,20 @@ export class Policy {
   checkQuery(sql: string, driver?: DatabaseDriver): PolicyResult {
     const stripped = sql.trim();
     if (!stripped) {
-      const result: PolicyResult = { decision: "deny", reason: "Empty SQL statement" };
+      const result: PolicyResult = {
+        decision: "deny",
+        reason: "Empty SQL statement",
+      };
       _emitDeny(result.reason, null);
       return result;
     }
 
     let op: OperationType;
     try {
-      op = driver !== undefined
-        ? driver.classifyOperation(stripped)
-        : this.classifySql(stripped);
+      op =
+        driver !== undefined
+          ? driver.classifyOperation(stripped)
+          : this.classifySql(stripped);
     } catch (exc) {
       const reason = (exc as Error).message;
       _emitDeny(reason, null);
@@ -399,9 +423,7 @@ function _emitPresentOnly(
   // can't leak. Same helper used by audit.logQuery.
   const scrubbed = scrubSqlSecrets(formattedSql);
   const truncated =
-    scrubbed.length > 500
-      ? scrubbed.slice(0, 500) + "\u2026"
-      : scrubbed;
+    scrubbed.length > 500 ? scrubbed.slice(0, 500) + "\u2026" : scrubbed;
   const details: Record<string, unknown> = {
     reason,
     formatted_sql: truncated,

--- a/agents/lib/wiki_db/policy.ts
+++ b/agents/lib/wiki_db/policy.ts
@@ -97,6 +97,9 @@ export function classifySqlKeywords(sql: string): OperationType {
 const _LINE_COMMENT_RE = /--[^\n]*/g;
 // Python uses re.DOTALL so `.` matches newlines; in JS use the `s` flag.
 const _BLOCK_COMMENT_RE = /\/\*.*?\*\//gs;
+// MySQL/MariaDB executable comments (`/*! ... */`) run on the server, so they
+// must never be treated as inert when deciding whether a read is unbounded.
+const _EXEC_COMMENT_RE = /\/\*!/;
 
 /**
  * Heuristic: a SELECT is "unbounded" if it reads from a table but has
@@ -178,9 +181,17 @@ export class Policy {
 
   /** Return true if the SELECT appears to lack a bounding clause. */
   static _isUnboundedSelect(sql: string): boolean {
-    const cleaned = Policy._stripComments(sql);
-    if (!_UNBOUNDED_RE.test(cleaned)) return false;
-    return !_BOUNDED_KEYWORDS_RE.test(cleaned);
+    // Fail closed: the regex `_stripComments` is not string-literal-aware, so a
+    // `/* ... */` that opens inside a quoted literal (e.g. `SELECT '/*' ... FROM
+    // users ... '*/'`) gets deleted along with the real `FROM users`, making an
+    // unbounded scan look bounded. MySQL executable comments (`/*! ... */`) are
+    // likewise stripped here but run on the server. So evaluate the heuristic on
+    // BOTH the raw and the comment-stripped text and escalate if either looks
+    // unbounded; always escalate when an executable comment is present.
+    const looksUnbounded = (text: string): boolean =>
+      _UNBOUNDED_RE.test(text) && !_BOUNDED_KEYWORDS_RE.test(text);
+    if (_EXEC_COMMENT_RE.test(sql)) return true;
+    return looksUnbounded(sql) || looksUnbounded(Policy._stripComments(sql));
   }
 
   // ------------------------------------------------------------------

--- a/agents/lib/wiki_db/policy.ts
+++ b/agents/lib/wiki_db/policy.ts
@@ -105,7 +105,9 @@ const _EXEC_COMMENT_RE = /\/\*[A-Za-z]*!/;
  *
  * Python uses `re.IGNORECASE | re.DOTALL`; in JS we emulate with `is` flags.
  */
-const _UNBOUNDED_RE = /^\s*SELECT\s+.*\bFROM\s+\w+/is;
+// The table name may be a quoted identifier (`FROM "users"`, MySQL
+// `FROM \`users\``), so accept an opening quote as well as a word character.
+const _UNBOUNDED_RE = /^\s*SELECT\s+.*\bFROM\s+["'`\w]/is;
 // G-POLICY-CROSSJOIN: require JOIN ... ON so CROSS JOIN (which has no
 // join predicate and explodes rows) does not count as bounded. Bare
 // JOIN USING (…) also falls through to escalate — safe direction.
@@ -178,11 +180,15 @@ export class Policy {
   // ------------------------------------------------------------------
 
   /**
-   * Replace the contents of single- or double-quoted string literals with spaces.
-   * This is a heuristic masker so string contents don't confuse keyword checks.
+   * Replace the contents of quoted spans with spaces so their text cannot
+   * satisfy a keyword check. Covers single and double quotes plus the
+   * MySQL/MariaDB backtick. A backtick span is an identifier rather than a
+   * string literal, but its contents are equally inert: without masking,
+   * `SELECT \`where\` FROM users` matched _BOUNDED_KEYWORDS_RE on the column
+   * name and a full-table read was classified bounded.
    */
   static _maskStringLiterals(sql: string): string {
-    return sql.replace(/(['"])(?:(?!\1)[^\\]|\\.)*\1/g, (match) => " ".repeat(match.length));
+    return sql.replace(/(['"`])(?:(?!\1)[^\\]|\\.)*\1/g, (match) => " ".repeat(match.length));
   }
 
   /** Return true if the SELECT appears to lack a bounding clause. */
@@ -194,9 +200,14 @@ export class Policy {
     // likewise stripped here but run on the server. So evaluate the heuristic on
     // BOTH the raw and the comment-stripped text and escalate if either looks
     // unbounded; always escalate when an executable comment is present.
+    // Ask the two questions of different views of the text. "Does this read
+    // from a table?" is a question about real syntax, so it runs on the raw
+    // text: masking blanks a quoted table name (`FROM \`users\``) and left the
+    // statement looking like no FROM at all, which read as bounded. "Is there
+    // a bounding clause?" must ignore quoted spans, so it runs on the mask.
     const looksUnbounded = (text: string): boolean => {
       const masked = Policy._maskStringLiterals(text);
-      return _UNBOUNDED_RE.test(masked) && !_BOUNDED_KEYWORDS_RE.test(masked);
+      return _UNBOUNDED_RE.test(text) && !_BOUNDED_KEYWORDS_RE.test(masked);
     };
 
     if (_EXEC_COMMENT_RE.test(sql)) return true;

--- a/agents/lib/wiki_db/policy.ts
+++ b/agents/lib/wiki_db/policy.ts
@@ -43,29 +43,17 @@ export const OperationType = {
 // -----------------------------------------------------------------------
 
 const _READ_KEYWORDS: ReadonlySet<string> = new Set([
-  "SELECT",
-  "EXPLAIN",
-  "SHOW",
-  "DESCRIBE",
-  "DESC",
-  "WITH",
+  "SELECT", "EXPLAIN", "SHOW", "DESCRIBE", "DESC", "WITH",
 ]);
 const _DML_KEYWORDS: ReadonlySet<string> = new Set([
-  "INSERT",
-  "UPDATE",
-  "DELETE",
-  "REPLACE",
-  "MERGE",
-  "UPSERT",
+  "INSERT", "UPDATE", "DELETE", "REPLACE", "MERGE", "UPSERT",
 ]);
 const _DDL_KEYWORDS: ReadonlySet<string> = new Set([
-  "CREATE",
-  "DROP",
-  "ALTER",
-  "TRUNCATE",
-  "RENAME",
+  "CREATE", "DROP", "ALTER", "TRUNCATE", "RENAME",
 ]);
-const _PRIVILEGE_KEYWORDS: ReadonlySet<string> = new Set(["GRANT", "REVOKE"]);
+const _PRIVILEGE_KEYWORDS: ReadonlySet<string> = new Set([
+  "GRANT", "REVOKE",
+]);
 
 /**
  * Classify a SQL string by its leading keyword.
@@ -118,10 +106,7 @@ export type ApprovalMode =
   | "grant_required";
 
 const _VALID_APPROVAL_MODES: ReadonlySet<ApprovalMode> = new Set([
-  "auto",
-  "confirm_once",
-  "confirm_each",
-  "grant_required",
+  "auto", "confirm_once", "confirm_each", "grant_required",
 ]);
 
 /**
@@ -196,20 +181,16 @@ export class Policy {
   checkQuery(sql: string, driver?: DatabaseDriver): PolicyResult {
     const stripped = sql.trim();
     if (!stripped) {
-      const result: PolicyResult = {
-        decision: "deny",
-        reason: "Empty SQL statement",
-      };
+      const result: PolicyResult = { decision: "deny", reason: "Empty SQL statement" };
       _emitDeny(result.reason, null);
       return result;
     }
 
     let op: OperationType;
     try {
-      op =
-        driver !== undefined
-          ? driver.classifyOperation(stripped)
-          : this.classifySql(stripped);
+      op = driver !== undefined
+        ? driver.classifyOperation(stripped)
+        : this.classifySql(stripped);
     } catch (exc) {
       const reason = (exc as Error).message;
       _emitDeny(reason, null);
@@ -418,7 +399,9 @@ function _emitPresentOnly(
   // can't leak. Same helper used by audit.logQuery.
   const scrubbed = scrubSqlSecrets(formattedSql);
   const truncated =
-    scrubbed.length > 500 ? scrubbed.slice(0, 500) + "\u2026" : scrubbed;
+    scrubbed.length > 500
+      ? scrubbed.slice(0, 500) + "\u2026"
+      : scrubbed;
   const details: Record<string, unknown> = {
     reason,
     formatted_sql: truncated,

--- a/agents/lib/wiki_db/policy.ts
+++ b/agents/lib/wiki_db/policy.ts
@@ -97,40 +97,7 @@ export function classifySqlKeywords(sql: string): OperationType {
 const _LINE_COMMENT_RE = /--[^\n]*/g;
 // Python uses re.DOTALL so `.` matches newlines; in JS use the `s` flag.
 const _BLOCK_COMMENT_RE = /\/\*.*?\*\//gs;
-// Executable comments run on the server and must never be treated as inert:
-// MySQL uses `/*! ... */`; MariaDB also runs `/*M! ... */` (optional version).
 const _EXEC_COMMENT_RE = /\/\*[A-Za-z]*!/;
-
-/**
- * Replace the contents of single-, double-, and backtick-quoted string
- * literals with spaces, keeping the delimiters and overall length. Used by
- * `_isUnboundedSelect` so a bounding keyword that appears only inside a literal
- * (e.g. `SELECT 'WHERE /*' ... FROM users`) can't make a full-table scan look
- * bounded. Handles SQL-standard `''` doubling.
- */
-function _maskStringLiterals(sql: string): string {
-  const out = sql.split("");
-  let inString: string | null = null;
-  for (let i = 0; i < sql.length; i++) {
-    const c = sql[i];
-    if (inString !== null) {
-      if (c === inString) {
-        if (i + 1 < sql.length && sql[i + 1] === inString) {
-          out[i] = " ";
-          out[i + 1] = " ";
-          i++; // skip the doubled (escaped) quote
-        } else {
-          inString = null; // keep the closing delimiter
-        }
-      } else {
-        out[i] = " ";
-      }
-    } else if (c === "'" || c === '"' || c === "`") {
-      inString = c;
-    }
-  }
-  return out.join("");
-}
 
 /**
  * Heuristic: a SELECT is "unbounded" if it reads from a table but has
@@ -210,29 +177,30 @@ export class Policy {
   // Unbounded query heuristic
   // ------------------------------------------------------------------
 
+  /**
+   * Replace the contents of single- or double-quoted string literals with spaces.
+   * This is a heuristic masker so string contents don't confuse keyword checks.
+   */
+  static _maskStringLiterals(sql: string): string {
+    return sql.replace(/(['"])(?:(?!\1)[^\\]|\\.)*\1/g, (match) => " ".repeat(match.length));
+  }
+
   /** Return true if the SELECT appears to lack a bounding clause. */
   static _isUnboundedSelect(sql: string): boolean {
-    // Executable comments (/*! ... */, MariaDB /*M! ... */) run on the server.
-    // Our naive strip drops them, so preemptively escalate to be safe.
-    if (_EXEC_COMMENT_RE.test(sql)) return true;
-
-    const isUnbounded = (s: string) => {
-      if (!_UNBOUNDED_RE.test(s)) return false;
-      return !_BOUNDED_KEYWORDS_RE.test(s);
+    // Fail closed: the regex `_stripComments` is not string-literal-aware, so a
+    // `/* ... */` that opens inside a quoted literal (e.g. `SELECT '/*' ... FROM
+    // users ... '*/'`) gets deleted along with the real `FROM users`, making an
+    // unbounded scan look bounded. MySQL executable comments (`/*! ... */`) are
+    // likewise stripped here but run on the server. So evaluate the heuristic on
+    // BOTH the raw and the comment-stripped text and escalate if either looks
+    // unbounded; always escalate when an executable comment is present.
+    const looksUnbounded = (text: string): boolean => {
+      const masked = Policy._maskStringLiterals(text);
+      return _UNBOUNDED_RE.test(masked) && !_BOUNDED_KEYWORDS_RE.test(masked);
     };
 
-    // The regex strip is not string-literal-aware, so evaluate the heuristic on
-    // three views and escalate if ANY looks unbounded:
-    //   - raw text: catches a real `FROM` hidden when the strip deletes a
-    //     literal that contains a fake comment (`SELECT '/*' ... FROM users`);
-    //   - comment-stripped: catches a real `FROM` when a comment legitimately
-    //     hides a bounding keyword;
-    //   - literal-masked: catches a bounding keyword that appears only inside a
-    //     string literal (`SELECT 'WHERE /*' ... FROM users`), which would
-    //     otherwise make the raw text look bounded.
-    const cleaned = Policy._stripComments(sql);
-    const masked = _maskStringLiterals(sql);
-    return isUnbounded(sql) || isUnbounded(cleaned) || isUnbounded(masked);
+    if (_EXEC_COMMENT_RE.test(sql)) return true;
+    return looksUnbounded(sql) || looksUnbounded(Policy._stripComments(sql));
   }
 
   // ------------------------------------------------------------------

--- a/agents/lib/wiki_db/tests/policy.test.ts
+++ b/agents/lib/wiki_db/tests/policy.test.ts
@@ -200,6 +200,38 @@ describe("TestDecisionLogic", () => {
     expect(result.decision).toBe(Decision.ESCALATE);
   });
 
+  it("test_unbounded_select_hidden_by_string_literal_comment_escalates", () => {
+    // `/*` opens inside a string literal; the non-literal-aware stripper would
+    // delete the real `FROM users`, making the scan look bounded. Fail closed.
+    const result = policyAuto().checkQuery(
+      "SELECT '/*' AS marker FROM users, (SELECT '*/') AS close",
+    );
+    expect(result.decision).toBe(Decision.ESCALATE);
+  });
+
+  it("test_unbounded_select_bounding_keyword_in_literal_escalates", () => {
+    // `WHERE` appears only inside a string literal, so the raw text looks
+    // bounded while the strip deletes the real `FROM users`. Literal-masking
+    // exposes the bare scan.
+    const result = policyAuto().checkQuery(
+      "SELECT 'WHERE /*' AS marker FROM users, (SELECT '*/') AS close",
+    );
+    expect(result.decision).toBe(Decision.ESCALATE);
+  });
+
+  it("test_unbounded_select_via_executable_comment_escalates", () => {
+    // MySQL `/*! ... */` and MariaDB `/*M! ... */` run on the server.
+    expect(
+      policyAuto().checkQuery("SELECT 1 /*! UNION SELECT id FROM users */")
+        .decision,
+    ).toBe(Decision.ESCALATE);
+    expect(
+      policyAuto().checkQuery(
+        "SELECT 1 /* WHERE */ /*M! UNION SELECT id FROM users */",
+      ).decision,
+    ).toBe(Decision.ESCALATE);
+  });
+
   it("test_bounded_select_allowed", () => {
     const result = policyAuto().checkQuery("SELECT * FROM users WHERE id = 1");
     expect(result.decision).toBe(Decision.ALLOW);

--- a/agents/lib/wiki_db/tests/policy.test.ts
+++ b/agents/lib/wiki_db/tests/policy.test.ts
@@ -205,6 +205,29 @@ describe("TestDecisionLogic", () => {
     expect(result.decision).toBe(Decision.ESCALATE);
   });
 
+  // A MySQL/MariaDB backtick-quoted identifier is not a string literal, but
+  // its contents are just as inert as one. Leaving backticks unmasked let a
+  // column named after a bounding keyword satisfy _BOUNDED_KEYWORDS_RE, so a
+  // full-table read classified as bounded and skipped the escalation prompt.
+  it("test_unbounded_select_bounding_keyword_in_backtick_identifier_escalates", () => {
+    const result = policyAuto().checkQuery("SELECT `where` FROM users");
+    expect(result.decision).toBe(Decision.ESCALATE);
+  });
+
+  // A quoted table name is still a table read. The masker blanks the quoted
+  // span, so testing _UNBOUNDED_RE on the masked text left `FROM "users"`
+  // looking like a SELECT with no FROM at all and a full-table read was
+  // allowed. _UNBOUNDED_RE now runs on the raw text; only the bounding-clause
+  // check reads the mask.
+  it("test_unbounded_select_quoted_table_name_escalates", () => {
+    expect(policyAuto().checkQuery('SELECT * FROM "users"').decision).toBe(
+      Decision.ESCALATE,
+    );
+    expect(policyAuto().checkQuery("SELECT * FROM `users`").decision).toBe(
+      Decision.ESCALATE,
+    );
+  });
+
   it("test_unbounded_select_via_executable_comment_escalates", () => {
     const result = policyAuto().checkQuery("SELECT 1 /* WHERE */ /*M! UNION SELECT id FROM users */");
     expect(result.decision).toBe(Decision.ESCALATE);

--- a/agents/lib/wiki_db/tests/policy.test.ts
+++ b/agents/lib/wiki_db/tests/policy.test.ts
@@ -195,6 +195,14 @@ describe("TestDecisionLogic", () => {
     expect(result.decision).toBe(Decision.ESCALATE);
   });
 
+  it("test_unbounded_select_with_comment_synthesized_keyword_escalates", () => {
+    // A comment wedged inside a token must not fuse fragments into a
+    // bounding keyword: `WHE/*x*/RE` is two identifiers (column `WHE`
+    // aliased `RE`), not a `WHERE` clause, so the scan stays unbounded.
+    const result = policyAuto().checkQuery("SELECT WHE/*x*/RE FROM users");
+    expect(result.decision).toBe(Decision.ESCALATE);
+  });
+
   it("test_bounded_select_allowed", () => {
     const result = policyAuto().checkQuery("SELECT * FROM users WHERE id = 1");
     expect(result.decision).toBe(Decision.ALLOW);

--- a/agents/lib/wiki_db/tests/policy.test.ts
+++ b/agents/lib/wiki_db/tests/policy.test.ts
@@ -7,12 +7,7 @@
  */
 import { describe, it, expect } from "vitest";
 
-import {
-  Decision,
-  grantFromEnv,
-  OperationType,
-  Policy,
-} from "../policy.js";
+import { Decision, grantFromEnv, OperationType, Policy } from "../policy.js";
 
 /** pytest fixture: policy_auto */
 function policyAuto(): Policy {
@@ -190,6 +185,11 @@ describe("TestDecisionLogic", () => {
     expect(result.decision).toBe(Decision.ESCALATE);
   });
 
+  it("test_unbounded_select_with_comment_escalates", () => {
+    const result = policyAuto().checkQuery("SELECT * FROM users /* WHERE */");
+    expect(result.decision).toBe(Decision.ESCALATE);
+  });
+
   it("test_bounded_select_allowed", () => {
     const result = policyAuto().checkQuery("SELECT * FROM users WHERE id = 1");
     expect(result.decision).toBe(Decision.ALLOW);
@@ -213,9 +213,7 @@ describe("TestDecisionLogic", () => {
   // JOIN USING (...) also loses to the tightened regex. Acceptable:
   // escalate is the safe direction and USING without WHERE is rare.
   it("test_join_using_escalates", () => {
-    const result = policyAuto().checkQuery(
-      "SELECT * FROM a JOIN b USING (id)",
-    );
+    const result = policyAuto().checkQuery("SELECT * FROM a JOIN b USING (id)");
     expect(result.decision).toBe(Decision.ESCALATE);
   });
 

--- a/agents/lib/wiki_db/tests/policy.test.ts
+++ b/agents/lib/wiki_db/tests/policy.test.ts
@@ -196,10 +196,7 @@ describe("TestDecisionLogic", () => {
   });
 
   it("test_unbounded_select_with_comment_synthesized_keyword_escalates", () => {
-    // A comment wedged inside a token must not fuse fragments into a
-    // bounding keyword: `WHE/*x*/RE` is two identifiers (column `WHE`
-    // aliased `RE`), not a `WHERE` clause, so the scan stays unbounded.
-    const result = policyAuto().checkQuery("SELECT WHE/*x*/RE FROM users");
+    const result = policyAuto().checkQuery("SELECT * FROM users WHE/*x*/RE id = 1");
     expect(result.decision).toBe(Decision.ESCALATE);
   });
 

--- a/agents/lib/wiki_db/tests/policy.test.ts
+++ b/agents/lib/wiki_db/tests/policy.test.ts
@@ -200,23 +200,6 @@ describe("TestDecisionLogic", () => {
     expect(result.decision).toBe(Decision.ESCALATE);
   });
 
-  it("test_unbounded_select_hidden_by_string_literal_comment_escalates", () => {
-    // `/*` opens inside a string literal; the non-literal-aware stripper would
-    // delete the real `FROM users`, making the scan look bounded. Fail closed.
-    const result = policyAuto().checkQuery(
-      "SELECT '/*' AS marker FROM users, (SELECT '*/') AS close",
-    );
-    expect(result.decision).toBe(Decision.ESCALATE);
-  });
-
-  it("test_unbounded_select_via_mysql_executable_comment_escalates", () => {
-    // `/*! ... */` runs on the MySQL server, so it must not be treated as inert.
-    const result = policyAuto().checkQuery(
-      "SELECT 1 /*! UNION SELECT id FROM users */",
-    );
-    expect(result.decision).toBe(Decision.ESCALATE);
-  });
-
   it("test_bounded_select_allowed", () => {
     const result = policyAuto().checkQuery("SELECT * FROM users WHERE id = 1");
     expect(result.decision).toBe(Decision.ALLOW);

--- a/agents/lib/wiki_db/tests/policy.test.ts
+++ b/agents/lib/wiki_db/tests/policy.test.ts
@@ -200,6 +200,23 @@ describe("TestDecisionLogic", () => {
     expect(result.decision).toBe(Decision.ESCALATE);
   });
 
+  it("test_unbounded_select_hidden_by_string_literal_comment_escalates", () => {
+    // `/*` opens inside a string literal; the non-literal-aware stripper would
+    // delete the real `FROM users`, making the scan look bounded. Fail closed.
+    const result = policyAuto().checkQuery(
+      "SELECT '/*' AS marker FROM users, (SELECT '*/') AS close",
+    );
+    expect(result.decision).toBe(Decision.ESCALATE);
+  });
+
+  it("test_unbounded_select_via_mysql_executable_comment_escalates", () => {
+    // `/*! ... */` runs on the MySQL server, so it must not be treated as inert.
+    const result = policyAuto().checkQuery(
+      "SELECT 1 /*! UNION SELECT id FROM users */",
+    );
+    expect(result.decision).toBe(Decision.ESCALATE);
+  });
+
   it("test_bounded_select_allowed", () => {
     const result = policyAuto().checkQuery("SELECT * FROM users WHERE id = 1");
     expect(result.decision).toBe(Decision.ALLOW);

--- a/agents/lib/wiki_db/tests/policy.test.ts
+++ b/agents/lib/wiki_db/tests/policy.test.ts
@@ -200,36 +200,14 @@ describe("TestDecisionLogic", () => {
     expect(result.decision).toBe(Decision.ESCALATE);
   });
 
-  it("test_unbounded_select_hidden_by_string_literal_comment_escalates", () => {
-    // `/*` opens inside a string literal; the non-literal-aware stripper would
-    // delete the real `FROM users`, making the scan look bounded. Fail closed.
-    const result = policyAuto().checkQuery(
-      "SELECT '/*' AS marker FROM users, (SELECT '*/') AS close",
-    );
-    expect(result.decision).toBe(Decision.ESCALATE);
-  });
-
   it("test_unbounded_select_bounding_keyword_in_literal_escalates", () => {
-    // `WHERE` appears only inside a string literal, so the raw text looks
-    // bounded while the strip deletes the real `FROM users`. Literal-masking
-    // exposes the bare scan.
-    const result = policyAuto().checkQuery(
-      "SELECT 'WHERE /*' AS marker FROM users, (SELECT '*/') AS close",
-    );
+    const result = policyAuto().checkQuery("SELECT 'WHERE /*' AS marker FROM users, (SELECT '*/') AS close");
     expect(result.decision).toBe(Decision.ESCALATE);
   });
 
   it("test_unbounded_select_via_executable_comment_escalates", () => {
-    // MySQL `/*! ... */` and MariaDB `/*M! ... */` run on the server.
-    expect(
-      policyAuto().checkQuery("SELECT 1 /*! UNION SELECT id FROM users */")
-        .decision,
-    ).toBe(Decision.ESCALATE);
-    expect(
-      policyAuto().checkQuery(
-        "SELECT 1 /* WHERE */ /*M! UNION SELECT id FROM users */",
-      ).decision,
-    ).toBe(Decision.ESCALATE);
+    const result = policyAuto().checkQuery("SELECT 1 /* WHERE */ /*M! UNION SELECT id FROM users */");
+    expect(result.decision).toBe(Decision.ESCALATE);
   });
 
   it("test_bounded_select_allowed", () => {

--- a/agents/lib/wiki_db/tests/policy.test.ts
+++ b/agents/lib/wiki_db/tests/policy.test.ts
@@ -7,7 +7,12 @@
  */
 import { describe, it, expect } from "vitest";
 
-import { Decision, grantFromEnv, OperationType, Policy } from "../policy.js";
+import {
+  Decision,
+  grantFromEnv,
+  OperationType,
+  Policy,
+} from "../policy.js";
 
 /** pytest fixture: policy_auto */
 function policyAuto(): Policy {
@@ -213,7 +218,9 @@ describe("TestDecisionLogic", () => {
   // JOIN USING (...) also loses to the tightened regex. Acceptable:
   // escalate is the safe direction and USING without WHERE is rare.
   it("test_join_using_escalates", () => {
-    const result = policyAuto().checkQuery("SELECT * FROM a JOIN b USING (id)");
+    const result = policyAuto().checkQuery(
+      "SELECT * FROM a JOIN b USING (id)",
+    );
     expect(result.decision).toBe(Decision.ESCALATE);
   });
 

--- a/test_bypass.ts
+++ b/test_bypass.ts
@@ -1,6 +1,0 @@
-import { Policy } from "./agents/lib/wiki_db/policy.ts";
-
-const p = new Policy("auto", "dev");
-
-console.log("Normal unbounded: ", p.checkQuery("SELECT * FROM users"));
-console.log("Comment bounded bypass: ", p.checkQuery("SELECT * FROM users /* WHERE */"));

--- a/test_bypass.ts
+++ b/test_bypass.ts
@@ -1,0 +1,6 @@
+import { Policy } from "./agents/lib/wiki_db/policy.ts";
+
+const p = new Policy("auto", "dev");
+
+console.log("Normal unbounded: ", p.checkQuery("SELECT * FROM users"));
+console.log("Comment bounded bypass: ", p.checkQuery("SELECT * FROM users /* WHERE */"));


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The DB policy's `Policy._isUnboundedSelect` was susceptible to bypasses if an attacker or user added bounding keywords like `WHERE` inside an SQL comment (e.g. `SELECT * FROM users /* WHERE */`).
🎯 Impact: This allowed unbounded queries to be executed, potentially dumping entire tables or causing DoS by exhausting memory.
🔧 Fix: Call `Policy._stripComments(sql)` before applying bounding keyword regexes in `Policy._isUnboundedSelect(sql)`. Added a test to verify that unbounded selects with bounding keywords in comments are properly escalated.
✅ Verification: Ran `npm run test` and `npx tsx test_bypass.ts` manually against the fix to ensure the comment-bypass now triggers an `ESCALATE` rather than `ALLOW`. Tests pass.

---
*PR created automatically by Jules for task [15960555966257222050](https://jules.google.com/task/15960555966257222050) started by @rfv-code*