### PR TITLE
chore(deps): update narai-primitives to 2.5.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "mongodb": "^7.1.1",
         "mssql": "^12.2.1",
         "mysql2": "^3.22.0",
-        "narai-primitives": "^2.3.0",
+        "narai-primitives": "^2.5.0",
         "pdfjs-dist": "^5.6.205",
         "pg": "^8.20.0",
         "smol-toml": "^1.6.1"
@@ -6896,9 +6896,9 @@
       "license": "MIT"
     },
     "node_modules/narai-primitives": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/narai-primitives/-/narai-primitives-2.3.0.tgz",
-      "integrity": "sha512-tSUr8+AuH4cF3ltPhwP3b+z0EcHtfPDMZuCdQ6p+lHBN1x2cEmBs9wDpWC5MaZ/GiHyjVfCXmXM9PJWrlEHMpQ==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/narai-primitives/-/narai-primitives-2.5.0.tgz",
+      "integrity": "sha512-jpm4+ZVfmjn73jk6XDvg1WAao5aXOO/DwfxEQrRbiwjdGNyTg/HpsC/5MUDba41TlaT48waq0ica9c0wuq/vUg==",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.119",
         "adf-to-markdown": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "mongodb": "^7.1.1",
     "mssql": "^12.2.1",
     "mysql2": "^3.22.0",
-    "narai-primitives": "^2.3.0",
+    "narai-primitives": "^2.5.0",
     "pdfjs-dist": "^5.6.205",
     "pg": "^8.20.0",
     "smol-toml": "^1.6.1"


### PR DESCRIPTION
## What

Updates `narai-primitives` from `^2.3.0` → `^2.5.0` (latest published) and refreshes the lockfile. Skips 2.4.0, so both minors land together.

## Scope check (both 2.4.0 + 2.5.0)

Verified clean before opening:
- **Same 9 bundled connectors** (aws, confluence, db, gcp, github, gitlab, jira, linear, notion) and identical export subpaths as 2.3.0 → no `source_registry` / docs changes.
- **`engines.node` unchanged** at `>=20.10.0` → no engine-floor change.
- **No transitive tree changes** — `npm install` reported `changed 1 package`; lockfile diff is 4 lines (narai-primitives version/resolved/integrity only).
- **No re-exported-behavior changes** surfaced (full suite passes unmodified, unlike the 2.2.0 `scrubSqlSecrets` shift).

## Verification

- `npm run typecheck` — clean
- `npm run build` — clean, no `.js` drift
- `npm test` — **1851 passed, 20 skipped**