### PR TITLE
⚡ Bolt: replace massive array allocation from string split with lazy traversal

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -12,3 +12,7 @@
 
 **Learning:** Inner JSON fields might mistakenly contain match substrings like dates (e.g., inside the text of the event). Utilizing a strict, anchored regex check for extracting fields like timestamps directly (`/^{"ts":"([^"\\]+)"/`) avoids both `JSON.parse` overhead and incorrect partial string matches from `String.includes()`.
 **Action:** Use an anchored regex (`/^{"ts":"([^"\\]+)"/`) and check the captured group directly before falling back to full JSON parsing.
+## 2026-07-21 - Array allocation in file splitting
+
+**Learning:** When using `.split('\n')` on large text files (like JSONL logs read via `fs.readFileSync`), it synchronously allocates a massive intermediate array in memory which takes CPU and memory overhead, especially when only a few backwards iterations are necessary.
+**Action:** Use an iterative `lastIndexOf('\n')` or `indexOf('\n')` combined with `substring()` to sequentially scan backward or forward and extract lines lazily.

--- a/skills/doc-wiki/scripts/atlas_gitlog.js
+++ b/skills/doc-wiki/scripts/atlas_gitlog.js
@@ -52,16 +52,27 @@ export function getLastAtlasTimestamp(wikiRoot) {
     const eventsPath = path.join(wikiRoot, "log", "events.jsonl");
     if (!fs.existsSync(eventsPath))
         return null;
-    let lines;
+    let body;
     try {
-        lines = fs.readFileSync(eventsPath, "utf-8").split("\n");
+        body = fs.readFileSync(eventsPath, "utf-8");
     }
     catch {
         return null;
     }
     // Walk backwards — most recent atlas event wins.
-    for (let i = lines.length - 1; i >= 0; i--) {
-        const line = lines[i];
+    // OPTIMIZATION: Use backwards substring scanning to prevent massive intermediate array
+    // allocation that occurs when calling .split('\n') on the entire events.jsonl file.
+    let endIdx = body.length;
+    while (endIdx >= 0) {
+        let startIdx = endIdx === 0 ? -1 : body.lastIndexOf("\n", endIdx - 1);
+        let actualStart = startIdx === -1 ? 0 : startIdx + 1;
+        let line = body.substring(actualStart, endIdx);
+        if (startIdx === -1) {
+            endIdx = -1; // ensure termination
+        }
+        else {
+            endIdx = startIdx;
+        }
         if (!line)
             continue;
         // Fast-path: skip JSON parse overhead if this line cannot be an atlas event

--- a/skills/doc-wiki/scripts/atlas_gitlog.ts
+++ b/skills/doc-wiki/scripts/atlas_gitlog.ts
@@ -79,15 +79,28 @@ export interface ClassifyResult {
 export function getLastAtlasTimestamp(wikiRoot: string): string | null {
   const eventsPath = path.join(wikiRoot, "log", "events.jsonl");
   if (!fs.existsSync(eventsPath)) return null;
-  let lines: string[];
+  let body: string;
   try {
-    lines = fs.readFileSync(eventsPath, "utf-8").split("\n");
+    body = fs.readFileSync(eventsPath, "utf-8");
   } catch {
     return null;
   }
+
   // Walk backwards — most recent atlas event wins.
-  for (let i = lines.length - 1; i >= 0; i--) {
-    const line = lines[i];
+  // OPTIMIZATION: Use backwards substring scanning to prevent massive intermediate array
+  // allocation that occurs when calling .split('\n') on the entire events.jsonl file.
+  let endIdx = body.length;
+  while (endIdx >= 0) {
+    let startIdx = endIdx === 0 ? -1 : body.lastIndexOf("\n", endIdx - 1);
+    let actualStart = startIdx === -1 ? 0 : startIdx + 1;
+    let line = body.substring(actualStart, endIdx);
+
+    if (startIdx === -1) {
+      endIdx = -1; // ensure termination
+    } else {
+      endIdx = startIdx;
+    }
+
     if (!line) continue;
 
     // Fast-path: skip JSON parse overhead if this line cannot be an atlas event

--- a/skills/doc-wiki/scripts/atlas_orchestrator.js
+++ b/skills/doc-wiki/scripts/atlas_orchestrator.js
@@ -124,15 +124,26 @@ export function getLastAtlasRunId(wikiRoot) {
     const eventsPath = path.join(wikiRoot, "log", "events.jsonl");
     if (!fs.existsSync(eventsPath))
         return null;
-    let lines;
+    let body;
     try {
-        lines = fs.readFileSync(eventsPath, "utf-8").split("\n");
+        body = fs.readFileSync(eventsPath, "utf-8");
     }
     catch {
         return null;
     }
-    for (let i = lines.length - 1; i >= 0; i--) {
-        const line = lines[i];
+    // OPTIMIZATION: Use backwards substring scanning to prevent massive intermediate array
+    // allocation that occurs when calling .split('\n') on the entire events.jsonl file.
+    let endIdx = body.length;
+    while (endIdx >= 0) {
+        let startIdx = endIdx === 0 ? -1 : body.lastIndexOf("\n", endIdx - 1);
+        let actualStart = startIdx === -1 ? 0 : startIdx + 1;
+        let line = body.substring(actualStart, endIdx);
+        if (startIdx === -1) {
+            endIdx = -1; // ensure termination
+        }
+        else {
+            endIdx = startIdx;
+        }
         if (!line)
             continue;
         // Fast-path: skip JSON parse overhead if this line cannot be an atlas event
@@ -202,16 +213,27 @@ export function getRollingPerIngestAvg(wikiRoot, sampleSize = 50) {
     const eventsPath = path.join(wikiRoot, "log", "events.jsonl");
     if (!fs.existsSync(eventsPath))
         return DEFAULT_PER_INGEST_AVG_USD;
-    let lines;
+    let body;
     try {
-        lines = fs.readFileSync(eventsPath, "utf-8").split("\n");
+        body = fs.readFileSync(eventsPath, "utf-8");
     }
     catch {
         return DEFAULT_PER_INGEST_AVG_USD;
     }
     const samples = [];
-    for (let i = lines.length - 1; i >= 0 && samples.length < sampleSize; i--) {
-        const line = lines[i];
+    // OPTIMIZATION: Use backwards substring scanning to prevent massive intermediate array
+    // allocation that occurs when calling .split('\n') on the entire events.jsonl file.
+    let endIdx = body.length;
+    while (endIdx >= 0 && samples.length < sampleSize) {
+        let startIdx = endIdx === 0 ? -1 : body.lastIndexOf("\n", endIdx - 1);
+        let actualStart = startIdx === -1 ? 0 : startIdx + 1;
+        let line = body.substring(actualStart, endIdx);
+        if (startIdx === -1) {
+            endIdx = -1; // ensure termination
+        }
+        else {
+            endIdx = startIdx;
+        }
         if (!line)
             continue;
         // Fast-path: skip JSON parse overhead if this line cannot be an ingest event

--- a/skills/doc-wiki/scripts/atlas_orchestrator.ts
+++ b/skills/doc-wiki/scripts/atlas_orchestrator.ts
@@ -170,14 +170,27 @@ export function countAllPages(wikiRoot: string): number {
 export function getLastAtlasRunId(wikiRoot: string): string | null {
   const eventsPath = path.join(wikiRoot, "log", "events.jsonl");
   if (!fs.existsSync(eventsPath)) return null;
-  let lines: string[];
+  let body: string;
   try {
-    lines = fs.readFileSync(eventsPath, "utf-8").split("\n");
+    body = fs.readFileSync(eventsPath, "utf-8");
   } catch {
     return null;
   }
-  for (let i = lines.length - 1; i >= 0; i--) {
-    const line = lines[i];
+
+  // OPTIMIZATION: Use backwards substring scanning to prevent massive intermediate array
+  // allocation that occurs when calling .split('\n') on the entire events.jsonl file.
+  let endIdx = body.length;
+  while (endIdx >= 0) {
+    let startIdx = endIdx === 0 ? -1 : body.lastIndexOf("\n", endIdx - 1);
+    let actualStart = startIdx === -1 ? 0 : startIdx + 1;
+    let line = body.substring(actualStart, endIdx);
+
+    if (startIdx === -1) {
+      endIdx = -1; // ensure termination
+    } else {
+      endIdx = startIdx;
+    }
+
     if (!line) continue;
 
     // Fast-path: skip JSON parse overhead if this line cannot be an atlas event
@@ -253,15 +266,28 @@ export function getRollingPerIngestAvg(
 ): number {
   const eventsPath = path.join(wikiRoot, "log", "events.jsonl");
   if (!fs.existsSync(eventsPath)) return DEFAULT_PER_INGEST_AVG_USD;
-  let lines: string[];
+  let body: string;
   try {
-    lines = fs.readFileSync(eventsPath, "utf-8").split("\n");
+    body = fs.readFileSync(eventsPath, "utf-8");
   } catch {
     return DEFAULT_PER_INGEST_AVG_USD;
   }
   const samples: number[] = [];
-  for (let i = lines.length - 1; i >= 0 && samples.length < sampleSize; i--) {
-    const line = lines[i];
+
+  // OPTIMIZATION: Use backwards substring scanning to prevent massive intermediate array
+  // allocation that occurs when calling .split('\n') on the entire events.jsonl file.
+  let endIdx = body.length;
+  while (endIdx >= 0 && samples.length < sampleSize) {
+    let startIdx = endIdx === 0 ? -1 : body.lastIndexOf("\n", endIdx - 1);
+    let actualStart = startIdx === -1 ? 0 : startIdx + 1;
+    let line = body.substring(actualStart, endIdx);
+
+    if (startIdx === -1) {
+      endIdx = -1; // ensure termination
+    } else {
+      endIdx = startIdx;
+    }
+
     if (!line) continue;
 
     // Fast-path: skip JSON parse overhead if this line cannot be an ingest event


### PR DESCRIPTION
💡 What: Replaced synchronous `.split('\n')` allocations with a `while` loop relying on `lastIndexOf('\n')` and `substring()`.
🎯 Why: `.split('\n')` on large log files (`events.jsonl`) allocates huge arrays in memory immediately which is extremely inefficient when we often terminate traversal early.
📊 Impact: Considerably reduces memory overhead, removes CPU parsing of early logs and speeds up `doc-wiki` commands reading event logs on large scale.
🔬 Measurement: Verify changes in memory allocations during runs by analyzing heap size and verifying unit tests run normally.

---
*PR created automatically by Jules for task [6361934372137306854](https://jules.google.com/task/6361934372137306854) started by @rfv-code*