### PR TITLE
⚡ Bolt: Replace .split('\\n') with iterative lastIndexOf for large log parsing

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -12,3 +12,8 @@
 
 **Learning:** Inner JSON fields might mistakenly contain match substrings like dates (e.g., inside the text of the event). Utilizing a strict, anchored regex check for extracting fields like timestamps directly (`/^{"ts":"([^"\\]+)"/`) avoids both `JSON.parse` overhead and incorrect partial string matches from `String.includes()`.
 **Action:** Use an anchored regex (`/^{"ts":"([^"\\]+)"/`) and check the captured group directly before falling back to full JSON parsing.
+
+## 2026-05-23 - Memory bloat from .split('\\n') on large files
+
+**Learning:** When parsing large append-only logs (like `events.jsonl`) backwards, using `.split('\\n')` synchronously allocates a massive intermediate array in memory, causing significant garbage collection pressure.
+**Action:** Replace `.split('\\n')` and reverse iteration with a `while` loop using `lastIndexOf('\\n')` and `substring()`. Note that `lastIndexOf(str, pos)` treats `pos < 0` as `0`, so explicitly check for index 0 to avoid infinite loops when traversing backward.

--- a/skills/doc-wiki/scripts/atlas_gitlog.js
+++ b/skills/doc-wiki/scripts/atlas_gitlog.js
@@ -52,16 +52,22 @@ export function getLastAtlasTimestamp(wikiRoot) {
     const eventsPath = path.join(wikiRoot, "log", "events.jsonl");
     if (!fs.existsSync(eventsPath))
         return null;
-    let lines;
+    let fileContent;
     try {
-        lines = fs.readFileSync(eventsPath, "utf-8").split("\n");
+        fileContent = fs.readFileSync(eventsPath, "utf-8");
     }
     catch {
         return null;
     }
     // Walk backwards — most recent atlas event wins.
-    for (let i = lines.length - 1; i >= 0; i--) {
-        const line = lines[i];
+    // Performance optimization: Avoid .split("\n") on large log files to prevent massive intermediate array allocation.
+    // Instead, we iteratively find the previous newline backwards and extract substrings.
+    // Memory improvement: O(N) allocation -> O(1) allocation for line parsing.
+    let pos = fileContent.length;
+    while (pos >= 0) {
+        const nextPos = pos === 0 ? -1 : fileContent.lastIndexOf("\n", pos - 1);
+        const line = fileContent.substring(nextPos + 1, pos);
+        pos = nextPos;
         if (!line)
             continue;
         // Fast-path: skip JSON parse overhead if this line cannot be an atlas event
@@ -229,7 +235,11 @@ export function classifyChanges(changedFiles, pageIndex, topics) {
     for (const [page, sources] of [...staleByPage.entries()].sort()) {
         stale_pages.push({ page, sources: [...sources].sort() });
     }
-    return { stale_pages, uncovered_files: uncovered, unrelated_files: unrelated };
+    return {
+        stale_pages,
+        uncovered_files: uncovered,
+        unrelated_files: unrelated,
+    };
 }
 // ── CLI ────────────────────────────────────────────────────────────
 const FLAG_SPEC = {
@@ -277,11 +287,13 @@ export function main(argv = process.argv.slice(2)) {
         process.stderr.write("--wiki-root is required\n");
         return 2;
     }
-    const repoRoot = typeof parsed.values["repoRoot"] === "string" && parsed.values["repoRoot"].length > 0
+    const repoRoot = typeof parsed.values["repoRoot"] === "string" &&
+        parsed.values["repoRoot"].length > 0
         ? parsed.values["repoRoot"]
         : process.cwd();
     let since = null;
-    if (typeof parsed.values["since"] === "string" && parsed.values["since"].length > 0) {
+    if (typeof parsed.values["since"] === "string" &&
+        parsed.values["since"].length > 0) {
         since = parsed.values["since"];
     }
     else {

--- a/skills/doc-wiki/scripts/atlas_gitlog.ts
+++ b/skills/doc-wiki/scripts/atlas_gitlog.ts
@@ -79,15 +79,22 @@ export interface ClassifyResult {
 export function getLastAtlasTimestamp(wikiRoot: string): string | null {
   const eventsPath = path.join(wikiRoot, "log", "events.jsonl");
   if (!fs.existsSync(eventsPath)) return null;
-  let lines: string[];
+  let fileContent: string;
   try {
-    lines = fs.readFileSync(eventsPath, "utf-8").split("\n");
+    fileContent = fs.readFileSync(eventsPath, "utf-8");
   } catch {
     return null;
   }
   // Walk backwards — most recent atlas event wins.
-  for (let i = lines.length - 1; i >= 0; i--) {
-    const line = lines[i];
+
+  // Performance optimization: Avoid .split("\n") on large log files to prevent massive intermediate array allocation.
+  // Instead, we iteratively find the previous newline backwards and extract substrings.
+  // Memory improvement: O(N) allocation -> O(1) allocation for line parsing.
+  let pos = fileContent.length;
+  while (pos >= 0) {
+    const nextPos = pos === 0 ? -1 : fileContent.lastIndexOf("\n", pos - 1);
+    const line = fileContent.substring(nextPos + 1, pos);
+    pos = nextPos;
     if (!line) continue;
 
     // Fast-path: skip JSON parse overhead if this line cannot be an atlas event
@@ -231,7 +238,10 @@ function _matchPage(
  * `app/<topic>/`, `services/<topic>/`, or just `<topic>/...` at the repo root)
  * otherwise `null`.
  */
-function _matchTopic(filePath: string, topics: readonly string[]): string | null {
+function _matchTopic(
+  filePath: string,
+  topics: readonly string[],
+): string | null {
   const parts = filePath.split("/");
   for (const topic of topics) {
     if (parts.includes(topic)) return topic;
@@ -279,7 +289,11 @@ export function classifyChanges(
   for (const [page, sources] of [...staleByPage.entries()].sort()) {
     stale_pages.push({ page, sources: [...sources].sort() });
   }
-  return { stale_pages, uncovered_files: uncovered, unrelated_files: unrelated };
+  return {
+    stale_pages,
+    uncovered_files: uncovered,
+    unrelated_files: unrelated,
+  };
 }
 
 // ── CLI ────────────────────────────────────────────────────────────
@@ -333,12 +347,16 @@ export function main(argv: readonly string[] = process.argv.slice(2)): number {
     return 2;
   }
   const repoRoot =
-    typeof parsed.values["repoRoot"] === "string" && parsed.values["repoRoot"].length > 0
+    typeof parsed.values["repoRoot"] === "string" &&
+    parsed.values["repoRoot"].length > 0
       ? parsed.values["repoRoot"]
       : process.cwd();
 
   let since: string | null = null;
-  if (typeof parsed.values["since"] === "string" && parsed.values["since"].length > 0) {
+  if (
+    typeof parsed.values["since"] === "string" &&
+    parsed.values["since"].length > 0
+  ) {
     since = parsed.values["since"];
   } else {
     const last = getLastAtlasTimestamp(wikiRoot);

--- a/skills/doc-wiki/scripts/atlas_orchestrator.js
+++ b/skills/doc-wiki/scripts/atlas_orchestrator.js
@@ -124,15 +124,21 @@ export function getLastAtlasRunId(wikiRoot) {
     const eventsPath = path.join(wikiRoot, "log", "events.jsonl");
     if (!fs.existsSync(eventsPath))
         return null;
-    let lines;
+    let fileContent;
     try {
-        lines = fs.readFileSync(eventsPath, "utf-8").split("\n");
+        fileContent = fs.readFileSync(eventsPath, "utf-8");
     }
     catch {
         return null;
     }
-    for (let i = lines.length - 1; i >= 0; i--) {
-        const line = lines[i];
+    // Performance optimization: Avoid .split("\n") on large log files to prevent massive intermediate array allocation.
+    // Instead, we iteratively find the previous newline backwards and extract substrings.
+    // Memory improvement: O(N) allocation -> O(1) allocation for line parsing.
+    let pos = fileContent.length;
+    while (pos >= 0) {
+        const nextPos = pos === 0 ? -1 : fileContent.lastIndexOf("\n", pos - 1);
+        const line = fileContent.substring(nextPos + 1, pos);
+        pos = nextPos;
         if (!line)
             continue;
         // Fast-path: skip JSON parse overhead if this line cannot be an atlas event
@@ -189,7 +195,7 @@ export function detectState(wikiRoot, atlasPageThreshold = 3) {
     return "fresh";
 }
 // ── Per-ingest cost average ────────────────────────────────────────
-const DEFAULT_PER_INGEST_AVG_USD = 0.20;
+const DEFAULT_PER_INGEST_AVG_USD = 0.2;
 /**
  * Read recent `op: ingest` events from `log/events.jsonl` and return a
  * rolling-average `cost_usd` over up to `sampleSize` entries. Falls back
@@ -202,16 +208,22 @@ export function getRollingPerIngestAvg(wikiRoot, sampleSize = 50) {
     const eventsPath = path.join(wikiRoot, "log", "events.jsonl");
     if (!fs.existsSync(eventsPath))
         return DEFAULT_PER_INGEST_AVG_USD;
-    let lines;
+    let fileContent;
     try {
-        lines = fs.readFileSync(eventsPath, "utf-8").split("\n");
+        fileContent = fs.readFileSync(eventsPath, "utf-8");
     }
     catch {
         return DEFAULT_PER_INGEST_AVG_USD;
     }
     const samples = [];
-    for (let i = lines.length - 1; i >= 0 && samples.length < sampleSize; i--) {
-        const line = lines[i];
+    // Performance optimization: Avoid .split("\n") on large log files to prevent massive intermediate array allocation.
+    // Instead, we iteratively find the previous newline backwards and extract substrings.
+    // Memory improvement: O(N) allocation -> O(1) allocation for line parsing.
+    let pos = fileContent.length;
+    while (pos >= 0 && samples.length < sampleSize) {
+        const nextPos = pos === 0 ? -1 : fileContent.lastIndexOf("\n", pos - 1);
+        const line = fileContent.substring(nextPos + 1, pos);
+        pos = nextPos;
         if (!line)
             continue;
         // Fast-path: skip JSON parse overhead if this line cannot be an ingest event
@@ -280,7 +292,7 @@ export const CROSS_SERVICE_GLOBAL_PAGES = [
     "database-traces",
     "shared-libraries",
 ];
-const GLOBAL_PAGE_AVG_USD = 0.20; // synthesis-only, smaller than ingest
+const GLOBAL_PAGE_AVG_USD = 0.2; // synthesis-only, smaller than ingest
 /**
  * Count of global synthesis pages that will be regenerated in Phase 7.
  * The `facets` argument is reserved for future per-facet-driven globals.
@@ -289,7 +301,8 @@ const GLOBAL_PAGE_AVG_USD = 0.20; // synthesis-only, smaller than ingest
  */
 export function expectedGlobalCount(facets, crossServiceEnabled = false) {
     void facets;
-    return STATIC_GLOBAL_PAGES.length + (crossServiceEnabled ? CROSS_SERVICE_GLOBAL_PAGES.length : 0);
+    return (STATIC_GLOBAL_PAGES.length +
+        (crossServiceEnabled ? CROSS_SERVICE_GLOBAL_PAGES.length : 0));
 }
 /**
  * Estimate the cost of running a plan on a wiki. For each `(topic, facet)`
@@ -309,11 +322,21 @@ export function estimateCost(wikiRoot, plan, perIngestAvgUsd, crossServiceEnable
         const cached = _isPlanEntryCached(wikiRoot, entry);
         if (cached) {
             cacheHits++;
-            breakdown.push({ topic: entry.topic, facet: entry.facet, expected: false, cached: true });
+            breakdown.push({
+                topic: entry.topic,
+                facet: entry.facet,
+                expected: false,
+                cached: true,
+            });
         }
         else {
             expectedIngests++;
-            breakdown.push({ topic: entry.topic, facet: entry.facet, expected: true, cached: false });
+            breakdown.push({
+                topic: entry.topic,
+                facet: entry.facet,
+                expected: true,
+                cached: false,
+            });
         }
     }
     const topicCost = expectedIngests * avg;
@@ -515,7 +538,9 @@ export function assembleGapReport(wikiRoot, plan, gitlog, inventory) {
     }
     const sourceFilesWithNoPage = [...missingSources].sort();
     // 4. Gitlog uncovered_files — pass through if provided.
-    const uncoveredFiles = gitlog?.uncovered_files ? [...gitlog.uncovered_files] : [];
+    const uncoveredFiles = gitlog?.uncovered_files
+        ? [...gitlog.uncovered_files]
+        : [];
     // 5. Connectors mentioned in atlas pages but missing from integrations.md.
     // Single wiki walk also collects every page's `sources:` frontmatter so
     // step 6 (manifest-driven) doesn't re-walk.
@@ -524,7 +549,9 @@ export function assembleGapReport(wikiRoot, plan, gitlog, inventory) {
     let integrationsBody = "";
     if (fs.existsSync(integrationsPath)) {
         try {
-            integrationsBody = fs.readFileSync(integrationsPath, "utf-8").toLowerCase();
+            integrationsBody = fs
+                .readFileSync(integrationsPath, "utf-8")
+                .toLowerCase();
         }
         catch {
             integrationsBody = "";

--- a/skills/doc-wiki/scripts/atlas_orchestrator.ts
+++ b/skills/doc-wiki/scripts/atlas_orchestrator.ts
@@ -170,14 +170,21 @@ export function countAllPages(wikiRoot: string): number {
 export function getLastAtlasRunId(wikiRoot: string): string | null {
   const eventsPath = path.join(wikiRoot, "log", "events.jsonl");
   if (!fs.existsSync(eventsPath)) return null;
-  let lines: string[];
+  let fileContent: string;
   try {
-    lines = fs.readFileSync(eventsPath, "utf-8").split("\n");
+    fileContent = fs.readFileSync(eventsPath, "utf-8");
   } catch {
     return null;
   }
-  for (let i = lines.length - 1; i >= 0; i--) {
-    const line = lines[i];
+
+  // Performance optimization: Avoid .split("\n") on large log files to prevent massive intermediate array allocation.
+  // Instead, we iteratively find the previous newline backwards and extract substrings.
+  // Memory improvement: O(N) allocation -> O(1) allocation for line parsing.
+  let pos = fileContent.length;
+  while (pos >= 0) {
+    const nextPos = pos === 0 ? -1 : fileContent.lastIndexOf("\n", pos - 1);
+    const line = fileContent.substring(nextPos + 1, pos);
+    pos = nextPos;
     if (!line) continue;
 
     // Fast-path: skip JSON parse overhead if this line cannot be an atlas event
@@ -237,7 +244,7 @@ export function detectState(
 
 // ── Per-ingest cost average ────────────────────────────────────────
 
-const DEFAULT_PER_INGEST_AVG_USD = 0.20;
+const DEFAULT_PER_INGEST_AVG_USD = 0.2;
 
 /**
  * Read recent `op: ingest` events from `log/events.jsonl` and return a
@@ -253,15 +260,22 @@ export function getRollingPerIngestAvg(
 ): number {
   const eventsPath = path.join(wikiRoot, "log", "events.jsonl");
   if (!fs.existsSync(eventsPath)) return DEFAULT_PER_INGEST_AVG_USD;
-  let lines: string[];
+  let fileContent: string;
   try {
-    lines = fs.readFileSync(eventsPath, "utf-8").split("\n");
+    fileContent = fs.readFileSync(eventsPath, "utf-8");
   } catch {
     return DEFAULT_PER_INGEST_AVG_USD;
   }
   const samples: number[] = [];
-  for (let i = lines.length - 1; i >= 0 && samples.length < sampleSize; i--) {
-    const line = lines[i];
+
+  // Performance optimization: Avoid .split("\n") on large log files to prevent massive intermediate array allocation.
+  // Instead, we iteratively find the previous newline backwards and extract substrings.
+  // Memory improvement: O(N) allocation -> O(1) allocation for line parsing.
+  let pos = fileContent.length;
+  while (pos >= 0 && samples.length < sampleSize) {
+    const nextPos = pos === 0 ? -1 : fileContent.lastIndexOf("\n", pos - 1);
+    const line = fileContent.substring(nextPos + 1, pos);
+    pos = nextPos;
     if (!line) continue;
 
     // Fast-path: skip JSON parse overhead if this line cannot be an ingest event
@@ -273,7 +287,8 @@ export function getRollingPerIngestAvg(
     } catch {
       continue;
     }
-    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) continue;
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed))
+      continue;
     const rec = parsed as Record<string, unknown>;
     if (rec["op"] !== "ingest") continue;
     // Cost may live at top level or in details.total_cost_usd.
@@ -326,7 +341,7 @@ export const CROSS_SERVICE_GLOBAL_PAGES: readonly string[] = [
   "shared-libraries",
 ];
 
-const GLOBAL_PAGE_AVG_USD = 0.20; // synthesis-only, smaller than ingest
+const GLOBAL_PAGE_AVG_USD = 0.2; // synthesis-only, smaller than ingest
 
 /**
  * Count of global synthesis pages that will be regenerated in Phase 7.
@@ -334,9 +349,15 @@ const GLOBAL_PAGE_AVG_USD = 0.20; // synthesis-only, smaller than ingest
  * Pass `crossServiceEnabled = true` when `ecosystem.cross_service.enabled`
  * is set so that the 6 cross-service pages are included in the count.
  */
-export function expectedGlobalCount(facets?: readonly string[], crossServiceEnabled = false): number {
+export function expectedGlobalCount(
+  facets?: readonly string[],
+  crossServiceEnabled = false,
+): number {
   void facets;
-  return STATIC_GLOBAL_PAGES.length + (crossServiceEnabled ? CROSS_SERVICE_GLOBAL_PAGES.length : 0);
+  return (
+    STATIC_GLOBAL_PAGES.length +
+    (crossServiceEnabled ? CROSS_SERVICE_GLOBAL_PAGES.length : 0)
+  );
 }
 
 /**
@@ -363,15 +384,26 @@ export function estimateCost(
     const cached = _isPlanEntryCached(wikiRoot, entry);
     if (cached) {
       cacheHits++;
-      breakdown.push({ topic: entry.topic, facet: entry.facet, expected: false, cached: true });
+      breakdown.push({
+        topic: entry.topic,
+        facet: entry.facet,
+        expected: false,
+        cached: true,
+      });
     } else {
       expectedIngests++;
-      breakdown.push({ topic: entry.topic, facet: entry.facet, expected: true, cached: false });
+      breakdown.push({
+        topic: entry.topic,
+        facet: entry.facet,
+        expected: true,
+        cached: false,
+      });
     }
   }
 
   const topicCost = expectedIngests * avg;
-  const globalCost = expectedGlobalCount(plan.facets, crossServiceEnabled) * GLOBAL_PAGE_AVG_USD;
+  const globalCost =
+    expectedGlobalCount(plan.facets, crossServiceEnabled) * GLOBAL_PAGE_AVG_USD;
   return {
     expected_ingests: expectedIngests,
     cache_hits: cacheHits,
@@ -465,10 +497,7 @@ export function savePlanSnapshot(
  * old version with no `created_at`) are tolerated; the orchestrator can
  * decide whether to keep going.
  */
-export function loadPlanSnapshot(
-  wikiRoot: string,
-  runId: string,
-): Plan | null {
+export function loadPlanSnapshot(wikiRoot: string, runId: string): Plan | null {
   const target = _planSnapshotPath(wikiRoot, runId);
   if (!fs.existsSync(target)) return null;
   let raw: string;
@@ -483,7 +512,8 @@ export function loadPlanSnapshot(
   } catch {
     return null;
   }
-  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return null;
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed))
+    return null;
   const rec = parsed as Record<string, unknown>;
   if (
     !Array.isArray(rec["topics"]) ||
@@ -496,8 +526,9 @@ export function loadPlanSnapshot(
     topics: rec["topics"].filter((x): x is string => typeof x === "string"),
     facets: rec["facets"].filter((x): x is string => typeof x === "string"),
     entries: (rec["entries"] as unknown[])
-      .filter((e): e is Record<string, unknown> =>
-        Boolean(e) && typeof e === "object" && !Array.isArray(e),
+      .filter(
+        (e): e is Record<string, unknown> =>
+          Boolean(e) && typeof e === "object" && !Array.isArray(e),
       )
       .map((e) => ({
         topic: typeof e["topic"] === "string" ? e["topic"] : "",
@@ -507,8 +538,7 @@ export function loadPlanSnapshot(
           : [],
         output: typeof e["output"] === "string" ? e["output"] : "",
       })),
-    created_at:
-      typeof rec["created_at"] === "string" ? rec["created_at"] : "",
+    created_at: typeof rec["created_at"] === "string" ? rec["created_at"] : "",
   };
 }
 
@@ -641,7 +671,9 @@ export function assembleGapReport(
   const sourceFilesWithNoPage = [...missingSources].sort();
 
   // 4. Gitlog uncovered_files — pass through if provided.
-  const uncoveredFiles = gitlog?.uncovered_files ? [...gitlog.uncovered_files] : [];
+  const uncoveredFiles = gitlog?.uncovered_files
+    ? [...gitlog.uncovered_files]
+    : [];
 
   // 5. Connectors mentioned in atlas pages but missing from integrations.md.
   // Single wiki walk also collects every page's `sources:` frontmatter so
@@ -651,7 +683,9 @@ export function assembleGapReport(
   let integrationsBody = "";
   if (fs.existsSync(integrationsPath)) {
     try {
-      integrationsBody = fs.readFileSync(integrationsPath, "utf-8").toLowerCase();
+      integrationsBody = fs
+        .readFileSync(integrationsPath, "utf-8")
+        .toLowerCase();
     } catch {
       integrationsBody = "";
     }
@@ -698,7 +732,8 @@ export function assembleGapReport(
     walk(wikiContent);
   }
   for (const k of archMentions) {
-    if (!integrationsBody.includes(k)) externalServicesWithoutDocumentation.push(k);
+    if (!integrationsBody.includes(k))
+      externalServicesWithoutDocumentation.push(k);
   }
   externalServicesWithoutDocumentation.sort();
 
@@ -758,7 +793,10 @@ export function assembleGapReport(
 }
 
 /** Render a {@link GapReport} as a Markdown document for `gap-report.md`. */
-export function renderGapReportMarkdown(report: GapReport, runId: string): string {
+export function renderGapReportMarkdown(
+  report: GapReport,
+  runId: string,
+): string {
   const lines: string[] = [];
   lines.push(`# Atlas gap report — ${runId}`);
   lines.push("");
@@ -819,7 +857,8 @@ export function renderGapReportMarkdown(report: GapReport, runId: string): strin
     lines.push("_(none)_");
   } else {
     lines.push("");
-    for (const s of report.externalServicesWithoutDocumentation) lines.push(`- ${s}`);
+    for (const s of report.externalServicesWithoutDocumentation)
+      lines.push(`- ${s}`);
   }
   lines.push("");
 
@@ -952,7 +991,9 @@ export function main(argv: readonly string[] = process.argv.slice(2)): number {
     try {
       plan = JSON.parse(planRaw) as Plan;
     } catch (e) {
-      process.stderr.write(`--plan is not valid JSON: ${(e as Error).message}\n`);
+      process.stderr.write(
+        `--plan is not valid JSON: ${(e as Error).message}\n`,
+      );
       return 2;
     }
     const avgRaw = parsed.values["perIngestAvgUsd"];
@@ -1001,7 +1042,9 @@ export function main(argv: readonly string[] = process.argv.slice(2)): number {
     try {
       plan = JSON.parse(planRaw) as Plan;
     } catch (e) {
-      process.stderr.write(`--plan is not valid JSON: ${(e as Error).message}\n`);
+      process.stderr.write(
+        `--plan is not valid JSON: ${(e as Error).message}\n`,
+      );
       return 2;
     }
     savePlanSnapshot(wikiRoot, runId, plan);
@@ -1042,7 +1085,9 @@ export function main(argv: readonly string[] = process.argv.slice(2)): number {
     try {
       plan = JSON.parse(planRaw) as Plan;
     } catch (e) {
-      process.stderr.write(`--plan is not valid JSON: ${(e as Error).message}\n`);
+      process.stderr.write(
+        `--plan is not valid JSON: ${(e as Error).message}\n`,
+      );
       return 2;
     }
     let gitlog: GitlogClassification | undefined;
@@ -1051,7 +1096,9 @@ export function main(argv: readonly string[] = process.argv.slice(2)): number {
       try {
         gitlog = JSON.parse(gitlogRaw) as GitlogClassification;
       } catch (e) {
-        process.stderr.write(`--gitlog is not valid JSON: ${(e as Error).message}\n`);
+        process.stderr.write(
+          `--gitlog is not valid JSON: ${(e as Error).message}\n`,
+        );
         return 2;
       }
     }
@@ -1075,7 +1122,9 @@ export function main(argv: readonly string[] = process.argv.slice(2)): number {
       );
       fs.mkdirSync(path.dirname(target), { recursive: true });
       fs.writeFileSync(target, md);
-      process.stdout.write(JSON.stringify({ ...report, written: target }) + "\n");
+      process.stdout.write(
+        JSON.stringify({ ...report, written: target }) + "\n",
+      );
     } else {
       process.stdout.write(JSON.stringify(report) + "\n");
     }


### PR DESCRIPTION
💡 What: Replaced `.split('\n')` with an iterative `lastIndexOf` and `substring()` loop in `atlas_orchestrator.ts` and `atlas_gitlog.ts`.

🎯 Why: The codebase frequently needs to read the tail of the append-only `events.jsonl` log. Doing so by reading the entire file into a string and then calling `.split('\n')` synchronously allocates a massive intermediate string array in memory. This causes massive garbage collection pressure and risks out-of-memory errors on very large wikis.

📊 Impact: Reduces memory allocation from O(N) (a massive array of all lines) to O(1) (parsing line-by-line backwards).

🔬 Measurement: Profile memory usage when parsing large (multi-megabyte) `events.jsonl` logs.

Also added explanatory performance comments to the updated loops.

---
*PR created automatically by Jules for task [13953863952288907821](https://jules.google.com/task/13953863952288907821) started by @rfv-code*