### PR TITLE
⚡ Bolt: Hoist regex out of hot loops in log parsing

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -12,3 +12,8 @@
 
 **Learning:** Inner JSON fields might mistakenly contain match substrings like dates (e.g., inside the text of the event). Utilizing a strict, anchored regex check for extracting fields like timestamps directly (`/^{"ts":"([^"\\]+)"/`) avoids both `JSON.parse` overhead and incorrect partial string matches from `String.includes()`.
 **Action:** Use an anchored regex (`/^{"ts":"([^"\\]+)"/`) and check the captured group directly before falling back to full JSON parsing.
+
+## 2026-05-23 - Hoisting regex out of hot loops
+
+**Learning:** When using regex to extract fields from lines in a large log file like `events.jsonl`, using an inline regex literal with `line.match(/.../)` causes the regex engine to instantiate it repeatedly inside the loop. This causes overhead on the fast path.
+**Action:** Always hoist regex literals out of loops to module-level constants and use `REGEX.exec(line)` to avoid instantiation overhead.

--- a/skills/doc-wiki/scripts/daily_summary.js
+++ b/skills/doc-wiki/scripts/daily_summary.js
@@ -20,6 +20,7 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
 import { parseFlags } from "./_cli_args.js";
+const TS_REGEX = /^{"ts":"([^"\\]+)"/;
 // ── Helpers ─────────────────────────────────────────────────────────
 /**
  * Read events from `<wikiRoot>/log/events.jsonl`, keeping only entries whose
@@ -40,7 +41,7 @@ function readEvents(wikiRoot, dateStr) {
         // Fast-path: skip JSON parse overhead if this line cannot match our date
         if (!line.includes(dateStr))
             continue;
-        const match = line.match(/^{"ts":"([^"\\]+)"/);
+        const match = TS_REGEX.exec(line);
         if (match && match[1] && !match[1].startsWith(dateStr))
             continue;
         let entry;

--- a/skills/doc-wiki/scripts/daily_summary.ts
+++ b/skills/doc-wiki/scripts/daily_summary.ts
@@ -21,6 +21,8 @@ import * as path from "node:path";
 import { fileURLToPath } from "node:url";
 import { parseFlags } from "./_cli_args.js";
 
+const TS_REGEX = /^{"ts":"([^"\\]+)"/;
+
 // ── Helpers ─────────────────────────────────────────────────────────
 
 /**
@@ -44,7 +46,7 @@ function readEvents(
 
     // Fast-path: skip JSON parse overhead if this line cannot match our date
     if (!line.includes(dateStr)) continue;
-    const match = line.match(/^{"ts":"([^"\\]+)"/);
+    const match = TS_REGEX.exec(line);
     if (match && match[1] && !match[1].startsWith(dateStr)) continue;
 
     let entry: unknown;

--- a/skills/doc-wiki/scripts/event_logger.js
+++ b/skills/doc-wiki/scripts/event_logger.js
@@ -95,6 +95,7 @@ function _normalizeAgentCalls(details) {
         out["total_cost_usd"] = cu;
     return out;
 }
+const TS_REGEX = /^{"ts":"([^"\\]+)"/;
 // ── Paths ───────────────────────────────────────────────────────────
 function _eventsPath(wikiRoot) {
     const p = path.join(wikiRoot, "log", "events.jsonl");
@@ -156,7 +157,7 @@ function _readEvents(wikiRoot, since = null) {
             // leading whitespace. The character class excludes both `"` and `\` so
             // any ts containing a JSON escape (like `\+` for `+`) misses the regex
             // and safely falls through to the slow path for proper decoding.
-            const m = line.match(/^{"ts":"([^"\\]+)"/);
+            const m = TS_REGEX.exec(line);
             if (m) {
                 const entryMs = parsePythonIsoformat(m[1]);
                 // G-EVENTS-TS-STRICT: when --since is active, drop events whose

--- a/skills/doc-wiki/scripts/event_logger.ts
+++ b/skills/doc-wiki/scripts/event_logger.ts
@@ -117,6 +117,8 @@ function _normalizeAgentCalls(
   return out;
 }
 
+const TS_REGEX = /^{"ts":"([^"\\]+)"/;
+
 // ── Paths ───────────────────────────────────────────────────────────
 
 function _eventsPath(wikiRoot: string): string {
@@ -201,7 +203,7 @@ function _readEvents(
       // leading whitespace. The character class excludes both `"` and `\` so
       // any ts containing a JSON escape (like `\+` for `+`) misses the regex
       // and safely falls through to the slow path for proper decoding.
-      const m = line.match(/^{"ts":"([^"\\]+)"/);
+      const m = TS_REGEX.exec(line);
       if (m) {
         const entryMs = parsePythonIsoformat(m[1] as string);
         // G-EVENTS-TS-STRICT: when --since is active, drop events whose


### PR DESCRIPTION
💡 What:
Hoisted the inline timestamp regex `^{"ts":"([^"\\]+)"/` into a module-level constant (`TS_REGEX`) and changed the `String.prototype.match` call to `RegExp.prototype.exec` in both `daily_summary.ts` and `event_logger.ts`. Added a new journal entry to `.jules/bolt.md` detailing this learning.

🎯 Why:
Inside `readEvents` (`daily_summary.ts`) and the main event loop (`event_logger.ts`), large append-only log files like `events.jsonl` are read line-by-line. Using an inline regex literal like `line.match(/.../)` inside these tight loops forces the JavaScript engine to allocate and instantiate the RegExp repeatedly on a hot path.

📊 Impact:
Reduces object instantiation overhead and garbage collection pressure when parsing thousands or millions of lines from the `events.jsonl` append-only log, providing a measurable fast-path optimization.

🔬 Measurement:
Run the Vitest suite `npm run test` using Node.js v20 to verify everything still successfully parses and logs event streams without functional regressions. Ensure `events.jsonl` lines are filtered exactly as before.

---
*PR created automatically by Jules for task [7256714738008620352](https://jules.google.com/task/7256714738008620352) started by @rfv-code*