### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix command injection in hook installer

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-06-24 - [Command Injection via Double Quotes]
+**Vulnerability:** Double quoting unescaped variables like `wikiRoot` in shell commands allows command injection because double quotes do not prevent bash expansion or command substitution.
+**Learning:** `JSON.stringify` only escapes double quotes and wraps strings in double quotes. It is insecure for UNIX shell environments.
+**Prevention:** Use a proper escaping method for UNIX shell, like wrapping in single quotes and replacing inner single quotes with `'\''`.

--- a/skills/doc-wiki/scripts/hook_installer.js
+++ b/skills/doc-wiki/scripts/hook_installer.js
@@ -107,71 +107,6 @@ function arrayContainsEntry(arr, item) {
     }
     return false;
 }
-/**
- * True when `command` is a doc-wiki–managed hook command — one that
- * invokes our `security_check.js` guard with `--wiki-root`. Used to
- * distinguish our own entries (safe to refresh) from user-authored hooks
- * (must never be touched).
- */
-function isManagedHookCommand(command) {
-    return (typeof command === "string" &&
-        command.includes("security_check.js") &&
-        command.includes("--wiki-root"));
-}
-/**
- * Refresh the stored command of any pre-existing doc-wiki–managed entry
- * in `target` to match the freshly-built `incoming` entry with the same
- * matcher. `deepMergePreferExisting` skips an incoming entry whenever its
- * matcher already exists, so an install created before a security fix
- * keeps its outdated (e.g. unescaped, injectable) command string. This
- * pass upgrades those in place. Entries whose command does not invoke our
- * `security_check.js` are user-authored and left untouched.
- *
- * Handles both hook shapes:
- *   - Claude Code:   `{ matcher, hooks: [{ type, command }] }`
- *   - Codex/Cursor:  `{ matcher, command }`
- */
-function refreshManagedEntries(target, incoming) {
-    if (!Array.isArray(target) || !Array.isArray(incoming))
-        return;
-    for (const existing of target) {
-        if (existing === null || typeof existing !== "object" || Array.isArray(existing)) {
-            continue;
-        }
-        const entry = existing;
-        const matcher = entry["matcher"];
-        if (typeof matcher !== "string")
-            continue;
-        const fresh = incoming.find((i) => i !== null &&
-            typeof i === "object" &&
-            !Array.isArray(i) &&
-            i["matcher"] === matcher);
-        if (!fresh)
-            continue;
-        // Codex/Cursor shape: top-level command.
-        if (isManagedHookCommand(entry["command"]) && typeof fresh["command"] === "string") {
-            entry["command"] = fresh["command"];
-        }
-        // Claude Code shape: nested hooks[].command.
-        if (Array.isArray(entry["hooks"]) && Array.isArray(fresh["hooks"])) {
-            const freshCmd = fresh["hooks"]
-                .map((h) => h !== null && typeof h === "object" && !Array.isArray(h)
-                ? h["command"]
-                : undefined)
-                .find((c) => typeof c === "string");
-            if (typeof freshCmd === "string") {
-                for (const h of entry["hooks"]) {
-                    if (h !== null && typeof h === "object" && !Array.isArray(h)) {
-                        const hook = h;
-                        if (isManagedHookCommand(hook["command"])) {
-                            hook["command"] = freshCmd;
-                        }
-                    }
-                }
-            }
-        }
-    }
-}
 // ── JSON file I/O ──────────────────────────────────────────────────────
 function readJsonFile(filePath) {
     if (!fs.existsSync(filePath))
@@ -244,10 +179,6 @@ export function installClaudeCodeHooks(wikiRoot) {
         },
     };
     const merged = deepMergePreferExisting(existing, incoming);
-    const hooks = merged["hooks"];
-    if (hooks !== null && typeof hooks === "object" && !Array.isArray(hooks)) {
-        refreshManagedEntries(hooks["PreToolUse"], claudeCodeHookEntries(wikiRoot));
-    }
     const installed = writeJsonIfChanged(settingsPath, merged);
     return { installed, settingsPath };
 }
@@ -267,7 +198,6 @@ export function installCodexHooks(wikiRoot) {
         preToolUse: codexHookEntries(wikiRoot),
     };
     const merged = deepMergePreferExisting(existing, incoming);
-    refreshManagedEntries(merged["preToolUse"], codexHookEntries(wikiRoot));
     const installed = writeJsonIfChanged(settingsPath, merged);
     return { installed, settingsPath };
 }
@@ -287,7 +217,6 @@ export function installCursorHooks(wikiRoot) {
         preToolUse: cursorHookEntries(wikiRoot),
     };
     const merged = deepMergePreferExisting(existing, incoming);
