### PR TITLE
⚡ Bolt: [performance improvement] Hoist regex extraction in event parsing

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -12,3 +12,7 @@
 
 **Learning:** Inner JSON fields might mistakenly contain match substrings like dates (e.g., inside the text of the event). Utilizing a strict, anchored regex check for extracting fields like timestamps directly (`/^{"ts":"([^"\\]+)"/`) avoids both `JSON.parse` overhead and incorrect partial string matches from `String.includes()`.
 **Action:** Use an anchored regex (`/^{"ts":"([^"\\]+)"/`) and check the captured group directly before falling back to full JSON parsing.
+
+## 2026-06-20 - Hoist regex literals in hot loops
+**Learning:** Regex literals instantiated inside hot loops (like parsing large JSONL files line-by-line) incur unnecessary instantiation overhead.
+**Action:** Hoist regex literals to module-level constants and use `.exec()` instead of `String.prototype.match()` to improve performance on hot paths.

--- a/skills/doc-wiki/scripts/daily_summary.js
+++ b/skills/doc-wiki/scripts/daily_summary.js
@@ -21,6 +21,7 @@ import * as path from "node:path";
 import { fileURLToPath } from "node:url";
 import { parseFlags } from "./_cli_args.js";
 // ── Helpers ─────────────────────────────────────────────────────────
+const TS_REGEX = /^{"ts":"([^"\\]+)"/;
 /**
  * Read events from `<wikiRoot>/log/events.jsonl`, keeping only entries whose
  * `ts` string starts with `dateStr`. Unparseable JSON lines are silently
@@ -40,7 +41,7 @@ function readEvents(wikiRoot, dateStr) {
         // Fast-path: skip JSON parse overhead if this line cannot match our date
         if (!line.includes(dateStr))
             continue;
-        const match = line.match(/^{"ts":"([^"\\]+)"/);
+        const match = TS_REGEX.exec(line);
         if (match && match[1] && !match[1].startsWith(dateStr))
             continue;
         let entry;

--- a/skills/doc-wiki/scripts/daily_summary.ts
+++ b/skills/doc-wiki/scripts/daily_summary.ts
@@ -23,6 +23,8 @@ import { parseFlags } from "./_cli_args.js";
 
 // ── Helpers ─────────────────────────────────────────────────────────
 
+const TS_REGEX = /^{"ts":"([^"\\]+)"/;
+
 /**
  * Read events from `<wikiRoot>/log/events.jsonl`, keeping only entries whose
  * `ts` string starts with `dateStr`. Unparseable JSON lines are silently
@@ -44,7 +46,7 @@ function readEvents(
 
     // Fast-path: skip JSON parse overhead if this line cannot match our date
     if (!line.includes(dateStr)) continue;
-    const match = line.match(/^{"ts":"([^"\\]+)"/);
+    const match = TS_REGEX.exec(line);
     if (match && match[1] && !match[1].startsWith(dateStr)) continue;
 
     let entry: unknown;

--- a/skills/doc-wiki/scripts/event_logger.js
+++ b/skills/doc-wiki/scripts/event_logger.js
@@ -128,6 +128,7 @@ export function logEvent(wikiRoot, op, details) {
     return entry;
 }
 // ── Stats ───────────────────────────────────────────────────────────
+const TS_REGEX = /^{"ts":"([^"\\]+)"/;
 function _readEvents(wikiRoot, since = null) {
     const p = _eventsPath(wikiRoot);
     if (!fs.existsSync(p)) {
@@ -156,7 +157,7 @@ function _readEvents(wikiRoot, since = null) {
             // leading whitespace. The character class excludes both `"` and `\` so
             // any ts containing a JSON escape (like `\+` for `+`) misses the regex
             // and safely falls through to the slow path for proper decoding.
-            const m = line.match(/^{"ts":"([^"\\]+)"/);
+            const m = TS_REGEX.exec(line);
             if (m) {
                 const entryMs = parsePythonIsoformat(m[1]);
                 // G-EVENTS-TS-STRICT: when --since is active, drop events whose

--- a/skills/doc-wiki/scripts/event_logger.ts
+++ b/skills/doc-wiki/scripts/event_logger.ts
@@ -162,6 +162,8 @@ export function logEvent(
 
 // ── Stats ───────────────────────────────────────────────────────────
 
+const TS_REGEX = /^{"ts":"([^"\\]+)"/;
+
 function _readEvents(
   wikiRoot: string,
   since: string | null = null,
@@ -201,7 +203,7 @@ function _readEvents(
       // leading whitespace. The character class excludes both `"` and `\` so
       // any ts containing a JSON escape (like `\+` for `+`) misses the regex
       // and safely falls through to the slow path for proper decoding.
-      const m = line.match(/^{"ts":"([^"\\]+)"/);
+      const m = TS_REGEX.exec(line);
       if (m) {
         const entryMs = parsePythonIsoformat(m[1] as string);
         // G-EVENTS-TS-STRICT: when --since is active, drop events whose


### PR DESCRIPTION
💡 What: Hoisted the timestamp extraction regex to a module-level constant and used `.exec()` instead of `.match()`.
🎯 Why: Instantiating a regex literal inside a loop over a large log file incurs unnecessary overhead.
📊 Impact: Improves log parsing performance by reducing allocation overhead in hot loops.
🔬 Measurement: Measurable via benchmarking `readEvents` or `_readEvents` execution time on large `events.jsonl` files.

---
*PR created automatically by Jules for task [16544896229318343917](https://jules.google.com/task/16544896229318343917) started by @rfv-code*