### PR TITLE
chore(deps): pin narai-primitives 2.6.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "mongodb": "^7.1.1",
         "mssql": "^12.2.1",
         "mysql2": "^3.22.0",
-        "narai-primitives": "^2.5.0",
+        "narai-primitives": "2.6.0",
         "pdfjs-dist": "^5.6.205",
         "pg": "^8.20.0",
         "smol-toml": "^1.6.1"
@@ -6896,9 +6896,9 @@
       "license": "MIT"
     },
     "node_modules/narai-primitives": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/narai-primitives/-/narai-primitives-2.5.0.tgz",
-      "integrity": "sha512-jpm4+ZVfmjn73jk6XDvg1WAao5aXOO/DwfxEQrRbiwjdGNyTg/HpsC/5MUDba41TlaT48waq0ica9c0wuq/vUg==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/narai-primitives/-/narai-primitives-2.6.0.tgz",
+      "integrity": "sha512-eiwc9RWzu11PnRFOlyauqQP2e5u6XygTG8jh3DK8k9hRc09ZCXddz6zAoWkbsF+7Stxy2ywxe9RGVf0eEuRTeA==",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.119",
         "adf-to-markdown": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "mongodb": "^7.1.1",
     "mssql": "^12.2.1",
     "mysql2": "^3.22.0",
-    "narai-primitives": "^2.5.0",
+    "narai-primitives": "2.6.0",
     "pdfjs-dist": "^5.6.205",
     "pg": "^8.20.0",
     "smol-toml": "^1.6.1"


### PR DESCRIPTION
Exact pin (was `^2.5.0`) picking up the 2.6.0 gcp connector release: `structured_filter` for `query_logs` (JSON clauses compiled internally with correct quoting/escaping — severity floors, exact matches, multi-word text search now expressible), scoped metachar blocklist, and the richer null-filled log entry projection (`message` fallback chain + `container`/`namespace`/`pod`/`trace_id`/`log_name`/`insert_id`).

Verified locally: `npm run build` clean, full suite 1855 passed / 16 skipped.

https://claude.ai/code/session_01Vs4UdYp47N6FuATxDZg9mh