### PR TITLE
⚡ Bolt: [performance improvement] Hoist regex and use exec in log parser hot loop

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -12,3 +12,8 @@
 
 **Learning:** Inner JSON fields might mistakenly contain match substrings like dates (e.g., inside the text of the event). Utilizing a strict, anchored regex check for extracting fields like timestamps directly (`/^{"ts":"([^"\\]+)"/`) avoids both `JSON.parse` overhead and incorrect partial string matches from `String.includes()`.
 **Action:** Use an anchored regex (`/^{"ts":"([^"\\]+)"/`) and check the captured group directly before falling back to full JSON parsing.
+
+## 2026-06-12 - Fast-path regex matching optimization
+
+**Learning:** When parsing large append-only JSON logs, using inline `.match()` in a hot path causes significant array allocation/instantiation overhead on every line.
+**Action:** Always hoist regular expressions (e.g., `const TS_EXTRACT_REGEX = /^{"ts":"([^"\\]+)"/`) to module-level constants and use `.exec()` instead of `.match()` within tight loops to avoid instantiation overhead and improve log processing speed.

--- a/skills/doc-wiki/scripts/daily_summary.js
+++ b/skills/doc-wiki/scripts/daily_summary.js
@@ -20,6 +20,12 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
 import { parseFlags } from "./_cli_args.js";
+// ── Constants ───────────────────────────────────────────────────────
+/**
+ * Hoisted regex to extract the "ts" field from an events.jsonl line
+ * without parsing the full JSON.
+ */
+const TS_EXTRACT_REGEX = /^{"ts":"([^"\\]+)"/;
 // ── Helpers ─────────────────────────────────────────────────────────
 /**
  * Read events from `<wikiRoot>/log/events.jsonl`, keeping only entries whose
@@ -40,7 +46,7 @@ function readEvents(wikiRoot, dateStr) {
         // Fast-path: skip JSON parse overhead if this line cannot match our date
         if (!line.includes(dateStr))
             continue;
-        const match = line.match(/^{"ts":"([^"\\]+)"/);
+        const match = TS_EXTRACT_REGEX.exec(line);
         if (match && match[1] && !match[1].startsWith(dateStr))
             continue;
         let entry;

--- a/skills/doc-wiki/scripts/daily_summary.ts
+++ b/skills/doc-wiki/scripts/daily_summary.ts
@@ -21,6 +21,14 @@ import * as path from "node:path";
 import { fileURLToPath } from "node:url";
 import { parseFlags } from "./_cli_args.js";
 
+// ── Constants ───────────────────────────────────────────────────────
+
+/**
+ * Hoisted regex to extract the "ts" field from an events.jsonl line
+ * without parsing the full JSON.
+ */
+const TS_EXTRACT_REGEX = /^{"ts":"([^"\\]+)"/;
+
 // ── Helpers ─────────────────────────────────────────────────────────
 
 /**
@@ -44,7 +52,7 @@ function readEvents(
 
     // Fast-path: skip JSON parse overhead if this line cannot match our date
     if (!line.includes(dateStr)) continue;
-    const match = line.match(/^{"ts":"([^"\\]+)"/);
+    const match = TS_EXTRACT_REGEX.exec(line);
     if (match && match[1] && !match[1].startsWith(dateStr)) continue;
 
     let entry: unknown;
@@ -299,9 +307,7 @@ options:
   --date DATE           Date (YYYY-MM-DD), defaults to today
 `;
 
-export function main(
-  argv: readonly string[] = process.argv.slice(2),
-): number {
+export function main(argv: readonly string[] = process.argv.slice(2)): number {
   let parsed: ReturnType<typeof parseFlags>;
   try {
     parsed = parseFlags(argv, FLAG_SPEC);

--- a/skills/doc-wiki/scripts/event_logger.js
+++ b/skills/doc-wiki/scripts/event_logger.js
@@ -95,6 +95,12 @@ function _normalizeAgentCalls(details) {
         out["total_cost_usd"] = cu;
     return out;
 }
+// ── Constants ───────────────────────────────────────────────────────
+/**
+ * Hoisted regex to extract the "ts" field from an events.jsonl line
+ * without parsing the full JSON.
+ */
+const TS_EXTRACT_REGEX = /^{"ts":"([^"\\]+)"/;
 // ── Paths ───────────────────────────────────────────────────────────
 function _eventsPath(wikiRoot) {
     const p = path.join(wikiRoot, "log", "events.jsonl");
@@ -156,7 +162,7 @@ function _readEvents(wikiRoot, since = null) {
             // leading whitespace. The character class excludes both `"` and `\` so
             // any ts containing a JSON escape (like `\+` for `+`) misses the regex
             // and safely falls through to the slow path for proper decoding.
-            const m = line.match(/^{"ts":"([^"\\]+)"/);
+            const m = TS_EXTRACT_REGEX.exec(line);
             if (m) {
                 const entryMs = parsePythonIsoformat(m[1]);
                 // G-EVENTS-TS-STRICT: when --since is active, drop events whose

--- a/skills/doc-wiki/scripts/event_logger.ts
+++ b/skills/doc-wiki/scripts/event_logger.ts
@@ -117,6 +117,14 @@ function _normalizeAgentCalls(
   return out;
 }
 
+// ── Constants ───────────────────────────────────────────────────────
+
+/**
+ * Hoisted regex to extract the "ts" field from an events.jsonl line
+ * without parsing the full JSON.
+ */
+const TS_EXTRACT_REGEX = /^{"ts":"([^"\\]+)"/;
+
 // ── Paths ───────────────────────────────────────────────────────────
 
 function _eventsPath(wikiRoot: string): string {
@@ -201,7 +209,7 @@ function _readEvents(
       // leading whitespace. The character class excludes both `"` and `\` so
       // any ts containing a JSON escape (like `\+` for `+`) misses the regex
       // and safely falls through to the slow path for proper decoding.
-      const m = line.match(/^{"ts":"([^"\\]+)"/);
+      const m = TS_EXTRACT_REGEX.exec(line);
       if (m) {
         const entryMs = parsePythonIsoformat(m[1] as string);
         // G-EVENTS-TS-STRICT: when --since is active, drop events whose


### PR DESCRIPTION
💡 What: Hoisted the timestamp extraction regex `/^{"ts":"([^"\\]+)"/` to a module-level constant (`TS_EXTRACT_REGEX`) and replaced `String.prototype.match()` with `RegExp.prototype.exec()` in both `event_logger.ts` and `daily_summary.ts`. Also updated `.jules/bolt.md` with this performance learning.

🎯 Why: In tight loops that process large, append-only JSON logs (like `events.jsonl`), inline literal regexes combined with `.match()` cause unnecessary overhead due to internal dispatching and continuous RegExp instantiations. Hoisting the regex and using `.exec()` avoids this allocation overhead on the hot path.

📊 Impact: Reduces allocation and instantiation overhead per log line read. Across tens of thousands of log entries, this avoids generating thousands of short-lived RegExp objects, improving throughput during log parsing and stats aggregation.

🔬 Measurement: Run `npm run benchmark run` or view throughput parsing speeds of `event_logger stats` or `daily_summary` over a heavily-populated log file. Code maintains 100% test passing functionality.

---
*PR created automatically by Jules for task [3959537101577110803](https://jules.google.com/task/3959537101577110803) started by @rfv-code*