### PR TITLE
⚡ Bolt: Replace split with indexOf to reduce memory overhead

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -12,3 +12,8 @@
 
 **Learning:** Inner JSON fields might mistakenly contain match substrings like dates (e.g., inside the text of the event). Utilizing a strict, anchored regex check for extracting fields like timestamps directly (`/^{"ts":"([^"\\]+)"/`) avoids both `JSON.parse` overhead and incorrect partial string matches from `String.includes()`.
 **Action:** Use an anchored regex (`/^{"ts":"([^"\\]+)"/`) and check the captured group directly before falling back to full JSON parsing.
+
+## 2026-08-15 - Optimize log parsing memory usage
+
+**Learning:** When processing large files read into memory as a single string (e.g., via `fs.readFileSync`), using `.split('\n')` to iterate over lines synchronously allocates a massive intermediate array, causing a significant memory overhead.
+**Action:** Use an iterative `indexOf('\n')` for forward iteration, or `lastIndexOf('\n')` for backward iteration, combined with a `substring()` loop to significantly reduce memory overhead.

--- a/skills/doc-wiki/scripts/event_logger.js
+++ b/skills/doc-wiki/scripts/event_logger.js
@@ -146,7 +146,14 @@ function _readEvents(wikiRoot, since = null) {
     }
     const raw = fs.readFileSync(p, { encoding: "utf-8" });
     const events = [];
-    for (const rawLine of raw.split("\n")) {
+    let _start = 0;
+    while (_start < raw.length) {
+        let _end = raw.indexOf("\n", _start);
+        if (_end === -1) {
+            _end = raw.length;
+        }
+        const rawLine = raw.substring(_start, _end);
+        _start = _end + 1;
         const line = rawLine.trim();
         if (!line)
             continue;

--- a/skills/doc-wiki/scripts/event_logger.ts
+++ b/skills/doc-wiki/scripts/event_logger.ts
@@ -191,7 +191,14 @@ function _readEvents(
 
   const raw = fs.readFileSync(p, { encoding: "utf-8" });
   const events: Array<Record<string, unknown>> = [];
-  for (const rawLine of raw.split("\n")) {
+  let _start = 0;
+  while (_start < raw.length) {
+    let _end = raw.indexOf("\n", _start);
+    if (_end === -1) {
+      _end = raw.length;
+    }
+    const rawLine = raw.substring(_start, _end);
+    _start = _end + 1;
     const line = rawLine.trim();
     if (!line) continue;
 


### PR DESCRIPTION
💡 What: Replaced the memory-intensive `raw.split('\n')` iteration with a `while` loop utilizing `indexOf('\n')` and `substring()` for parsing large strings in `event_logger.ts`.
🎯 Why: Iterating over lines using `.split('\n')` synchronously allocates a massive intermediate array. When dealing with potentially large log files read into memory as strings, this causes excessive memory overhead and potential out-of-memory errors. The change effectively processes the string piece-by-piece, reducing memory allocations significantly.
📊 Impact: Considerably reduces maximum memory footprint when processing large files because the full array of split strings is no longer constructed and retained in memory simultaneously.
🔬 Measurement: Run the `getStats` or similar event logger routines over an exceptionally large log file (>100MB) before and after the patch and observe reduced heap size usage and lower garbage collection pauses via Node.js memory profiling (`--inspect`).

---
*PR created automatically by Jules for task [9416962701274683951](https://jules.google.com/task/9416962701274683951) started by @rfv-code*