### PR TITLE
⚡ Bolt: Extract timestamp regex to module constant in hot loops

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -12,3 +12,8 @@
 
 **Learning:** Inner JSON fields might mistakenly contain match substrings like dates (e.g., inside the text of the event). Utilizing a strict, anchored regex check for extracting fields like timestamps directly (`/^{"ts":"([^"\\]+)"/`) avoids both `JSON.parse` overhead and incorrect partial string matches from `String.includes()`.
 **Action:** Use an anchored regex (`/^{"ts":"([^"\\]+)"/`) and check the captured group directly before falling back to full JSON parsing.
+
+## 2024-06-24 - Optimization of timestamp parsing inside hot loops
+
+**Learning:** Hoisting regexes used repeatedly (like `/^{"ts":"([^"\\]+)"/`) outside hot loops rather than declaring them inside prevents repetitive compilation and significantly speeds up execution.
+**Action:** Extract such regex definitions to module-level constants and use `.exec()` instead of `String.prototype.match()` within the loop.

--- a/skills/doc-wiki/scripts/daily_summary.js
+++ b/skills/doc-wiki/scripts/daily_summary.js
@@ -21,6 +21,7 @@ import * as path from "node:path";
 import { fileURLToPath } from "node:url";
 import { parseFlags } from "./_cli_args.js";
 // ── Helpers ─────────────────────────────────────────────────────────
+const TS_FAST_PATH_REGEX = /^{"ts":"([^"\\]+)"/;
 /**
  * Read events from `<wikiRoot>/log/events.jsonl`, keeping only entries whose
  * `ts` string starts with `dateStr`. Unparseable JSON lines are silently
@@ -40,7 +41,7 @@ function readEvents(wikiRoot, dateStr) {
         // Fast-path: skip JSON parse overhead if this line cannot match our date
         if (!line.includes(dateStr))
             continue;
-        const match = line.match(/^{"ts":"([^"\\]+)"/);
+        const match = TS_FAST_PATH_REGEX.exec(line);
         if (match && match[1] && !match[1].startsWith(dateStr))
             continue;
         let entry;

--- a/skills/doc-wiki/scripts/daily_summary.ts
+++ b/skills/doc-wiki/scripts/daily_summary.ts
@@ -23,6 +23,8 @@ import { parseFlags } from "./_cli_args.js";
 
 // ── Helpers ─────────────────────────────────────────────────────────
 
+const TS_FAST_PATH_REGEX = /^{"ts":"([^"\\]+)"/;
+
 /**
  * Read events from `<wikiRoot>/log/events.jsonl`, keeping only entries whose
  * `ts` string starts with `dateStr`. Unparseable JSON lines are silently
@@ -44,7 +46,7 @@ function readEvents(
 
     // Fast-path: skip JSON parse overhead if this line cannot match our date
     if (!line.includes(dateStr)) continue;
-    const match = line.match(/^{"ts":"([^"\\]+)"/);
+    const match = TS_FAST_PATH_REGEX.exec(line);
     if (match && match[1] && !match[1].startsWith(dateStr)) continue;
 
     let entry: unknown;
@@ -299,9 +301,7 @@ options:
   --date DATE           Date (YYYY-MM-DD), defaults to today
 `;
 
-export function main(
-  argv: readonly string[] = process.argv.slice(2),
-): number {
+export function main(argv: readonly string[] = process.argv.slice(2)): number {
   let parsed: ReturnType<typeof parseFlags>;
   try {
     parsed = parseFlags(argv, FLAG_SPEC);

--- a/skills/doc-wiki/scripts/event_logger.js
+++ b/skills/doc-wiki/scripts/event_logger.js
@@ -128,6 +128,7 @@ export function logEvent(wikiRoot, op, details) {
     return entry;
 }
 // ── Stats ───────────────────────────────────────────────────────────
+const TS_FAST_PATH_REGEX = /^{"ts":"([^"\\]+)"/;
 function _readEvents(wikiRoot, since = null) {
     const p = _eventsPath(wikiRoot);
     if (!fs.existsSync(p)) {
@@ -156,7 +157,7 @@ function _readEvents(wikiRoot, since = null) {
             // leading whitespace. The character class excludes both `"` and `\` so
             // any ts containing a JSON escape (like `\+` for `+`) misses the regex
             // and safely falls through to the slow path for proper decoding.
-            const m = line.match(/^{"ts":"([^"\\]+)"/);
+            const m = TS_FAST_PATH_REGEX.exec(line);
             if (m) {
                 const entryMs = parsePythonIsoformat(m[1]);
                 // G-EVENTS-TS-STRICT: when --since is active, drop events whose

--- a/skills/doc-wiki/scripts/event_logger.ts
+++ b/skills/doc-wiki/scripts/event_logger.ts
@@ -162,6 +162,8 @@ export function logEvent(
 
 // ── Stats ───────────────────────────────────────────────────────────
 
+const TS_FAST_PATH_REGEX = /^{"ts":"([^"\\]+)"/;
+
 function _readEvents(
   wikiRoot: string,
   since: string | null = null,
@@ -201,7 +203,7 @@ function _readEvents(
       // leading whitespace. The character class excludes both `"` and `\` so
       // any ts containing a JSON escape (like `\+` for `+`) misses the regex
       // and safely falls through to the slow path for proper decoding.
-      const m = line.match(/^{"ts":"([^"\\]+)"/);
+      const m = TS_FAST_PATH_REGEX.exec(line);
       if (m) {
         const entryMs = parsePythonIsoformat(m[1] as string);
         // G-EVENTS-TS-STRICT: when --since is active, drop events whose


### PR DESCRIPTION
💡 What: Extract the inline regex `/^{"ts":"([^"\\]+)"/` into a module-level constant (`TS_FAST_PATH_REGEX`) in both `event_logger.ts` and `daily_summary.ts`, replacing `.match()` with `.exec()`.
🎯 Why: Inside the hot loop iterating over thousands of lines in `events.jsonl`, avoiding the inline instantiation and using the faster `.exec()` reduces unnecessary object creation and dispatch overhead.
📊 Impact: Very slightly faster timestamp parsing per line during log extraction. 
🔬 Measurement: Verify tests still pass to make sure functionality isn't broken. Measurements across massive lists would show a small but steady improvement due to reduced overhead.

---
*PR created automatically by Jules for task [15456148342771304096](https://jules.google.com/task/15456148342771304096) started by @rfv-code*