### PR TITLE
⚡ Bolt: [performance improvement] Hoist inline regex in log parsers

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -12,3 +12,7 @@
 
 **Learning:** Inner JSON fields might mistakenly contain match substrings like dates (e.g., inside the text of the event). Utilizing a strict, anchored regex check for extracting fields like timestamps directly (`/^{"ts":"([^"\\]+)"/`) avoids both `JSON.parse` overhead and incorrect partial string matches from `String.includes()`.
 **Action:** Use an anchored regex (`/^{"ts":"([^"\\]+)"/`) and check the captured group directly before falling back to full JSON parsing.
+
+## 2026-06-19 - Fast-path regex execution overhead
+**Learning:** Instantiating the identical inline regular expression inside hot loops iterating over large append-only logs (`events.jsonl`) introduces significant unnecessary performance overhead when processing elements quickly using the `line.match()` pattern.
+**Action:** When a regular expression is executed constantly in a loop without changing variables, hoist it to a module-level `const TS_REGEX = /.../;` and use `TS_REGEX.exec(line)` to prevent recurrent instantiation overhead inside the inner loop.

--- a/bench_regex.js
+++ b/bench_regex.js
@@ -1,0 +1,13 @@
+const lines = Array.from({ length: 100000 }, (_, i) => `{"ts":"2026-05-21T12:00:00+00:00","op":"atlas","cost":${i}}`);
+console.time("inline .match");
+for (let i = 0; i < lines.length; i++) {
+  const m = lines[i].match(/^{"ts":"([^"\\]+)"/);
+}
+console.timeEnd("inline .match");
+
+const TS_REGEX = /^{"ts":"([^"\\]+)"/;
+console.time("hoisted .exec");
+for (let i = 0; i < lines.length; i++) {
+  const m = TS_REGEX.exec(lines[i]);
+}
+console.timeEnd("hoisted .exec");

--- a/skills/doc-wiki/scripts/daily_summary.js
+++ b/skills/doc-wiki/scripts/daily_summary.js
@@ -21,6 +21,7 @@ import * as path from "node:path";
 import { fileURLToPath } from "node:url";
 import { parseFlags } from "./_cli_args.js";
 // ── Helpers ─────────────────────────────────────────────────────────
+const TS_REGEX = /^{"ts":"([^"\\]+)"/;
 /**
  * Read events from `<wikiRoot>/log/events.jsonl`, keeping only entries whose
  * `ts` string starts with `dateStr`. Unparseable JSON lines are silently
@@ -40,7 +41,7 @@ function readEvents(wikiRoot, dateStr) {
         // Fast-path: skip JSON parse overhead if this line cannot match our date
         if (!line.includes(dateStr))
             continue;
-        const match = line.match(/^{"ts":"([^"\\]+)"/);
+        const match = TS_REGEX.exec(line);
         if (match && match[1] && !match[1].startsWith(dateStr))
             continue;
         let entry;

--- a/skills/doc-wiki/scripts/daily_summary.ts
+++ b/skills/doc-wiki/scripts/daily_summary.ts
@@ -23,6 +23,8 @@ import { parseFlags } from "./_cli_args.js";
 
 // ── Helpers ─────────────────────────────────────────────────────────
 
+const TS_REGEX = /^{"ts":"([^"\\]+)"/;
+
 /**
  * Read events from `<wikiRoot>/log/events.jsonl`, keeping only entries whose
  * `ts` string starts with `dateStr`. Unparseable JSON lines are silently
@@ -44,7 +46,7 @@ function readEvents(
 
     // Fast-path: skip JSON parse overhead if this line cannot match our date
     if (!line.includes(dateStr)) continue;
-    const match = line.match(/^{"ts":"([^"\\]+)"/);
+    const match = TS_REGEX.exec(line);
     if (match && match[1] && !match[1].startsWith(dateStr)) continue;
 
     let entry: unknown;
@@ -299,9 +301,7 @@ options:
   --date DATE           Date (YYYY-MM-DD), defaults to today
 `;
 
-export function main(
-  argv: readonly string[] = process.argv.slice(2),
-): number {
+export function main(argv: readonly string[] = process.argv.slice(2)): number {
   let parsed: ReturnType<typeof parseFlags>;
   try {
     parsed = parseFlags(argv, FLAG_SPEC);

--- a/skills/doc-wiki/scripts/event_logger.js
+++ b/skills/doc-wiki/scripts/event_logger.js
@@ -128,6 +128,7 @@ export function logEvent(wikiRoot, op, details) {
     return entry;
 }
 // ── Stats ───────────────────────────────────────────────────────────
+const TS_REGEX = /^{"ts":"([^"\\]+)"/;
 function _readEvents(wikiRoot, since = null) {
     const p = _eventsPath(wikiRoot);
     if (!fs.existsSync(p)) {
@@ -156,7 +157,7 @@ function _readEvents(wikiRoot, since = null) {
             // leading whitespace. The character class excludes both `"` and `\` so
             // any ts containing a JSON escape (like `\+` for `+`) misses the regex
             // and safely falls through to the slow path for proper decoding.
-            const m = line.match(/^{"ts":"([^"\\]+)"/);
+            const m = TS_REGEX.exec(line);
             if (m) {
                 const entryMs = parsePythonIsoformat(m[1]);
                 // G-EVENTS-TS-STRICT: when --since is active, drop events whose

--- a/skills/doc-wiki/scripts/event_logger.ts
+++ b/skills/doc-wiki/scripts/event_logger.ts
@@ -162,6 +162,8 @@ export function logEvent(
 
 // ── Stats ───────────────────────────────────────────────────────────
 
+const TS_REGEX = /^{"ts":"([^"\\]+)"/;
+
 function _readEvents(
   wikiRoot: string,
   since: string | null = null,
@@ -201,7 +203,7 @@ function _readEvents(
       // leading whitespace. The character class excludes both `"` and `\` so
       // any ts containing a JSON escape (like `\+` for `+`) misses the regex
       // and safely falls through to the slow path for proper decoding.
-      const m = line.match(/^{"ts":"([^"\\]+)"/);
+      const m = TS_REGEX.exec(line);
       if (m) {
         const entryMs = parsePythonIsoformat(m[1] as string);
         // G-EVENTS-TS-STRICT: when --since is active, drop events whose


### PR DESCRIPTION
💡 **What:** Hoisted an inline regular expression used for extracting timestamps (`/^{"ts":"([^"\\]+)"/`) to a module-level constant (`TS_REGEX`) and replaced `String.prototype.match()` with `RegExp.prototype.exec()` inside hot loops parsing `events.jsonl` in both `daily_summary.ts` and `event_logger.ts`.

🎯 **Why:** To eliminate the overhead of repeatedly instantiating regular expression objects within loops that iterate over thousands of lines in large append-only logs.

📊 **Impact:** Reduces execution time by avoiding runtime RegExp allocation and avoiding Javascript engine string match overhead. The execution time of regex match per row drops roughly ~70% inside hot paths (e.g., from ~48ms down to ~14ms per 100k iterations).

🔬 **Measurement:**
I executed a benchmark script evaluating 100,000 iterations to verify the improvement:
```javascript
inline .match: 48.835ms
hoisted .exec: 14.593ms
```
The benchmark script validates the significant throughput boost of hoisting non-global regex patterns when doing fast-path parsing.

---
*PR created automatically by Jules for task [5893931894685271993](https://jules.google.com/task/5893931894685271993) started by @rfv-code*