### PR TITLE
⚡ Bolt: Replace .split('\\n') with iterative .indexOf() loop in archive log parsing

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -12,3 +12,6 @@
 
 **Learning:** Inner JSON fields might mistakenly contain match substrings like dates (e.g., inside the text of the event). Utilizing a strict, anchored regex check for extracting fields like timestamps directly (`/^{"ts":"([^"\\]+)"/`) avoids both `JSON.parse` overhead and incorrect partial string matches from `String.includes()`.
 **Action:** Use an anchored regex (`/^{"ts":"([^"\\]+)"/`) and check the captured group directly before falling back to full JSON parsing.
+## 2026-07-10 - Replace .split() with .indexOf()
+**Learning:** Using .split("\n") on large append-only logs allocates a massive array synchronously, causing memory spikes. Using iterative .indexOf() and .substring() keeps memory usage flat and allows garbage collection.
+**Action:** Use .indexOf("\n") loop when reading large files as strings.

--- a/agents/lib/atlas_archive.js
+++ b/agents/lib/atlas_archive.js
@@ -132,14 +132,27 @@ export async function rebuildArchiveIndex(wikiRoot) {
     const journalPath = path.join(wikiRoot, "_archive_history.jsonl");
     let allEvents = [];
     if (fs.existsSync(journalPath)) {
-        const lines = fs.readFileSync(journalPath, "utf-8").split("\n").filter(Boolean);
-        for (const line of lines) {
-            try {
-                allEvents.push(JSON.parse(line));
+        const content = fs.readFileSync(journalPath, "utf-8");
+        let startIdx = 0;
+        // ⚡ Bolt: Use an iterative .indexOf() and .substring() loop instead of .split('\n').
+        // This avoids allocating a massive intermediate array of strings synchronously when processing
+        // large, append-only JSON event logs, significantly reducing memory spikes and allowing
+        // garbage collection during parsing.
+        while (startIdx < content.length) {
+            const endIdx = content.indexOf("\n", startIdx);
+            const lineEnd = endIdx === -1 ? content.length : endIdx;
+            const line = content.substring(startIdx, lineEnd);
+            startIdx = lineEnd + 1;
+            if (line) {
+                try {
+                    allEvents.push(JSON.parse(line));
+                }
+                catch {
+                    // skip malformed lines
+                }
             }
-            catch {
-                // skip malformed lines
-            }
+            if (endIdx === -1)
+                break;
         }
     }
     // Only keep archive events (op !== "unarchive") whose archived file still exists.

--- a/agents/lib/atlas_archive.ts
+++ b/agents/lib/atlas_archive.ts
@@ -259,13 +259,28 @@ export async function rebuildArchiveIndex(wikiRoot: string): Promise<void> {
   let allEvents: Array<ArchiveEvent | UnarchiveEvent> = [];
 
   if (fs.existsSync(journalPath)) {
-    const lines = fs.readFileSync(journalPath, "utf-8").split("\n").filter(Boolean);
-    for (const line of lines) {
-      try {
-        allEvents.push(JSON.parse(line) as ArchiveEvent | UnarchiveEvent);
-      } catch {
-        // skip malformed lines
+    const content = fs.readFileSync(journalPath, "utf-8");
+    let startIdx = 0;
+
+    // ⚡ Bolt: Use an iterative .indexOf() and .substring() loop instead of .split('\n').
+    // This avoids allocating a massive intermediate array of strings synchronously when processing
+    // large, append-only JSON event logs, significantly reducing memory spikes and allowing
+    // garbage collection during parsing.
+    while (startIdx < content.length) {
+      const endIdx = content.indexOf("\n", startIdx);
+      const lineEnd = endIdx === -1 ? content.length : endIdx;
+      const line = content.substring(startIdx, lineEnd);
+      startIdx = lineEnd + 1;
+
+      if (line) {
+        try {
+          allEvents.push(JSON.parse(line) as ArchiveEvent | UnarchiveEvent);
+        } catch {
+          // skip malformed lines
+        }
       }
+
+      if (endIdx === -1) break;
     }
   }
 


### PR DESCRIPTION
💡 **What**: Replaced `.split('\\n')` with an iterative `while` loop using `indexOf('\\n')` and `substring()` when reading `_archive_history.jsonl` in `rebuildArchiveIndex`.
🎯 **Why**: Using `.split('\\n')` on large append-only logs allocates a massive array of strings synchronously, which causes severe memory spikes and prevents garbage collection during the array construction phase.
📊 **Impact**: Keeps memory overhead flat during event log parsing, preventing out-of-memory errors on large wikis.
🔬 **Measurement**: Run memory profiling with Node.js on a large `_archive_history.jsonl` file to verify a reduction in peak heap usage during the index rebuild phase.

---
*PR created automatically by Jules for task [16352358834993626130](https://jules.google.com/task/16352358834993626130) started by @rfv-code*