### PR TITLE
⚡ Bolt: [performance improvement] Hoist regex in event logger

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -12,3 +12,8 @@
 
 **Learning:** Inner JSON fields might mistakenly contain match substrings like dates (e.g., inside the text of the event). Utilizing a strict, anchored regex check for extracting fields like timestamps directly (`/^{"ts":"([^"\\]+)"/`) avoids both `JSON.parse` overhead and incorrect partial string matches from `String.includes()`.
 **Action:** Use an anchored regex (`/^{"ts":"([^"\\]+)"/`) and check the captured group directly before falling back to full JSON parsing.
+
+## 2026-05-25 - Regex instantiation inside loops
+
+**Learning:** Re-compiling and re-evaluating regex literals inside a tight loop when parsing massive JSON log files adds unnecessary overhead. `String.prototype.match()` can also be marginally slower than `RegExp.prototype.exec()` for exact group matching.
+**Action:** When a regular expression is used strictly on hot paths to extract fields from logs, declare it as a module-level constant (hoisting it) and use `.exec()` instead of `.match()`.

--- a/skills/doc-wiki/scripts/event_logger.js
+++ b/skills/doc-wiki/scripts/event_logger.js
@@ -110,6 +110,13 @@ function _eventsPath(wikiRoot) {
  *
  * Returns the full logged entry dict.
  */
+/**
+ * Bolt Performance Optimization:
+ * Hoisting this timestamp extraction regex prevents re-compiling/instantiating
+ * the regex object inside the tight loop reading events.jsonl.
+ * Using RegExp.exec() on a non-global regex is also a fast path compared to String.match().
+ */
+const TS_FAST_PATH_REGEX = /^{"ts":"([^"\\]+)"/;
 export function logEvent(wikiRoot, op, details) {
     // Normalize agent_calls[] → compute totals if caller omitted them.
     const normalized = _normalizeAgentCalls(details);
@@ -156,7 +163,7 @@ function _readEvents(wikiRoot, since = null) {
             // leading whitespace. The character class excludes both `"` and `\` so
             // any ts containing a JSON escape (like `\+` for `+`) misses the regex
             // and safely falls through to the slow path for proper decoding.
-            const m = line.match(/^{"ts":"([^"\\]+)"/);
+            const m = TS_FAST_PATH_REGEX.exec(line);
             if (m) {
                 const entryMs = parsePythonIsoformat(m[1]);
                 // G-EVENTS-TS-STRICT: when --since is active, drop events whose

--- a/skills/doc-wiki/scripts/event_logger.ts
+++ b/skills/doc-wiki/scripts/event_logger.ts
@@ -135,6 +135,14 @@ function _eventsPath(wikiRoot: string): string {
  *
  * Returns the full logged entry dict.
  */
+/**
+ * Bolt Performance Optimization:
+ * Hoisting this timestamp extraction regex prevents re-compiling/instantiating
+ * the regex object inside the tight loop reading events.jsonl.
+ * Using RegExp.exec() on a non-global regex is also a fast path compared to String.match().
+ */
+const TS_FAST_PATH_REGEX = /^{"ts":"([^"\\]+)"/;
+
 export function logEvent(
   wikiRoot: string,
   op: string,
@@ -201,7 +209,7 @@ function _readEvents(
       // leading whitespace. The character class excludes both `"` and `\` so
       // any ts containing a JSON escape (like `\+` for `+`) misses the regex
       // and safely falls through to the slow path for proper decoding.
-      const m = line.match(/^{"ts":"([^"\\]+)"/);
+      const m = TS_FAST_PATH_REGEX.exec(line);
       if (m) {
         const entryMs = parsePythonIsoformat(m[1] as string);
         // G-EVENTS-TS-STRICT: when --since is active, drop events whose


### PR DESCRIPTION
- **What:** Hoisted the timestamp extraction regex `/^{"ts":"([^"\\]+)"/` out of the loop in `_readEvents` into `TS_FAST_PATH_REGEX` and replaced `line.match()` with `TS_FAST_PATH_REGEX.exec(line)`. Also added a Bolt optimization comment.
- **Why:** Re-evaluating the regex inside the loop adds unnecessary overhead on hot paths when processing large append-only log files. Hoisting it improves log parsing speed and `.exec()` is a faster path.
- **Impact:** Reduces parsing time of large `events.jsonl` files by avoiding regex instantiation/processing overhead per line.
- **Measurement:** Micro-benchmarks for log parsing will show faster execution for large jsonl files.

---
*PR created automatically by Jules for task [15154032977796508578](https://jules.google.com/task/15154032977796508578) started by @rfv-code*