### PR TITLE
⚡ Bolt: Optimize RegExp instantiation in hot loops for events.jsonl parsing

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -12,3 +12,7 @@
 
 **Learning:** Inner JSON fields might mistakenly contain match substrings like dates (e.g., inside the text of the event). Utilizing a strict, anchored regex check for extracting fields like timestamps directly (`/^{"ts":"([^"\\]+)"/`) avoids both `JSON.parse` overhead and incorrect partial string matches from `String.includes()`.
 **Action:** Use an anchored regex (`/^{"ts":"([^"\\]+)"/`) and check the captured group directly before falling back to full JSON parsing.
+
+## 2024-06-15 - Optimize Regex Instantiation Overhead
+**Learning:** In hot loops parsing large append-only JSON files (like `events.jsonl`), inline regexes (e.g., `line.match(/.../)`) incur significant instantiation overhead per line.
+**Action:** When a fallback regex extraction is necessary on a hot path, hoist the regex literal to a module-level constant (e.g., `const TS_REGEX = /.../`) and use `TS_REGEX.exec(line)`.

--- a/skills/doc-wiki/scripts/daily_summary.js
+++ b/skills/doc-wiki/scripts/daily_summary.js
@@ -21,12 +21,13 @@ import * as path from "node:path";
 import { fileURLToPath } from "node:url";
 import { parseFlags } from "./_cli_args.js";
 // ── Helpers ─────────────────────────────────────────────────────────
+/** Hoisted out of `readEvents` so the literal is compiled once, not per line. */
+const TS_REGEX = /^{"ts":"([^"\\]+)"/;
 /**
  * Read events from `<wikiRoot>/log/events.jsonl`, keeping only entries whose
  * `ts` string starts with `dateStr`. Unparseable JSON lines are silently
  * skipped, matching the Python reference's `json.JSONDecodeError` branch.
  */
