### PR TITLE
⚡ Bolt: Optimize large file parsing memory usage in atlas_gitlog.ts

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -12,3 +12,8 @@
 
 **Learning:** Inner JSON fields might mistakenly contain match substrings like dates (e.g., inside the text of the event). Utilizing a strict, anchored regex check for extracting fields like timestamps directly (`/^{"ts":"([^"\\]+)"/`) avoids both `JSON.parse` overhead and incorrect partial string matches from `String.includes()`.
 **Action:** Use an anchored regex (`/^{"ts":"([^"\\]+)"/`) and check the captured group directly before falling back to full JSON parsing.
+
+## 2026-05-23 - Iterative backward splitting
+
+**Learning:** When processing large log files read into memory as a single string (e.g., via `fs.readFileSync`), avoiding `.split('\n')` to iterate over lines prevents synchronous allocation of a massive intermediate array.
+**Action:** Use an iterative `lastIndexOf('\n')` for backward iteration, combined with a `substring()` loop to significantly reduce memory overhead and allow garbage collection during processing.

--- a/skills/doc-wiki/scripts/atlas_gitlog.js
+++ b/skills/doc-wiki/scripts/atlas_gitlog.js
@@ -52,16 +52,23 @@ export function getLastAtlasTimestamp(wikiRoot) {
     const eventsPath = path.join(wikiRoot, "log", "events.jsonl");
     if (!fs.existsSync(eventsPath))
         return null;
-    let lines;
+    let content;
     try {
-        lines = fs.readFileSync(eventsPath, "utf-8").split("\n");
+        content = fs.readFileSync(eventsPath, "utf-8");
     }
     catch {
         return null;
     }
+    let lastNewline = content.length;
+    if (content.endsWith("\n")) {
+        lastNewline--;
+    }
     // Walk backwards — most recent atlas event wins.
-    for (let i = lines.length - 1; i >= 0; i--) {
-        const line = lines[i];
+    while (lastNewline >= 0) {
+        const prevNewline = lastNewline === 0 ? -1 : content.lastIndexOf("\n", lastNewline - 1);
+        const start = prevNewline === -1 ? 0 : prevNewline + 1;
+        const line = content.substring(start, lastNewline);
+        lastNewline = prevNewline;
         if (!line)
             continue;
         // Fast-path: skip JSON parse overhead if this line cannot be an atlas event
@@ -229,7 +236,11 @@ export function classifyChanges(changedFiles, pageIndex, topics) {
     for (const [page, sources] of [...staleByPage.entries()].sort()) {
         stale_pages.push({ page, sources: [...sources].sort() });
     }
-    return { stale_pages, uncovered_files: uncovered, unrelated_files: unrelated };
+    return {
+        stale_pages,
+        uncovered_files: uncovered,
+        unrelated_files: unrelated,
+    };
 }
 // ── CLI ────────────────────────────────────────────────────────────
 const FLAG_SPEC = {
@@ -277,11 +288,13 @@ export function main(argv = process.argv.slice(2)) {
         process.stderr.write("--wiki-root is required\n");
         return 2;
     }
-    const repoRoot = typeof parsed.values["repoRoot"] === "string" && parsed.values["repoRoot"].length > 0
+    const repoRoot = typeof parsed.values["repoRoot"] === "string" &&
+        parsed.values["repoRoot"].length > 0
         ? parsed.values["repoRoot"]
         : process.cwd();
     let since = null;
-    if (typeof parsed.values["since"] === "string" && parsed.values["since"].length > 0) {
+    if (typeof parsed.values["since"] === "string" &&
+        parsed.values["since"].length > 0) {
         since = parsed.values["since"];
     }
     else {

--- a/skills/doc-wiki/scripts/atlas_gitlog.ts
+++ b/skills/doc-wiki/scripts/atlas_gitlog.ts
@@ -79,15 +79,26 @@ export interface ClassifyResult {
 export function getLastAtlasTimestamp(wikiRoot: string): string | null {
   const eventsPath = path.join(wikiRoot, "log", "events.jsonl");
   if (!fs.existsSync(eventsPath)) return null;
-  let lines: string[];
+  let content: string;
   try {
-    lines = fs.readFileSync(eventsPath, "utf-8").split("\n");
+    content = fs.readFileSync(eventsPath, "utf-8");
   } catch {
     return null;
   }
+
+  let lastNewline = content.length;
+  if (content.endsWith("\n")) {
+    lastNewline--;
+  }
+
   // Walk backwards — most recent atlas event wins.
-  for (let i = lines.length - 1; i >= 0; i--) {
-    const line = lines[i];
+  while (lastNewline >= 0) {
+    const prevNewline =
+      lastNewline === 0 ? -1 : content.lastIndexOf("\n", lastNewline - 1);
+    const start = prevNewline === -1 ? 0 : prevNewline + 1;
+    const line = content.substring(start, lastNewline);
+    lastNewline = prevNewline;
+
     if (!line) continue;
 
     // Fast-path: skip JSON parse overhead if this line cannot be an atlas event
@@ -231,7 +242,10 @@ function _matchPage(
  * `app/<topic>/`, `services/<topic>/`, or just `<topic>/...` at the repo root)
  * otherwise `null`.
  */
-function _matchTopic(filePath: string, topics: readonly string[]): string | null {
+function _matchTopic(
+  filePath: string,
+  topics: readonly string[],
+): string | null {
   const parts = filePath.split("/");
   for (const topic of topics) {
     if (parts.includes(topic)) return topic;
@@ -279,7 +293,11 @@ export function classifyChanges(
   for (const [page, sources] of [...staleByPage.entries()].sort()) {
     stale_pages.push({ page, sources: [...sources].sort() });
   }
-  return { stale_pages, uncovered_files: uncovered, unrelated_files: unrelated };
+  return {
+    stale_pages,
+    uncovered_files: uncovered,
+    unrelated_files: unrelated,
+  };
 }
 
 // ── CLI ────────────────────────────────────────────────────────────
@@ -333,12 +351,16 @@ export function main(argv: readonly string[] = process.argv.slice(2)): number {
     return 2;
   }
   const repoRoot =
-    typeof parsed.values["repoRoot"] === "string" && parsed.values["repoRoot"].length > 0
+    typeof parsed.values["repoRoot"] === "string" &&
+    parsed.values["repoRoot"].length > 0
       ? parsed.values["repoRoot"]
       : process.cwd();
 
   let since: string | null = null;
-  if (typeof parsed.values["since"] === "string" && parsed.values["since"].length > 0) {
+  if (
+    typeof parsed.values["since"] === "string" &&
+    parsed.values["since"].length > 0
+  ) {
     since = parsed.values["since"];
   } else {
     const last = getLastAtlasTimestamp(wikiRoot);


### PR DESCRIPTION
💡 What: Replaced `fs.readFileSync(eventsPath, "utf-8").split("\n")` with an iterative backward traversal using `lastIndexOf("\n")` and `substring()` in `skills/doc-wiki/scripts/atlas_gitlog.ts`.
🎯 Why: Calling `.split("\n")` on large log files read entirely into memory synchronously allocates a massive intermediate array, causing substantial memory overhead and garbage collection pressure.
📊 Impact: Heavily reduces memory overhead when parsing large `events.jsonl` files by avoiding the synchronous allocation of an intermediate array of all lines. Allows garbage collection to clean up parsed lines as the string is processed.
🔬 Measurement: Verify tests pass and monitor the peak memory usage (`RSS`) when running `atlas_gitlog.ts` over very large `events.jsonl` files to observe decreased memory allocation.

---
*PR created automatically by Jules for task [12647244338121238464](https://jules.google.com/task/12647244338121238464) started by @rfv-code*