-    refreshManagedEntries(merged["preToolUse"], cursorHookEntries(wikiRoot));
     const installed = writeJsonIfChanged(settingsPath, merged);
     return { installed, settingsPath };
 }

--- a/skills/doc-wiki/scripts/hook_installer.js
+++ b/skills/doc-wiki/scripts/hook_installer.js
@@ -107,6 +107,71 @@ function arrayContainsEntry(arr, item) {
     }
     return false;
 }
+/**
+ * True when `command` is a doc-wiki–managed hook command — one that
+ * invokes our `security_check.js` guard with `--wiki-root`. Used to
+ * distinguish our own entries (safe to refresh) from user-authored hooks
+ * (must never be touched).
+ */
+function isManagedHookCommand(command) {
+    return (typeof command === "string" &&
+        command.includes("security_check.js") &&
+        command.includes("--wiki-root"));
+}
+/**
+ * Refresh the stored command of any pre-existing doc-wiki–managed entry
+ * in `target` to match the freshly-built `incoming` entry with the same
+ * matcher. `deepMergePreferExisting` skips an incoming entry whenever its
+ * matcher already exists, so an install created before a security fix
+ * keeps its outdated (e.g. unescaped, injectable) command string. This
+ * pass upgrades those in place. Entries whose command does not invoke our
+ * `security_check.js` are user-authored and left untouched.
+ *
+ * Handles both hook shapes:
+ *   - Claude Code:   `{ matcher, hooks: [{ type, command }] }`
+ *   - Codex/Cursor:  `{ matcher, command }`
+ */
+function refreshManagedEntries(target, incoming) {
+    if (!Array.isArray(target) || !Array.isArray(incoming))
+        return;
+    for (const existing of target) {
+        if (existing === null || typeof existing !== "object" || Array.isArray(existing)) {
+            continue;
+        }
+        const entry = existing;
+        const matcher = entry["matcher"];
+        if (typeof matcher !== "string")
+            continue;
+        const fresh = incoming.find((i) => i !== null &&
+            typeof i === "object" &&
+            !Array.isArray(i) &&
+            i["matcher"] === matcher);
+        if (!fresh)
+            continue;
+        // Codex/Cursor shape: top-level command.
+        if (isManagedHookCommand(entry["command"]) && typeof fresh["command"] === "string") {
+            entry["command"] = fresh["command"];
+        }
+        // Claude Code shape: nested hooks[].command.
+        if (Array.isArray(entry["hooks"]) && Array.isArray(fresh["hooks"])) {
+            const freshCmd = fresh["hooks"]
+                .map((h) => h !== null && typeof h === "object" && !Array.isArray(h)
+                ? h["command"]
+                : undefined)
+                .find((c) => typeof c === "string");
+            if (typeof freshCmd === "string") {
+                for (const h of entry["hooks"]) {
+                    if (h !== null && typeof h === "object" && !Array.isArray(h)) {
+                        const hook = h;
+                        if (isManagedHookCommand(hook["command"])) {
+                            hook["command"] = freshCmd;
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
 // ── JSON file I/O ──────────────────────────────────────────────────────
 function readJsonFile(filePath) {
     if (!fs.existsSync(filePath))
@@ -179,6 +244,10 @@ export function installClaudeCodeHooks(wikiRoot) {
         },
     };
     const merged = deepMergePreferExisting(existing, incoming);
+    const hooks = merged["hooks"];
+    if (hooks !== null && typeof hooks === "object" && !Array.isArray(hooks)) {
+        refreshManagedEntries(hooks["PreToolUse"], claudeCodeHookEntries(wikiRoot));
+    }
     const installed = writeJsonIfChanged(settingsPath, merged);
     return { installed, settingsPath };
 }
@@ -198,6 +267,7 @@ export function installCodexHooks(wikiRoot) {
         preToolUse: codexHookEntries(wikiRoot),
     };
     const merged = deepMergePreferExisting(existing, incoming);
+    refreshManagedEntries(merged["preToolUse"], codexHookEntries(wikiRoot));
     const installed = writeJsonIfChanged(settingsPath, merged);
     return { installed, settingsPath };
 }
@@ -217,6 +287,7 @@ export function installCursorHooks(wikiRoot) {
         preToolUse: cursorHookEntries(wikiRoot),
     };
     const merged = deepMergePreferExisting(existing, incoming);
+    refreshManagedEntries(merged["preToolUse"], cursorHookEntries(wikiRoot));
     const installed = writeJsonIfChanged(settingsPath, merged);
     return { installed, settingsPath };
 }

--- a/skills/doc-wiki/scripts/hook_installer.js
+++ b/skills/doc-wiki/scripts/hook_installer.js
@@ -33,6 +33,11 @@ function securityCheckPath() {
     const here = path.dirname(new URL(import.meta.url).pathname);
     return path.join(here, "security_check.js");
 }
+function escapeShellArg(arg) {
+    // Wrap string in single quotes and escape any internal single quotes.
+    // E.g., foo'bar -> 'foo'\''bar'
+    return "'" + arg.replace(/'/g, "'\\''") + "'";
+}
 /**
  * Deep-merge `incoming` into `base`, preferring existing user keys.
  * For plain objects, missing keys are added and existing keys are left
@@ -144,7 +149,7 @@ function writeJsonIfChanged(filePath, contents) {
  *   - `Write|Edit|MultiEdit` — path-containment check for wiki/raw paths
  */
 function claudeCodeHookEntries(wikiRoot) {
-    const cmd = (flag) => `node "${securityCheckPath()}" ${flag} --wiki-root "${wikiRoot}"`;
+    const cmd = (flag) => `node ${escapeShellArg(securityCheckPath())} ${flag} --wiki-root ${escapeShellArg(wikiRoot)}`;
     return [
         {
             matcher: "WebFetch",
@@ -179,7 +184,7 @@ export function installClaudeCodeHooks(wikiRoot) {
 }
 // ── Codex installer ────────────────────────────────────────────────────
 function codexHookEntries(wikiRoot) {
-    const cmd = (flag) => `node "${securityCheckPath()}" ${flag} --wiki-root "${wikiRoot}"`;
+    const cmd = (flag) => `node ${escapeShellArg(securityCheckPath())} ${flag} --wiki-root ${escapeShellArg(wikiRoot)}`;
     return [
         { matcher: "WebFetch", command: cmd("--tool-input-url") },
         { matcher: "WebSearch", command: cmd("--tool-input-url") },
@@ -198,7 +203,7 @@ export function installCodexHooks(wikiRoot) {
 }
 // ── Cursor installer ───────────────────────────────────────────────────
 function cursorHookEntries(wikiRoot) {
-    const cmd = (flag) => `node "${securityCheckPath()}" ${flag} --wiki-root "${wikiRoot}"`;
+    const cmd = (flag) => `node ${escapeShellArg(securityCheckPath())} ${flag} --wiki-root ${escapeShellArg(wikiRoot)}`;
     return [
         { matcher: "WebFetch", command: cmd("--tool-input-url") },
         { matcher: "WebSearch", command: cmd("--tool-input-url") },
@@ -232,10 +237,10 @@ function aiderManagedBlock(wikiRoot) {
         `pre_tool_use() {`,
         `  case "$TOOL_NAME" in`,
         `    WebFetch|WebSearch)`,
-        `      node "${sc}" --tool-input-url --wiki-root "${wikiRoot}" || return 1`,
+        `      node ${escapeShellArg(sc)} --tool-input-url --wiki-root ${escapeShellArg(wikiRoot)} || return 1`,
         `      ;;`,
         `    Write|Edit|MultiEdit)`,
-        `      node "${sc}" --tool-input-path --wiki-root "${wikiRoot}" || return 1`,
+        `      node ${escapeShellArg(sc)} --tool-input-path --wiki-root ${escapeShellArg(wikiRoot)} || return 1`,
         `      ;;`,
         `  esac`,
         `}`,

--- a/skills/doc-wiki/scripts/hook_installer.ts
+++ b/skills/doc-wiki/scripts/hook_installer.ts
@@ -126,79 +126,6 @@ function arrayContainsEntry(arr: Json[], item: Json): boolean {
   return false;
 }
 
-/**
- * True when `command` is a doc-wiki–managed hook command — one that
- * invokes our `security_check.js` guard with `--wiki-root`. Used to
- * distinguish our own entries (safe to refresh) from user-authored hooks
- * (must never be touched).
- */
-function isManagedHookCommand(command: Json | undefined): command is string {
-  return (
-    typeof command === "string" &&
-    command.includes("security_check.js") &&
-    command.includes("--wiki-root")
-  );
-}
-
-/**
- * Refresh the stored command of any pre-existing doc-wiki–managed entry
- * in `target` to match the freshly-built `incoming` entry with the same
- * matcher. `deepMergePreferExisting` skips an incoming entry whenever its
- * matcher already exists, so an install created before a security fix
- * keeps its outdated (e.g. unescaped, injectable) command string. This
- * pass upgrades those in place. Entries whose command does not invoke our
- * `security_check.js` are user-authored and left untouched.
- *
- * Handles both hook shapes:
- *   - Claude Code:   `{ matcher, hooks: [{ type, command }] }`
- *   - Codex/Cursor:  `{ matcher, command }`
- */
-function refreshManagedEntries(target: Json | undefined, incoming: Json): void {
-  if (!Array.isArray(target) || !Array.isArray(incoming)) return;
-  for (const existing of target) {
-    if (existing === null || typeof existing !== "object" || Array.isArray(existing)) {
-      continue;
-    }
-    const entry = existing as { [k: string]: Json };
-    const matcher = entry["matcher"];
-    if (typeof matcher !== "string") continue;
-    const fresh = incoming.find(
-      (i) =>
-        i !== null &&
-        typeof i === "object" &&
-        !Array.isArray(i) &&
-        (i as { [k: string]: Json })["matcher"] === matcher,
-    ) as { [k: string]: Json } | undefined;
-    if (!fresh) continue;
-
-    // Codex/Cursor shape: top-level command.
-    if (isManagedHookCommand(entry["command"]) && typeof fresh["command"] === "string") {
-      entry["command"] = fresh["command"];
-    }
-
-    // Claude Code shape: nested hooks[].command.
-    if (Array.isArray(entry["hooks"]) && Array.isArray(fresh["hooks"])) {
-      const freshCmd = (fresh["hooks"] as Json[])
-        .map((h) =>
-          h !== null && typeof h === "object" && !Array.isArray(h)
-            ? (h as { [k: string]: Json })["command"]
-            : undefined,
-        )
-        .find((c): c is string => typeof c === "string");
-      if (typeof freshCmd === "string") {
-        for (const h of entry["hooks"] as Json[]) {
-          if (h !== null && typeof h === "object" && !Array.isArray(h)) {
-            const hook = h as { [k: string]: Json };
-            if (isManagedHookCommand(hook["command"])) {
-              hook["command"] = freshCmd;
-            }
-          }
-        }
-      }
-    }
-  }
-}
-
 // ── JSON file I/O ──────────────────────────────────────────────────────
 
 function readJsonFile(filePath: string): Json | null {
@@ -276,16 +203,7 @@ export function installClaudeCodeHooks(wikiRoot: string): InstallResult {
     },
   };
 
-  const merged = deepMergePreferExisting(existing, incoming) as {
-    [k: string]: Json;
-  };
-  const hooks = merged["hooks"];
-  if (hooks !== null && typeof hooks === "object" && !Array.isArray(hooks)) {
-    refreshManagedEntries(
-      (hooks as { [k: string]: Json })["PreToolUse"],
-      claudeCodeHookEntries(wikiRoot),
-    );
-  }
+  const merged = deepMergePreferExisting(existing, incoming);
   const installed = writeJsonIfChanged(settingsPath, merged);
   return { installed, settingsPath };
 }
@@ -312,10 +230,7 @@ export function installCodexHooks(wikiRoot: string): InstallResult {
     preToolUse: codexHookEntries(wikiRoot),
   };
 
-  const merged = deepMergePreferExisting(existing, incoming) as {
-    [k: string]: Json;
-  };
-  refreshManagedEntries(merged["preToolUse"], codexHookEntries(wikiRoot));
+  const merged = deepMergePreferExisting(existing, incoming);
   const installed = writeJsonIfChanged(settingsPath, merged);
   return { installed, settingsPath };
 }
@@ -342,10 +257,7 @@ export function installCursorHooks(wikiRoot: string): InstallResult {
     preToolUse: cursorHookEntries(wikiRoot),
   };
 
-  const merged = deepMergePreferExisting(existing, incoming) as {
-    [k: string]: Json;
-  };
-  refreshManagedEntries(merged["preToolUse"], cursorHookEntries(wikiRoot));
+  const merged = deepMergePreferExisting(existing, incoming);
   const installed = writeJsonIfChanged(settingsPath, merged);
   return { installed, settingsPath };
 }

--- a/skills/doc-wiki/scripts/hook_installer.ts
+++ b/skills/doc-wiki/scripts/hook_installer.ts
@@ -126,6 +126,79 @@ function arrayContainsEntry(arr: Json[], item: Json): boolean {
   return false;
 }
 
+/**
+ * True when `command` is a doc-wiki–managed hook command — one that
+ * invokes our `security_check.js` guard with `--wiki-root`. Used to
+ * distinguish our own entries (safe to refresh) from user-authored hooks
+ * (must never be touched).
+ */
+function isManagedHookCommand(command: Json | undefined): command is string {
+  return (
+    typeof command === "string" &&
+    command.includes("security_check.js") &&
+    command.includes("--wiki-root")
+  );
+}
+
+/**
+ * Refresh the stored command of any pre-existing doc-wiki–managed entry
+ * in `target` to match the freshly-built `incoming` entry with the same
+ * matcher. `deepMergePreferExisting` skips an incoming entry whenever its
+ * matcher already exists, so an install created before a security fix
+ * keeps its outdated (e.g. unescaped, injectable) command string. This
+ * pass upgrades those in place. Entries whose command does not invoke our
+ * `security_check.js` are user-authored and left untouched.
+ *
+ * Handles both hook shapes:
+ *   - Claude Code:   `{ matcher, hooks: [{ type, command }] }`
+ *   - Codex/Cursor:  `{ matcher, command }`
+ */
+function refreshManagedEntries(target: Json | undefined, incoming: Json): void {
+  if (!Array.isArray(target) || !Array.isArray(incoming)) return;
+  for (const existing of target) {
+    if (existing === null || typeof existing !== "object" || Array.isArray(existing)) {
+      continue;
+    }
+    const entry = existing as { [k: string]: Json };
+    const matcher = entry["matcher"];
+    if (typeof matcher !== "string") continue;
+    const fresh = incoming.find(
+      (i) =>
+        i !== null &&
+        typeof i === "object" &&
+        !Array.isArray(i) &&
+        (i as { [k: string]: Json })["matcher"] === matcher,
+    ) as { [k: string]: Json } | undefined;
+    if (!fresh) continue;
+
+    // Codex/Cursor shape: top-level command.
+    if (isManagedHookCommand(entry["command"]) && typeof fresh["command"] === "string") {
+      entry["command"] = fresh["command"];
+    }
+
+    // Claude Code shape: nested hooks[].command.
+    if (Array.isArray(entry["hooks"]) && Array.isArray(fresh["hooks"])) {
+      const freshCmd = (fresh["hooks"] as Json[])
+        .map((h) =>
+          h !== null && typeof h === "object" && !Array.isArray(h)
+            ? (h as { [k: string]: Json })["command"]
+            : undefined,
+        )
+        .find((c): c is string => typeof c === "string");
+      if (typeof freshCmd === "string") {
+        for (const h of entry["hooks"] as Json[]) {
+          if (h !== null && typeof h === "object" && !Array.isArray(h)) {
+            const hook = h as { [k: string]: Json };
+            if (isManagedHookCommand(hook["command"])) {
+              hook["command"] = freshCmd;
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
 // ── JSON file I/O ──────────────────────────────────────────────────────
 
 function readJsonFile(filePath: string): Json | null {
@@ -203,7 +276,16 @@ export function installClaudeCodeHooks(wikiRoot: string): InstallResult {
     },
   };
 
-  const merged = deepMergePreferExisting(existing, incoming);
+  const merged = deepMergePreferExisting(existing, incoming) as {
+    [k: string]: Json;
+  };
+  const hooks = merged["hooks"];
+  if (hooks !== null && typeof hooks === "object" && !Array.isArray(hooks)) {
+    refreshManagedEntries(
+      (hooks as { [k: string]: Json })["PreToolUse"],
+      claudeCodeHookEntries(wikiRoot),
+    );
+  }
   const installed = writeJsonIfChanged(settingsPath, merged);
   return { installed, settingsPath };
 }
@@ -230,7 +312,10 @@ export function installCodexHooks(wikiRoot: string): InstallResult {
     preToolUse: codexHookEntries(wikiRoot),
   };
 
-  const merged = deepMergePreferExisting(existing, incoming);
+  const merged = deepMergePreferExisting(existing, incoming) as {
+    [k: string]: Json;
+  };
+  refreshManagedEntries(merged["preToolUse"], codexHookEntries(wikiRoot));
   const installed = writeJsonIfChanged(settingsPath, merged);
   return { installed, settingsPath };
 }
@@ -257,7 +342,10 @@ export function installCursorHooks(wikiRoot: string): InstallResult {
     preToolUse: cursorHookEntries(wikiRoot),
   };
 
-  const merged = deepMergePreferExisting(existing, incoming);
+  const merged = deepMergePreferExisting(existing, incoming) as {
+    [k: string]: Json;
+  };
+  refreshManagedEntries(merged["preToolUse"], cursorHookEntries(wikiRoot));
   const installed = writeJsonIfChanged(settingsPath, merged);
   return { installed, settingsPath };
 }

--- a/skills/doc-wiki/scripts/hook_installer.ts
+++ b/skills/doc-wiki/scripts/hook_installer.ts
@@ -41,6 +41,13 @@ function securityCheckPath(): string {
   return path.join(here, "security_check.js");
 }
 
+
+function escapeShellArg(arg: string): string {
+  // Wrap string in single quotes and escape any internal single quotes.
+  // E.g., foo'bar -> 'foo'\''bar'
+  return "'" + arg.replace(/'/g, "'\\''") + "'";
+}
+
 // ── Deep merge helper ──────────────────────────────────────────────────
 
 type Json = null | boolean | number | string | Json[] | { [k: string]: Json };
@@ -162,7 +169,7 @@ function writeJsonIfChanged(filePath: string, contents: Json): boolean {
  */
 function claudeCodeHookEntries(wikiRoot: string): Json {
   const cmd = (flag: string) =>
-    `node "${securityCheckPath()}" ${flag} --wiki-root "${wikiRoot}"`;
+    `node ${escapeShellArg(securityCheckPath())} ${flag} --wiki-root ${escapeShellArg(wikiRoot)}`;
   return [
     {
       matcher: "WebFetch",
@@ -205,7 +212,7 @@ export function installClaudeCodeHooks(wikiRoot: string): InstallResult {
 
 function codexHookEntries(wikiRoot: string): Json {
   const cmd = (flag: string) =>
-    `node "${securityCheckPath()}" ${flag} --wiki-root "${wikiRoot}"`;
+    `node ${escapeShellArg(securityCheckPath())} ${flag} --wiki-root ${escapeShellArg(wikiRoot)}`;
   return [
     { matcher: "WebFetch", command: cmd("--tool-input-url") },
     { matcher: "WebSearch", command: cmd("--tool-input-url") },
@@ -232,7 +239,7 @@ export function installCodexHooks(wikiRoot: string): InstallResult {
 
 function cursorHookEntries(wikiRoot: string): Json {
   const cmd = (flag: string) =>
-    `node "${securityCheckPath()}" ${flag} --wiki-root "${wikiRoot}"`;
+    `node ${escapeShellArg(securityCheckPath())} ${flag} --wiki-root ${escapeShellArg(wikiRoot)}`;
   return [
     { matcher: "WebFetch", command: cmd("--tool-input-url") },
     { matcher: "WebSearch", command: cmd("--tool-input-url") },
@@ -274,10 +281,10 @@ function aiderManagedBlock(wikiRoot: string): string {
     `pre_tool_use() {`,
     `  case "$TOOL_NAME" in`,
     `    WebFetch|WebSearch)`,
-    `      node "${sc}" --tool-input-url --wiki-root "${wikiRoot}" || return 1`,
+    `      node ${escapeShellArg(sc)} --tool-input-url --wiki-root ${escapeShellArg(wikiRoot)} || return 1`,
     `      ;;`,
     `    Write|Edit|MultiEdit)`,
-    `      node "${sc}" --tool-input-path --wiki-root "${wikiRoot}" || return 1`,
+    `      node ${escapeShellArg(sc)} --tool-input-path --wiki-root ${escapeShellArg(wikiRoot)} || return 1`,
     `      ;;`,
     `  esac`,
     `}`,

--- a/skills/doc-wiki/scripts/tests/hook_installer.test.ts
+++ b/skills/doc-wiki/scripts/tests/hook_installer.test.ts
@@ -121,6 +121,77 @@ describe("installClaudeCodeHooks", () => {
     const parsed2 = JSON.parse(fs.readFileSync(settingsPath, "utf-8"));
     expect(parsed2.hooks.PreToolUse.length).toBe(count1);
   });
+
+  it("upgrades a pre-existing managed entry with an outdated (injectable) command", () => {
+    // Simulate an install created before the shell-escaping fix: the
+    // WebFetch matcher already exists, but its command double-quotes the
+    // wiki root (vulnerable to command injection) instead of escaping it.
+    const settingsPath = path.join(tmpPath, ".claude", "settings.json");
+    fs.mkdirSync(path.dirname(settingsPath), { recursive: true });
+    const staleCommand = `node "/old/security_check.js" --tool-input-url --wiki-root "${tmpPath}; touch pwned"`;
+    fs.writeFileSync(
+      settingsPath,
+      JSON.stringify(
+        {
+          hooks: {
+            PreToolUse: [
+              {
+                matcher: "WebFetch",
+                hooks: [{ type: "command", command: staleCommand }],
+              },
+            ],
+          },
+        },
+        null,
+        2,
+      ) + "\n",
+    );
+
+    const result = installClaudeCodeHooks(tmpPath);
+    expect(result.installed).toBe(true);
+    const parsed = JSON.parse(fs.readFileSync(settingsPath, "utf-8"));
+    const webFetch = parsed.hooks.PreToolUse.find(
+      (e: { matcher: string }) => e.matcher === "WebFetch",
+    );
+    const cmd: string = webFetch.hooks[0].command;
+    // The stale, injectable command must be gone and replaced with the
+    // single-quote-escaped form.
+    expect(cmd).not.toBe(staleCommand);
+    expect(cmd).not.toContain('--wiki-root "');
+    expect(cmd).toContain(`--wiki-root '${tmpPath}'`);
+  });
+
+  it("never rewrites a user-authored entry that shares a matcher", () => {
+    const settingsPath = path.join(tmpPath, ".claude", "settings.json");
+    fs.mkdirSync(path.dirname(settingsPath), { recursive: true });
+    // User has their own WebFetch hook that does NOT invoke security_check.js.
+    const userCommand = `echo "my own webfetch hook"`;
+    fs.writeFileSync(
+      settingsPath,
+      JSON.stringify(
+        {
+          hooks: {
+            PreToolUse: [
+              {
+                matcher: "WebFetch",
+                hooks: [{ type: "command", command: userCommand }],
+              },
+            ],
+          },
+        },
+        null,
+        2,
+      ) + "\n",
+    );
+
+    installClaudeCodeHooks(tmpPath);
+    const parsed = JSON.parse(fs.readFileSync(settingsPath, "utf-8"));
+    const webFetch = parsed.hooks.PreToolUse.find(
+      (e: { matcher: string }) => e.matcher === "WebFetch",
+    );
+    // The user's command is untouched (not a managed security_check.js entry).
+    expect(webFetch.hooks[0].command).toBe(userCommand);
+  });
 });
 
 // ── Codex ──────────────────────────────────────────────────────────────
@@ -170,6 +241,29 @@ describe("installCodexHooks", () => {
     expect(parsed.custom).toEqual({ flag: true });
     expect(parsed.unrelated).toEqual([1, 2]);
     expect(Array.isArray(parsed.preToolUse)).toBe(true);
+  });
+
+  it("upgrades a pre-existing managed entry with an outdated command", () => {
+    const settingsPath = path.join(tmpPath, ".codex", "hooks.json");
+    fs.mkdirSync(path.dirname(settingsPath), { recursive: true });
+    const staleCommand = `node "/old/security_check.js" --tool-input-url --wiki-root "${tmpPath}; touch pwned"`;
+    fs.writeFileSync(
+      settingsPath,
+      JSON.stringify(
+        { preToolUse: [{ matcher: "WebFetch", command: staleCommand }] },
+        null,
+        2,
+      ) + "\n",
+    );
+
+    installCodexHooks(tmpPath);
+    const parsed = JSON.parse(fs.readFileSync(settingsPath, "utf-8"));
+    const webFetch = parsed.preToolUse.find(
+      (e: { matcher: string }) => e.matcher === "WebFetch",
+    );
+    expect(webFetch.command).not.toBe(staleCommand);
+    expect(webFetch.command).not.toContain('--wiki-root "');
+    expect(webFetch.command).toContain(`--wiki-root '${tmpPath}'`);
   });
 });
 

--- a/skills/doc-wiki/scripts/tests/hook_installer.test.ts
+++ b/skills/doc-wiki/scripts/tests/hook_installer.test.ts
@@ -121,77 +121,6 @@ describe("installClaudeCodeHooks", () => {
     const parsed2 = JSON.parse(fs.readFileSync(settingsPath, "utf-8"));
     expect(parsed2.hooks.PreToolUse.length).toBe(count1);
   });
-
-  it("upgrades a pre-existing managed entry with an outdated (injectable) command", () => {
-    // Simulate an install created before the shell-escaping fix: the
-    // WebFetch matcher already exists, but its command double-quotes the
-    // wiki root (vulnerable to command injection) instead of escaping it.
-    const settingsPath = path.join(tmpPath, ".claude", "settings.json");
-    fs.mkdirSync(path.dirname(settingsPath), { recursive: true });
-    const staleCommand = `node "/old/security_check.js" --tool-input-url --wiki-root "${tmpPath}; touch pwned"`;
-    fs.writeFileSync(
-      settingsPath,
-      JSON.stringify(
-        {
-          hooks: {
-            PreToolUse: [
-              {
-                matcher: "WebFetch",
-                hooks: [{ type: "command", command: staleCommand }],
-              },
-            ],
-          },
-        },
-        null,
-        2,
-      ) + "\n",
-    );
-
-    const result = installClaudeCodeHooks(tmpPath);
-    expect(result.installed).toBe(true);
-    const parsed = JSON.parse(fs.readFileSync(settingsPath, "utf-8"));
-    const webFetch = parsed.hooks.PreToolUse.find(
-      (e: { matcher: string }) => e.matcher === "WebFetch",
-    );
-    const cmd: string = webFetch.hooks[0].command;
-    // The stale, injectable command must be gone and replaced with the
-    // single-quote-escaped form.
-    expect(cmd).not.toBe(staleCommand);
-    expect(cmd).not.toContain('--wiki-root "');
-    expect(cmd).toContain(`--wiki-root '${tmpPath}'`);
-  });
-
-  it("never rewrites a user-authored entry that shares a matcher", () => {
-    const settingsPath = path.join(tmpPath, ".claude", "settings.json");
-    fs.mkdirSync(path.dirname(settingsPath), { recursive: true });
-    // User has their own WebFetch hook that does NOT invoke security_check.js.
-    const userCommand = `echo "my own webfetch hook"`;
-    fs.writeFileSync(
-      settingsPath,
-      JSON.stringify(
-        {
-          hooks: {
-            PreToolUse: [
-              {
-                matcher: "WebFetch",
-                hooks: [{ type: "command", command: userCommand }],
-              },
-            ],
-          },
-        },
-        null,
-        2,
-      ) + "\n",
-    );
-
-    installClaudeCodeHooks(tmpPath);
-    const parsed = JSON.parse(fs.readFileSync(settingsPath, "utf-8"));
-    const webFetch = parsed.hooks.PreToolUse.find(
-      (e: { matcher: string }) => e.matcher === "WebFetch",
-    );
-    // The user's command is untouched (not a managed security_check.js entry).
-    expect(webFetch.hooks[0].command).toBe(userCommand);
-  });
 });
 
 // ── Codex ──────────────────────────────────────────────────────────────
@@ -241,29 +170,6 @@ describe("installCodexHooks", () => {
     expect(parsed.custom).toEqual({ flag: true });
     expect(parsed.unrelated).toEqual([1, 2]);
     expect(Array.isArray(parsed.preToolUse)).toBe(true);
-  });
-
-  it("upgrades a pre-existing managed entry with an outdated command", () => {
-    const settingsPath = path.join(tmpPath, ".codex", "hooks.json");
-    fs.mkdirSync(path.dirname(settingsPath), { recursive: true });
-    const staleCommand = `node "/old/security_check.js" --tool-input-url --wiki-root "${tmpPath}; touch pwned"`;
-    fs.writeFileSync(
-      settingsPath,
-      JSON.stringify(
-        { preToolUse: [{ matcher: "WebFetch", command: staleCommand }] },
-        null,
-        2,
-      ) + "\n",
-    );
-
-    installCodexHooks(tmpPath);
-    const parsed = JSON.parse(fs.readFileSync(settingsPath, "utf-8"));
-    const webFetch = parsed.preToolUse.find(
-      (e: { matcher: string }) => e.matcher === "WebFetch",
-    );
-    expect(webFetch.command).not.toBe(staleCommand);
-    expect(webFetch.command).not.toContain('--wiki-root "');
-    expect(webFetch.command).toContain(`--wiki-root '${tmpPath}'`);
   });
 });
 


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: Command injection in `hook_installer.ts`. The script constructs shell commands with double quotes around the `wikiRoot` argument. Since `wikiRoot` could be an arbitrary user-controlled path, a malicious path containing double quotes and bash command substitution (e.g. `$(...)` or `` `...` ``) could lead to arbitrary shell command execution when the generated hooks run.
🎯 Impact: Exploiting this could allow remote code execution if a victim installs doc-wiki inside a maliciously crafted directory name or triggers the hooks.
🔧 Fix: Replaced double-quote wrapping with a robust `escapeShellArg` function that correctly wraps the string in single quotes and safely escapes inner single quotes (e.g., `'${arg.replace(/'/g, "'\\''")}'`). Applied this escaping function to all hook generators: `claudeCodeHookEntries`, `codexHookEntries`, `cursorHookEntries`, and `aiderManagedBlock`.
✅ Verification: Ran unit tests and the full test suite (`npm run test`) to ensure no regressions. Verified string formatting logic for Unix shells.

---
*PR created automatically by Jules for task [4415523963833976749](https://jules.google.com/task/4415523963833976749) started by @rfv-code*