-const TS_REGEX = /^{"ts":"([^"\\]+)"/;
 function readEvents(wikiRoot, dateStr) {
     const eventsPath = path.join(wikiRoot, "log", "events.jsonl");
     if (!fs.existsSync(eventsPath)) {

--- a/skills/doc-wiki/scripts/daily_summary.js
+++ b/skills/doc-wiki/scripts/daily_summary.js
@@ -26,6 +26,7 @@ import { parseFlags } from "./_cli_args.js";
  * `ts` string starts with `dateStr`. Unparseable JSON lines are silently
  * skipped, matching the Python reference's `json.JSONDecodeError` branch.
  */
+const TS_REGEX = /^{"ts":"([^"\\]+)"/;
 function readEvents(wikiRoot, dateStr) {
     const eventsPath = path.join(wikiRoot, "log", "events.jsonl");
     if (!fs.existsSync(eventsPath)) {
@@ -40,7 +41,7 @@ function readEvents(wikiRoot, dateStr) {
         // Fast-path: skip JSON parse overhead if this line cannot match our date
         if (!line.includes(dateStr))
             continue;
-        const match = line.match(/^{"ts":"([^"\\]+)"/);
+        const match = TS_REGEX.exec(line);
         if (match && match[1] && !match[1].startsWith(dateStr))
             continue;
         let entry;

--- a/skills/doc-wiki/scripts/daily_summary.ts
+++ b/skills/doc-wiki/scripts/daily_summary.ts
@@ -23,13 +23,14 @@ import { parseFlags } from "./_cli_args.js";
 
 // ── Helpers ─────────────────────────────────────────────────────────
 
+/** Hoisted out of `readEvents` so the literal is compiled once, not per line. */
+const TS_REGEX = /^{"ts":"([^"\\]+)"/;
+
 /**
  * Read events from `<wikiRoot>/log/events.jsonl`, keeping only entries whose
  * `ts` string starts with `dateStr`. Unparseable JSON lines are silently
  * skipped, matching the Python reference's `json.JSONDecodeError` branch.
  */
-const TS_REGEX = /^{"ts":"([^"\\]+)"/;
-
 function readEvents(
   wikiRoot: string,
   dateStr: string,
@@ -301,7 +302,9 @@ options:
   --date DATE           Date (YYYY-MM-DD), defaults to today
 `;
 
-export function main(argv: readonly string[] = process.argv.slice(2)): number {
+export function main(
+  argv: readonly string[] = process.argv.slice(2),
+): number {
   let parsed: ReturnType<typeof parseFlags>;
   try {
     parsed = parseFlags(argv, FLAG_SPEC);

--- a/skills/doc-wiki/scripts/daily_summary.ts
+++ b/skills/doc-wiki/scripts/daily_summary.ts
@@ -28,6 +28,8 @@ import { parseFlags } from "./_cli_args.js";
  * `ts` string starts with `dateStr`. Unparseable JSON lines are silently
  * skipped, matching the Python reference's `json.JSONDecodeError` branch.
  */
+const TS_REGEX = /^{"ts":"([^"\\]+)"/;
+
 function readEvents(
   wikiRoot: string,
   dateStr: string,
@@ -44,7 +46,7 @@ function readEvents(
 
     // Fast-path: skip JSON parse overhead if this line cannot match our date
     if (!line.includes(dateStr)) continue;
-    const match = line.match(/^{"ts":"([^"\\]+)"/);
+    const match = TS_REGEX.exec(line);
     if (match && match[1] && !match[1].startsWith(dateStr)) continue;
 
     let entry: unknown;
@@ -299,9 +301,7 @@ options:
   --date DATE           Date (YYYY-MM-DD), defaults to today
 `;
 
-export function main(
-  argv: readonly string[] = process.argv.slice(2),
-): number {
+export function main(argv: readonly string[] = process.argv.slice(2)): number {
   let parsed: ReturnType<typeof parseFlags>;
   try {
     parsed = parseFlags(argv, FLAG_SPEC);

--- a/skills/doc-wiki/scripts/event_logger.js
+++ b/skills/doc-wiki/scripts/event_logger.js
@@ -128,6 +128,7 @@ export function logEvent(wikiRoot, op, details) {
     return entry;
 }
 // ── Stats ───────────────────────────────────────────────────────────
+const TS_REGEX = /^{"ts":"([^"\\]+)"/;
 function _readEvents(wikiRoot, since = null) {
     const p = _eventsPath(wikiRoot);
     if (!fs.existsSync(p)) {
@@ -156,7 +157,7 @@ function _readEvents(wikiRoot, since = null) {
             // leading whitespace. The character class excludes both `"` and `\` so
             // any ts containing a JSON escape (like `\+` for `+`) misses the regex
             // and safely falls through to the slow path for proper decoding.
-            const m = line.match(/^{"ts":"([^"\\]+)"/);
+            const m = TS_REGEX.exec(line);
             if (m) {
                 const entryMs = parsePythonIsoformat(m[1]);
                 // G-EVENTS-TS-STRICT: when --since is active, drop events whose

--- a/skills/doc-wiki/scripts/event_logger.js
+++ b/skills/doc-wiki/scripts/event_logger.js
@@ -128,6 +128,7 @@ export function logEvent(wikiRoot, op, details) {
     return entry;
 }
 // ── Stats ───────────────────────────────────────────────────────────
+/** Hoisted out of `_readEvents` so the literal is compiled once, not per line. */
 const TS_REGEX = /^{"ts":"([^"\\]+)"/;
 function _readEvents(wikiRoot, since = null) {
     const p = _eventsPath(wikiRoot);

--- a/skills/doc-wiki/scripts/event_logger.ts
+++ b/skills/doc-wiki/scripts/event_logger.ts
@@ -162,6 +162,8 @@ export function logEvent(
 
 // ── Stats ───────────────────────────────────────────────────────────
 
+const TS_REGEX = /^{"ts":"([^"\\]+)"/;
+
 function _readEvents(
   wikiRoot: string,
   since: string | null = null,
@@ -201,7 +203,7 @@ function _readEvents(
       // leading whitespace. The character class excludes both `"` and `\` so
       // any ts containing a JSON escape (like `\+` for `+`) misses the regex
       // and safely falls through to the slow path for proper decoding.
-      const m = line.match(/^{"ts":"([^"\\]+)"/);
+      const m = TS_REGEX.exec(line);
       if (m) {
         const entryMs = parsePythonIsoformat(m[1] as string);
         // G-EVENTS-TS-STRICT: when --since is active, drop events whose

--- a/skills/doc-wiki/scripts/event_logger.ts
+++ b/skills/doc-wiki/scripts/event_logger.ts
@@ -162,6 +162,7 @@ export function logEvent(
 
 // ── Stats ───────────────────────────────────────────────────────────
 
+/** Hoisted out of `_readEvents` so the literal is compiled once, not per line. */
 const TS_REGEX = /^{"ts":"([^"\\]+)"/;
 
 function _readEvents(


### PR DESCRIPTION
💡 **What**: Hoisted the timestamp extraction regex literal `/^{"ts":"([^"\\]+)"/` into a module-level constant (`TS_REGEX`) in `daily_summary.ts` and `event_logger.ts` and updated hot loops parsing `events.jsonl` to use `TS_REGEX.exec(line)` instead of `line.match(...)`. Also logged this learning to `.jules/bolt.md`.

🎯 **Why**: In JavaScript, evaluating a literal regex inside a loop creates a new `RegExp` object instance on every iteration. When parsing large, append-only logs like `events.jsonl` with potentially thousands of lines, this instantiation overhead accumulates, creating a minor but measurable bottleneck. Hoisting the literal to a constant evaluates the regular expression and its state machine once, significantly decreasing execution time and reducing garbage collection pressure on the hot path.

📊 **Impact**: Expected to slightly speed up JSON log parsing execution times and memory allocations.

🔬 **Measurement**: Verify by benchmarking `getEventsSince()` or `readEvents()` with large JSON files, or by running `npm run benchmark`. Tested with `npm run build` and `npm run test` to verify functionality.

---
*PR created automatically by Jules for task [9011698945037828808](https://jules.google.com/task/9011698945037828808) started by @rfv-code*