### PR TITLE
⚡ Bolt: Optimize log parsing memory usage by removing `.split('\n')`

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -12,3 +12,7 @@
 
 **Learning:** Inner JSON fields might mistakenly contain match substrings like dates (e.g., inside the text of the event). Utilizing a strict, anchored regex check for extracting fields like timestamps directly (`/^{"ts":"([^"\\]+)"/`) avoids both `JSON.parse` overhead and incorrect partial string matches from `String.includes()`.
 **Action:** Use an anchored regex (`/^{"ts":"([^"\\]+)"/`) and check the captured group directly before falling back to full JSON parsing.
+
+## 2026-05-23 - Iterating over lines in large strings
+**Learning:** Calling `.split('\n')` on a massive string (like the entire contents of an append-only JSON log file) creates a massive intermediate array, which is a significant performance bottleneck and causes heavy garbage collection load.
+**Action:** Use an iterative `indexOf('\n')` (for forward traversal) or `lastIndexOf('\n')` (for backward traversal) combined with a `.substring()` loop to parse strings line by line efficiently without synchronously allocating large arrays.

--- a/agents/lib/atlas_archive.js
+++ b/agents/lib/atlas_archive.js
@@ -17,13 +17,18 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
 import * as yaml from "js-yaml";
-import { walkLivePages } from "../../skills/doc-wiki/scripts/_wiki_fs.js";
+import { walkLivePages, } from "../../skills/doc-wiki/scripts/_wiki_fs.js";
 import { parseFrontmatter } from "../../skills/doc-wiki/scripts/_frontmatter.js";
 import { sourceExistence, } from "../../skills/doc-wiki/scripts/atlas_validate.js";
 import { parseFlags } from "../../skills/doc-wiki/scripts/_cli_args.js";
 import { checkPathContainment } from "narai-primitives/toolkit";
-import { parseConfig } from "./parse_config.js";
-export const AUTONOMY_MODES = ["conservative", "balanced", "autonomous", "auto"];
+import { parseConfig, } from "./parse_config.js";
+export const AUTONOMY_MODES = [
+    "conservative",
+    "balanced",
+    "autonomous",
+    "auto",
+];
 export const REWRITE_MODES = ["rewrite", "drop", "leave"];
 function decideAutonomy(autonomy, _kind) {
     switch (autonomy) {
@@ -47,7 +52,9 @@ function filterAtlasPages(pages) {
             continue;
         }
         const { frontmatter } = parseFrontmatter(raw);
-        if (frontmatter && "atlas_facet" in frontmatter && frontmatter["atlas_facet"] != null) {
+        if (frontmatter &&
+            "atlas_facet" in frontmatter &&
+            frontmatter["atlas_facet"] != null) {
             out.push(page);
         }
     }
@@ -132,14 +139,24 @@ export async function rebuildArchiveIndex(wikiRoot) {
     const journalPath = path.join(wikiRoot, "_archive_history.jsonl");
     let allEvents = [];
     if (fs.existsSync(journalPath)) {
-        const lines = fs.readFileSync(journalPath, "utf-8").split("\n").filter(Boolean);
-        for (const line of lines) {
-            try {
-                allEvents.push(JSON.parse(line));
+        const raw = fs.readFileSync(journalPath, "utf-8");
+        // Performance optimization: Avoid .split('\n') which allocates a massive intermediate array.
+        // Iterating with indexOf and substring significantly reduces memory usage and GC pressure.
+        let start = 0;
+        while (start < raw.length) {
+            const end = raw.indexOf("\n", start);
+            const line = end === -1 ? raw.substring(start) : raw.substring(start, end);
+            if (line) {
+                try {
+                    allEvents.push(JSON.parse(line));
+                }
+                catch {
+                    // skip malformed lines
+                }
             }
-            catch {
-                // skip malformed lines
-            }
+            if (end === -1)
+                break;
+            start = end + 1;
         }
     }
     // Only keep archive events (op !== "unarchive") whose archived file still exists.
@@ -210,7 +227,8 @@ async function resolveArchivePath(wikiRoot, pageOrSlug) {
     const candidateRelPosix = path.posix.normalize(candidateRelRaw);
     // If the raw input looked like a direct wiki/_archive/ path but normalization
     // resolved ".." segments that escape the archive root, it is a traversal attempt.
-    if (candidateRelRaw.startsWith("wiki/_archive/") && !candidateRelPosix.startsWith("wiki/_archive/")) {
+    if (candidateRelRaw.startsWith("wiki/_archive/") &&
+        !candidateRelPosix.startsWith("wiki/_archive/")) {
         throw new Error(`path traversal detected: "${pageOrSlug}" resolves outside wiki/_archive/`);
     }
     if (candidateRelPosix.startsWith("wiki/_archive/")) {
@@ -233,7 +251,9 @@ async function resolveArchivePath(wikiRoot, pageOrSlug) {
             if (entry.isDirectory()) {
                 walk(abs);
             }
-            else if (entry.isFile() && entry.name.endsWith(".md") && entry.name !== "index.md") {
+            else if (entry.isFile() &&
+                entry.name.endsWith(".md") &&
+                entry.name !== "index.md") {
                 const relPath = path.relative(wikiRoot, abs).replace(/\\/g, "/");
                 if (relPath.includes(pageOrSlug)) {
                     matches.push({ absPath: abs, relPath });
@@ -252,7 +272,12 @@ async function resolveArchivePath(wikiRoot, pageOrSlug) {
     return matches[0];
 }
 // ── stripArchiveFrontmatter ───────────────────────────────────────────────────
-const ARCHIVE_FM_KEYS = new Set(["status", "archived_at", "archive_reason", "archived_from"]);
+const ARCHIVE_FM_KEYS = new Set([
+    "status",
+    "archived_at",
+    "archive_reason",
+    "archived_from",
+]);
 /**
  * Read the file at absPath, remove the four deprecation frontmatter fields,
  * preserve everything else, write it back in place.
@@ -268,9 +293,7 @@ async function stripArchiveFrontmatter(absPath) {
             }
         }
     }
-    const newContent = Object.keys(fm).length === 0
-        ? body
-        : `---\n${yaml.dump(fm)}---\n${body}`;
+    const newContent = Object.keys(fm).length === 0 ? body : `---\n${yaml.dump(fm)}---\n${body}`;
     await fs.promises.writeFile(absPath, newContent, "utf-8");
 }
 // ── Code-block-aware text rewriter ────────────────────────────────────────────
@@ -411,7 +434,8 @@ export async function rewriteInboundLinksForUnarchive(opts) {
                 const [whole, label, rawTarget] = m;
                 // Only process links that look like rewritten archive links:
                 // label must end with " (archived)" AND path must be under _archive/.
-                if (!label.endsWith(" (archived)") || !rawTarget.includes("_archive/")) {
+                if (!label.endsWith(" (archived)") ||
+                    !rawTarget.includes("_archive/")) {
                     out.push(text.slice(lastIndex, m.index + whole.length));
                     lastIndex = m.index + whole.length;
                     continue;
@@ -457,7 +481,8 @@ export async function unarchive(opts) {
     const resolved = await resolveArchivePath(opts.wikiRoot, opts.pageOrSlug);
     const raw = await fs.promises.readFile(resolved.absPath, "utf-8");
     const { frontmatter } = parseFrontmatter(raw);
-    const archivedFrom = opts.target ?? frontmatter?.["archived_from"];
+    const archivedFrom = opts.target ??
+        frontmatter?.["archived_from"];
     if (!archivedFrom) {
         throw new Error(`page ${resolved.relPath} lacks archived_from frontmatter; pass --target to specify restore path`);
     }
@@ -492,7 +517,10 @@ export async function unarchive(opts) {
     // there are no archive-style links to drop, so treat it as "leave".
     const effectiveMode = opts.inboundLinks === "drop" ? "leave" : opts.inboundLinks;
     const linksReverted = effectiveMode === "rewrite"
-        ? await rewriteInboundLinksForUnarchive({ wikiRoot: opts.wikiRoot, event })
+        ? await rewriteInboundLinksForUnarchive({
+            wikiRoot: opts.wikiRoot,
+            event,
+        })
         : 0;
     return { from: event.from, to: event.to, linksReverted };
 }
@@ -502,7 +530,11 @@ export async function sweep(opts) {
         throw new Error(`invalid autonomy '${opts.autonomy}'; expected one of: ${AUTONOMY_MODES.join(", ")}`);
     }
     const partialThreshold = opts.partialThreshold ?? 1.0;
-    const resolvedOpts = { inboundLinks: "rewrite", ...opts, partialThreshold };
+    const resolvedOpts = {
+        inboundLinks: "rewrite",
+        ...opts,
+        partialThreshold,
+    };
     const livePages = walkLivePages(opts.wikiRoot);
     const atlasPages = filterAtlasPages(livePages);
     const archived = [];
@@ -664,9 +696,12 @@ export async function main() {
         const wikiRoot = parsed.values["wikiRoot"];
         const repoRoot = parsed.values["repoRoot"];
         const runId = parsed.values["runId"];
-        if (typeof wikiRoot !== "string" || wikiRoot.length === 0 ||
-            typeof repoRoot !== "string" || repoRoot.length === 0 ||
-            typeof runId !== "string" || runId.length === 0) {
+        if (typeof wikiRoot !== "string" ||
+            wikiRoot.length === 0 ||
+            typeof repoRoot !== "string" ||
+            repoRoot.length === 0 ||
+            typeof runId !== "string" ||
+            runId.length === 0) {
             process.stderr.write("--wiki-root, --repo-root, and --run-id are required\n");
             return 2;
         }
@@ -713,7 +748,15 @@ export async function main() {
         else {
             inboundLinks = configInboundLinks;
         }
-        const result = await sweep({ wikiRoot, repoRoot, runId, autonomy, partialThreshold, dryRun, inboundLinks });
+        const result = await sweep({
+            wikiRoot,
+            repoRoot,
+            runId,
+            autonomy,
+            partialThreshold,
+            dryRun,
+            inboundLinks,
+        });
         process.stdout.write(JSON.stringify(result) + "\n");
         return 0;
     }
@@ -728,12 +771,15 @@ export async function main() {
         }
         const wikiRoot = parsed.values["wikiRoot"];
         const pageOrSlug = parsed.values["pageOrSlug"];
-        if (typeof wikiRoot !== "string" || wikiRoot.length === 0 ||
-            typeof pageOrSlug !== "string" || pageOrSlug.length === 0) {
+        if (typeof wikiRoot !== "string" ||
+            wikiRoot.length === 0 ||
+            typeof pageOrSlug !== "string" ||
+            pageOrSlug.length === 0) {
             process.stderr.write("--wiki-root and --page-or-slug are required\n");
             return 2;
         }
-        const target = typeof parsed.values["target"] === "string" && parsed.values["target"].length > 0
+        const target = typeof parsed.values["target"] === "string" &&
+            parsed.values["target"].length > 0
             ? parsed.values["target"]
             : undefined;
         const inboundLinksRaw = parsed.values["inboundLinks"] ?? "rewrite";
@@ -744,7 +790,12 @@ export async function main() {
         }
         const inboundLinks = inboundLinksRaw;
         try {
-            const result = await unarchive({ wikiRoot, pageOrSlug, target, inboundLinks });
+            const result = await unarchive({
+                wikiRoot,
+                pageOrSlug,
+                target,
+                inboundLinks,
+            });
             process.stdout.write(JSON.stringify(result) + "\n");
             return 0;
         }
@@ -783,12 +834,15 @@ export async function main() {
         const wikiRoot = parsed.values["wikiRoot"];
         const eventsFile = parsed.values["eventsFile"];
         const modeRaw = parsed.values["mode"] ?? "rewrite";
-        if (typeof wikiRoot !== "string" || wikiRoot.length === 0 ||
-            typeof eventsFile !== "string" || eventsFile.length === 0) {
+        if (typeof wikiRoot !== "string" ||
+            wikiRoot.length === 0 ||
+            typeof eventsFile !== "string" ||
+            eventsFile.length === 0) {
             process.stderr.write("--wiki-root and --events-file are required\n");
             return 2;
         }
-        if (typeof modeRaw !== "string" || !REWRITE_MODES.includes(modeRaw)) {
+        if (typeof modeRaw !== "string" ||
+            !REWRITE_MODES.includes(modeRaw)) {
             process.stderr.write(`error: invalid --mode value '${modeRaw}'; expected one of: ${REWRITE_MODES.join(", ")}\n`);
             return 2;
         }
@@ -809,8 +863,10 @@ export async function main() {
         }
         const wikiRoot = parsed.values["wikiRoot"];
         const eventFile = parsed.values["eventFile"];
-        if (typeof wikiRoot !== "string" || wikiRoot.length === 0 ||
-            typeof eventFile !== "string" || eventFile.length === 0) {
+        if (typeof wikiRoot !== "string" ||
+            wikiRoot.length === 0 ||
+            typeof eventFile !== "string" ||
+            eventFile.length === 0) {
             process.stderr.write("--wiki-root and --event-file are required\n");
             return 2;
         }
@@ -825,7 +881,9 @@ export async function main() {
 }
 const thisFile = fileURLToPath(import.meta.url);
 if (process.argv[1] && path.resolve(process.argv[1]) === thisFile) {
-    main().then(process.exit).catch((e) => {
+    main()
+        .then(process.exit)
+        .catch((e) => {
         process.stderr.write(`${e.message}\n`);
         process.exit(1);
     });

--- a/agents/lib/atlas_archive.ts
+++ b/agents/lib/atlas_archive.ts
@@ -18,7 +18,10 @@ import * as path from "node:path";
 import { fileURLToPath } from "node:url";
 import * as yaml from "js-yaml";
 
-import { walkLivePages, type WikiPage } from "../../skills/doc-wiki/scripts/_wiki_fs.js";
+import {
+  walkLivePages,
+  type WikiPage,
+} from "../../skills/doc-wiki/scripts/_wiki_fs.js";
 import { parseFrontmatter } from "../../skills/doc-wiki/scripts/_frontmatter.js";
 import {
   sourceExistence,
@@ -26,12 +29,21 @@ import {
 } from "../../skills/doc-wiki/scripts/atlas_validate.js";
 import { parseFlags } from "../../skills/doc-wiki/scripts/_cli_args.js";
 import { checkPathContainment } from "narai-primitives/toolkit";
-import { parseConfig, ConfigFileNotFoundError, type ArchiveConfig } from "./parse_config.js";
+import {
+  parseConfig,
+  ConfigFileNotFoundError,
+  type ArchiveConfig,
+} from "./parse_config.js";
 
 // ── Public types ───────────────────────────────────────────────────────────────
 
 export type Autonomy = "conservative" | "balanced" | "autonomous" | "auto";
-export const AUTONOMY_MODES = ["conservative", "balanced", "autonomous", "auto"] as const;
+export const AUTONOMY_MODES = [
+  "conservative",
+  "balanced",
+  "autonomous",
+  "auto",
+] as const;
 
 export const REWRITE_MODES = ["rewrite", "drop", "leave"] as const;
 export type RewriteMode = (typeof REWRITE_MODES)[number];
@@ -39,7 +51,7 @@ export type RewriteMode = (typeof REWRITE_MODES)[number];
 export interface UnarchiveOptions {
   wikiRoot: string;
   pageOrSlug: string; // "wiki/_archive/billing/architecture.md" OR "architecture"
-  target?: string;    // override the archived_from value
+  target?: string; // override the archived_from value
   inboundLinks: RewriteMode;
 }
 
@@ -53,7 +65,7 @@ export interface UnarchiveEvent {
   ts: string;
   op: "unarchive";
   from: string; // wiki/_archive/<topic>/<page>.md
-  to: string;   // wiki/<topic>/<page>.md
+  to: string; // wiki/<topic>/<page>.md
 }
 
 export interface SweepOptions {
@@ -144,7 +156,11 @@ function filterAtlasPages(pages: WikiPage[]): AtlasPage[] {
       continue;
     }
     const { frontmatter } = parseFrontmatter(raw);
-    if (frontmatter && "atlas_facet" in frontmatter && frontmatter["atlas_facet"] != null) {
+    if (
+      frontmatter &&
+      "atlas_facet" in frontmatter &&
+      frontmatter["atlas_facet"] != null
+    ) {
       out.push(page);
     }
   }
@@ -178,7 +194,11 @@ function isoDate(isoTs: string): string {
  */
 function stampFrontmatter(
   absPath: string,
-  fields: { archived_from: string; archived_at: string; archive_reason: string },
+  fields: {
+    archived_from: string;
+    archived_at: string;
+    archive_reason: string;
+  },
 ): void {
   const raw = fs.readFileSync(absPath, "utf-8");
   const { frontmatter, body } = parseFrontmatter(raw);
@@ -200,9 +220,10 @@ function buildEvent(
   ts: string,
 ): ArchiveEvent {
   const archRelPath = toArchiveRelPath(page.relPath);
-  const reason = existence.ratio === 1.0
-    ? `all sources removed (${existence.missing.join(", ")})`
-    : `${existence.missing.length} of ${existence.total} sources removed (${existence.missing.join(", ")})`;
+  const reason =
+    existence.ratio === 1.0
+      ? `all sources removed (${existence.missing.join(", ")})`
+      : `${existence.missing.length} of ${existence.total} sources removed (${existence.missing.join(", ")})`;
   return {
     ts,
     op: "archive",
@@ -230,9 +251,10 @@ async function applyArchive(
   // If stamp fails after rename, the file is at the archive path with original
   // frontmatter; the next sweep won't see it (outside walkLivePages).
   fs.renameSync(page.absPath, archAbsPath);
-  const archiveReason = existence.ratio === 1.0
-    ? `all sources removed (${existence.missing.join(", ")})`
-    : `${existence.missing.length} of ${existence.total} sources removed (${existence.missing.join(", ")})`;
+  const archiveReason =
+    existence.ratio === 1.0
+      ? `all sources removed (${existence.missing.join(", ")})`
+      : `${existence.missing.length} of ${existence.total} sources removed (${existence.missing.join(", ")})`;
   stampFrontmatter(archAbsPath, {
     archived_from: page.relPath,
     archived_at: isoDate(ts),
@@ -259,13 +281,23 @@ export async function rebuildArchiveIndex(wikiRoot: string): Promise<void> {
   let allEvents: Array<ArchiveEvent | UnarchiveEvent> = [];
 
   if (fs.existsSync(journalPath)) {
-    const lines = fs.readFileSync(journalPath, "utf-8").split("\n").filter(Boolean);
-    for (const line of lines) {
-      try {
-        allEvents.push(JSON.parse(line) as ArchiveEvent | UnarchiveEvent);
-      } catch {
-        // skip malformed lines
+    const raw = fs.readFileSync(journalPath, "utf-8");
+    // Performance optimization: Avoid .split('\n') which allocates a massive intermediate array.
+    // Iterating with indexOf and substring significantly reduces memory usage and GC pressure.
+    let start = 0;
+    while (start < raw.length) {
+      const end = raw.indexOf("\n", start);
+      const line =
+        end === -1 ? raw.substring(start) : raw.substring(start, end);
+      if (line) {
+        try {
+          allEvents.push(JSON.parse(line) as ArchiveEvent | UnarchiveEvent);
+        } catch {
+          // skip malformed lines
+        }
       }
+      if (end === -1) break;
+      start = end + 1;
     }
   }
 
@@ -317,7 +349,9 @@ export async function rebuildArchiveIndex(wikiRoot: string): Promise<void> {
       const archRelPath = e.to; // e.g. "wiki/_archive/billing/architecture.md"
       const linkTarget = archRelPath.replace(/^wiki\/_archive\//, "");
       const dateStr = isoDate(e.ts);
-      lines.push(`- [${linkTarget}](${linkTarget}) — archived ${dateStr}, ${e.reason}`);
+      lines.push(
+        `- [${linkTarget}](${linkTarget}) — archived ${dateStr}, ${e.reason}`,
+      );
     }
     lines.push("");
   }
@@ -356,7 +390,10 @@ async function resolveArchivePath(
 
   // If the raw input looked like a direct wiki/_archive/ path but normalization
   // resolved ".." segments that escape the archive root, it is a traversal attempt.
-  if (candidateRelRaw.startsWith("wiki/_archive/") && !candidateRelPosix.startsWith("wiki/_archive/")) {
+  if (
+    candidateRelRaw.startsWith("wiki/_archive/") &&
+    !candidateRelPosix.startsWith("wiki/_archive/")
+  ) {
     throw new Error(
       `path traversal detected: "${pageOrSlug}" resolves outside wiki/_archive/`,
     );
@@ -364,7 +401,9 @@ async function resolveArchivePath(
 
   if (candidateRelPosix.startsWith("wiki/_archive/")) {
     const absPath = path.resolve(wikiRoot, candidateRelPosix);
-    if (!checkPathContainment(absPath, path.join(wikiRoot, "wiki", "_archive"))) {
+    if (
+      !checkPathContainment(absPath, path.join(wikiRoot, "wiki", "_archive"))
+    ) {
       throw new Error(
         `path traversal detected: "${pageOrSlug}" resolves outside wiki/_archive/`,
       );
@@ -376,7 +415,9 @@ async function resolveArchivePath(
 
   // Substring slug match: collect all *.md under wiki/_archive/
   if (!fs.existsSync(archiveRoot)) {
-    throw new Error(`no archived page matching "${pageOrSlug}" — archive directory does not exist`);
+    throw new Error(
+      `no archived page matching "${pageOrSlug}" — archive directory does not exist`,
+    );
   }
 
   const matches: ResolvedArchivePath[] = [];
@@ -385,7 +426,11 @@ async function resolveArchivePath(
       const abs = path.join(dir, entry.name);
       if (entry.isDirectory()) {
         walk(abs);
-      } else if (entry.isFile() && entry.name.endsWith(".md") && entry.name !== "index.md") {
+      } else if (
+        entry.isFile() &&
+        entry.name.endsWith(".md") &&
+        entry.name !== "index.md"
+      ) {
         const relPath = path.relative(wikiRoot, abs).replace(/\\/g, "/");
         if (relPath.includes(pageOrSlug)) {
           matches.push({ absPath: abs, relPath });
@@ -407,7 +452,12 @@ async function resolveArchivePath(
 
 // ── stripArchiveFrontmatter ───────────────────────────────────────────────────
 
-const ARCHIVE_FM_KEYS = new Set(["status", "archived_at", "archive_reason", "archived_from"]);
+const ARCHIVE_FM_KEYS = new Set([
+  "status",
+  "archived_at",
+  "archive_reason",
+  "archived_from",
+]);
 
 /**
  * Read the file at absPath, remove the four deprecation frontmatter fields,
@@ -425,9 +475,7 @@ async function stripArchiveFrontmatter(absPath: string): Promise<void> {
     }
   }
   const newContent =
-    Object.keys(fm).length === 0
-      ? body
-      : `---\n${yaml.dump(fm)}---\n${body}`;
+    Object.keys(fm).length === 0 ? body : `---\n${yaml.dump(fm)}---\n${body}`;
   await fs.promises.writeFile(absPath, newContent, "utf-8");
 }
 
@@ -451,7 +499,9 @@ export interface RewriteUnarchiveLinksOptions {
  * Fenced code blocks (triple backtick) are "code" segments; everything else is
  * "non-code".  Returns an array of { text, isCode } records.
  */
-function splitOnFencedBlocks(body: string): Array<{ text: string; isCode: boolean }> {
+function splitOnFencedBlocks(
+  body: string,
+): Array<{ text: string; isCode: boolean }> {
   const segments: Array<{ text: string; isCode: boolean }> = [];
   const fenceRe = /^```/m;
   let remaining = body;
@@ -484,7 +534,9 @@ function splitOnFencedBlocks(body: string): Array<{ text: string; isCode: boolea
  *
  * Returns the total number of link substitutions made.
  */
-export async function rewriteInboundLinks(opts: RewriteArchiveLinksOptions): Promise<number> {
+export async function rewriteInboundLinks(
+  opts: RewriteArchiveLinksOptions,
+): Promise<number> {
   if (!(REWRITE_MODES as readonly string[]).includes(opts.mode)) {
     throw new Error(
       `invalid mode '${opts.mode}'; expected one of: ${REWRITE_MODES.join(", ")}`,
@@ -517,7 +569,8 @@ export async function rewriteInboundLinks(opts: RewriteArchiveLinksOptions): Pro
       const out: string[] = [];
 
       while ((m = re.exec(text)) !== null) {
-        const [whole, label, rawTarget] = m as RegExpExecArray & [string, string, string];
+        const [whole, label, rawTarget] = m as RegExpExecArray &
+          [string, string, string];
 
         // Skip already-rewritten links
         if (label.endsWith(" (archived)") && rawTarget.includes("_archive/")) {
@@ -528,7 +581,8 @@ export async function rewriteInboundLinks(opts: RewriteArchiveLinksOptions): Pro
 
         // Split off fragment/query so resolution works on the bare path
         const fragIdx = rawTarget.search(/[#?]/);
-        const pathPart = fragIdx === -1 ? rawTarget : rawTarget.slice(0, fragIdx);
+        const pathPart =
+          fragIdx === -1 ? rawTarget : rawTarget.slice(0, fragIdx);
         const suffix = fragIdx === -1 ? "" : rawTarget.slice(fragIdx);
 
         // Resolve target to wiki-relative path
@@ -588,7 +642,7 @@ export async function rewriteInboundLinksForUnarchive(
 
   // The archived path and the restored (live) path, both wiki-relative.
   const archiveRelPath = event.from; // "wiki/_archive/billing/architecture.md"
-  const liveRelPath = event.to;      // "wiki/billing/architecture.md"
+  const liveRelPath = event.to; // "wiki/billing/architecture.md"
 
   const livePages = walkLivePages(wikiRoot);
   let totalReverted = 0;
@@ -609,11 +663,15 @@ export async function rewriteInboundLinksForUnarchive(
       const out: string[] = [];
 
       while ((m = re.exec(text)) !== null) {
-        const [whole, label, rawTarget] = m as RegExpExecArray & [string, string, string];
+        const [whole, label, rawTarget] = m as RegExpExecArray &
+          [string, string, string];
 
         // Only process links that look like rewritten archive links:
         // label must end with " (archived)" AND path must be under _archive/.
-        if (!label.endsWith(" (archived)") || !rawTarget.includes("_archive/")) {
+        if (
+          !label.endsWith(" (archived)") ||
+          !rawTarget.includes("_archive/")
+        ) {
           out.push(text.slice(lastIndex, m.index + whole.length));
           lastIndex = m.index + whole.length;
           continue;
@@ -621,7 +679,8 @@ export async function rewriteInboundLinksForUnarchive(
 
         // Split off fragment/query so resolution works on the bare path
         const fragIdx = rawTarget.search(/[#?]/);
-        const pathPart = fragIdx === -1 ? rawTarget : rawTarget.slice(0, fragIdx);
+        const pathPart =
+          fragIdx === -1 ? rawTarget : rawTarget.slice(0, fragIdx);
         const suffix = fragIdx === -1 ? "" : rawTarget.slice(fragIdx);
 
         // Resolve to wiki-relative to check it matches the archive path
@@ -665,15 +724,17 @@ export async function rewriteInboundLinksForUnarchive(
 
 // ── unarchive ─────────────────────────────────────────────────────────────────
 
-export async function unarchive(opts: UnarchiveOptions): Promise<UnarchiveResult> {
+export async function unarchive(
+  opts: UnarchiveOptions,
+): Promise<UnarchiveResult> {
   const resolved = await resolveArchivePath(opts.wikiRoot, opts.pageOrSlug);
 
   const raw = await fs.promises.readFile(resolved.absPath, "utf-8");
   const { frontmatter } = parseFrontmatter(raw);
   const archivedFrom =
-    opts.target ?? (frontmatter as Record<string, unknown> | null)?.[
-      "archived_from"
-    ] as string | undefined;
+    opts.target ??
+    ((frontmatter as Record<string, unknown> | null)?.["archived_from"] as
+      string | undefined);
 
   if (!archivedFrom) {
     throw new Error(
@@ -723,10 +784,14 @@ export async function unarchive(opts: UnarchiveOptions): Promise<UnarchiveResult
 
   // "drop" was forward-only (drop links to a page being archived); on unarchive
   // there are no archive-style links to drop, so treat it as "leave".
-  const effectiveMode = opts.inboundLinks === "drop" ? "leave" : opts.inboundLinks;
+  const effectiveMode =
+    opts.inboundLinks === "drop" ? "leave" : opts.inboundLinks;
   const linksReverted =
     effectiveMode === "rewrite"
-      ? await rewriteInboundLinksForUnarchive({ wikiRoot: opts.wikiRoot, event })
+      ? await rewriteInboundLinksForUnarchive({
+          wikiRoot: opts.wikiRoot,
+          event,
+        })
       : 0;
   return { from: event.from, to: event.to, linksReverted };
 }
@@ -740,7 +805,11 @@ export async function sweep(opts: SweepOptions): Promise<SweepResult> {
     );
   }
   const partialThreshold = opts.partialThreshold ?? 1.0;
-  const resolvedOpts: SweepOptions = { inboundLinks: "rewrite", ...opts, partialThreshold };
+  const resolvedOpts: SweepOptions = {
+    inboundLinks: "rewrite",
+    ...opts,
+    partialThreshold,
+  };
 
   const livePages = walkLivePages(opts.wikiRoot);
   const atlasPages = filterAtlasPages(livePages);
@@ -779,7 +848,8 @@ export async function sweep(opts: SweepOptions): Promise<SweepResult> {
       const decision = decideAutonomy(opts.autonomy, "orphan");
       if (decision === "auto") {
         try {
-          if (!opts.dryRun) await applyArchive(page, existence, resolvedOpts, ts);
+          if (!opts.dryRun)
+            await applyArchive(page, existence, resolvedOpts, ts);
           const event = buildEvent(page, existence, resolvedOpts, ts);
           archived.push(event);
         } catch (e) {
@@ -802,7 +872,8 @@ export async function sweep(opts: SweepOptions): Promise<SweepResult> {
       const decision = decideAutonomy(opts.autonomy, "orphan");
       if (decision === "auto") {
         try {
-          if (!opts.dryRun) await applyArchive(page, existence, resolvedOpts, ts);
+          if (!opts.dryRun)
+            await applyArchive(page, existence, resolvedOpts, ts);
           const event = buildEvent(page, existence, resolvedOpts, ts);
           archived.push(event);
         } catch (e) {
@@ -906,11 +977,16 @@ export async function main(): Promise<number> {
     const repoRoot = parsed.values["repoRoot"];
     const runId = parsed.values["runId"];
     if (
-      typeof wikiRoot !== "string" || wikiRoot.length === 0 ||
-      typeof repoRoot !== "string" || repoRoot.length === 0 ||
-      typeof runId !== "string" || runId.length === 0
+      typeof wikiRoot !== "string" ||
+      wikiRoot.length === 0 ||
+      typeof repoRoot !== "string" ||
+      repoRoot.length === 0 ||
+      typeof runId !== "string" ||
+      runId.length === 0
     ) {
-      process.stderr.write("--wiki-root, --repo-root, and --run-id are required\n");
+      process.stderr.write(
+        "--wiki-root, --repo-root, and --run-id are required\n",
+      );
       return 2;
     }
     const autonomyRaw = parsed.values["autonomy"] ?? "autonomous";
@@ -943,7 +1019,9 @@ export async function main(): Promise<number> {
     const configPath = path.join(wikiRoot, "wiki.config.yaml");
     try {
       const cfg = parseConfig(configPath);
-      const archiveCfg = (cfg["ecosystem"] as Record<string, unknown> | undefined)?.["archive"] as ArchiveConfig | undefined;
+      const archiveCfg = (
+        cfg["ecosystem"] as Record<string, unknown> | undefined
+      )?.["archive"] as ArchiveConfig | undefined;
       if (archiveCfg?.inbound_links) {
         configInboundLinks = archiveCfg.inbound_links;
       }
@@ -965,7 +1043,15 @@ export async function main(): Promise<number> {
       inboundLinks = configInboundLinks;
     }
 
-    const result = await sweep({ wikiRoot, repoRoot, runId, autonomy, partialThreshold, dryRun, inboundLinks });
+    const result = await sweep({
+      wikiRoot,
+      repoRoot,
+      runId,
+      autonomy,
+      partialThreshold,
+      dryRun,
+      inboundLinks,
+    });
     process.stdout.write(JSON.stringify(result) + "\n");
     return 0;
   }
@@ -981,14 +1067,17 @@ export async function main(): Promise<number> {
     const wikiRoot = parsed.values["wikiRoot"];
     const pageOrSlug = parsed.values["pageOrSlug"];
     if (
-      typeof wikiRoot !== "string" || wikiRoot.length === 0 ||
-      typeof pageOrSlug !== "string" || pageOrSlug.length === 0
+      typeof wikiRoot !== "string" ||
+      wikiRoot.length === 0 ||
+      typeof pageOrSlug !== "string" ||
+      pageOrSlug.length === 0
     ) {
       process.stderr.write("--wiki-root and --page-or-slug are required\n");
       return 2;
     }
     const target =
-      typeof parsed.values["target"] === "string" && parsed.values["target"].length > 0
+      typeof parsed.values["target"] === "string" &&
+      parsed.values["target"].length > 0
         ? parsed.values["target"]
         : undefined;
     const inboundLinksRaw = parsed.values["inboundLinks"] ?? "rewrite";
@@ -1003,7 +1092,12 @@ export async function main(): Promise<number> {
     }
     const inboundLinks = inboundLinksRaw as RewriteMode;
     try {
-      const result = await unarchive({ wikiRoot, pageOrSlug, target, inboundLinks });
+      const result = await unarchive({
+        wikiRoot,
+        pageOrSlug,
+        target,
+        inboundLinks,
+      });
       process.stdout.write(JSON.stringify(result) + "\n");
       return 0;
     } catch (e) {
@@ -1042,13 +1136,18 @@ export async function main(): Promise<number> {
     const eventsFile = parsed.values["eventsFile"];
     const modeRaw = parsed.values["mode"] ?? "rewrite";
     if (
-      typeof wikiRoot !== "string" || wikiRoot.length === 0 ||
-      typeof eventsFile !== "string" || eventsFile.length === 0
+      typeof wikiRoot !== "string" ||
+      wikiRoot.length === 0 ||
+      typeof eventsFile !== "string" ||
+      eventsFile.length === 0
     ) {
       process.stderr.write("--wiki-root and --events-file are required\n");
       return 2;
     }
-    if (typeof modeRaw !== "string" || !(REWRITE_MODES as readonly string[]).includes(modeRaw)) {
+    if (
+      typeof modeRaw !== "string" ||
+      !(REWRITE_MODES as readonly string[]).includes(modeRaw)
+    ) {
       process.stderr.write(
         `error: invalid --mode value '${modeRaw}'; expected one of: ${REWRITE_MODES.join(", ")}\n`,
       );
@@ -1074,8 +1173,10 @@ export async function main(): Promise<number> {
     const wikiRoot = parsed.values["wikiRoot"];
     const eventFile = parsed.values["eventFile"];
     if (
-      typeof wikiRoot !== "string" || wikiRoot.length === 0 ||
-      typeof eventFile !== "string" || eventFile.length === 0
+      typeof wikiRoot !== "string" ||
+      wikiRoot.length === 0 ||
+      typeof eventFile !== "string" ||
+      eventFile.length === 0
     ) {
       process.stderr.write("--wiki-root and --event-file are required\n");
       return 2;
@@ -1095,8 +1196,10 @@ export async function main(): Promise<number> {
 
 const thisFile = fileURLToPath(import.meta.url);
 if (process.argv[1] && path.resolve(process.argv[1]) === thisFile) {
-  main().then(process.exit).catch((e) => {
-    process.stderr.write(`${(e as Error).message}\n`);
-    process.exit(1);
-  });
+  main()
+    .then(process.exit)
+    .catch((e) => {
+      process.stderr.write(`${(e as Error).message}\n`);
+      process.exit(1);
+    });
 }

--- a/skills/doc-wiki/scripts/atlas_gitlog.js
+++ b/skills/doc-wiki/scripts/atlas_gitlog.js
@@ -52,16 +52,17 @@ export function getLastAtlasTimestamp(wikiRoot) {
     const eventsPath = path.join(wikiRoot, "log", "events.jsonl");
     if (!fs.existsSync(eventsPath))
         return null;
-    let lines;
+    let raw;
     try {
-        lines = fs.readFileSync(eventsPath, "utf-8").split("\n");
+        raw = fs.readFileSync(eventsPath, "utf-8");
     }
     catch {
         return null;
     }
-    // Walk backwards — most recent atlas event wins.
-    for (let i = lines.length - 1; i >= 0; i--) {
-        const line = lines[i];
+    // Performance optimization: Iterating backwards using lastIndexOf avoids materializing a massive array
+    // via .split('\n'). This is significantly faster and uses far less memory.
+    for (let pos = raw.length, nextPos = pos === 0 ? -1 : raw.lastIndexOf("\n", pos - 1); pos > 0; pos = nextPos, nextPos = pos === 0 ? -1 : raw.lastIndexOf("\n", pos - 1)) {
+        const line = nextPos === -1 ? raw.substring(0, pos) : raw.substring(nextPos + 1, pos);
         if (!line)
             continue;
         // Fast-path: skip JSON parse overhead if this line cannot be an atlas event
@@ -229,7 +230,11 @@ export function classifyChanges(changedFiles, pageIndex, topics) {
     for (const [page, sources] of [...staleByPage.entries()].sort()) {
         stale_pages.push({ page, sources: [...sources].sort() });
     }
-    return { stale_pages, uncovered_files: uncovered, unrelated_files: unrelated };
+    return {
+        stale_pages,
+        uncovered_files: uncovered,
+        unrelated_files: unrelated,
+    };
 }
 // ── CLI ────────────────────────────────────────────────────────────
 const FLAG_SPEC = {
@@ -277,11 +282,13 @@ export function main(argv = process.argv.slice(2)) {
         process.stderr.write("--wiki-root is required\n");
         return 2;
     }
-    const repoRoot = typeof parsed.values["repoRoot"] === "string" && parsed.values["repoRoot"].length > 0
+    const repoRoot = typeof parsed.values["repoRoot"] === "string" &&
+        parsed.values["repoRoot"].length > 0
         ? parsed.values["repoRoot"]
         : process.cwd();
     let since = null;
-    if (typeof parsed.values["since"] === "string" && parsed.values["since"].length > 0) {
+    if (typeof parsed.values["since"] === "string" &&
+        parsed.values["since"].length > 0) {
         since = parsed.values["since"];
     }
     else {

--- a/skills/doc-wiki/scripts/atlas_gitlog.ts
+++ b/skills/doc-wiki/scripts/atlas_gitlog.ts
@@ -79,15 +79,24 @@ export interface ClassifyResult {
 export function getLastAtlasTimestamp(wikiRoot: string): string | null {
   const eventsPath = path.join(wikiRoot, "log", "events.jsonl");
   if (!fs.existsSync(eventsPath)) return null;
-  let lines: string[];
+  let raw: string;
   try {
-    lines = fs.readFileSync(eventsPath, "utf-8").split("\n");
+    raw = fs.readFileSync(eventsPath, "utf-8");
   } catch {
     return null;
   }
-  // Walk backwards — most recent atlas event wins.
-  for (let i = lines.length - 1; i >= 0; i--) {
-    const line = lines[i];
+
+  // Performance optimization: Iterating backwards using lastIndexOf avoids materializing a massive array
+  // via .split('\n'). This is significantly faster and uses far less memory.
+  for (
+    let pos = raw.length,
+      nextPos = pos === 0 ? -1 : raw.lastIndexOf("\n", pos - 1);
+    pos > 0;
+    pos = nextPos, nextPos = pos === 0 ? -1 : raw.lastIndexOf("\n", pos - 1)
+  ) {
+    const line =
+      nextPos === -1 ? raw.substring(0, pos) : raw.substring(nextPos + 1, pos);
+
     if (!line) continue;
 
     // Fast-path: skip JSON parse overhead if this line cannot be an atlas event
@@ -99,6 +108,7 @@ export function getLastAtlasTimestamp(wikiRoot: string): string | null {
     } catch {
       continue;
     }
+
     if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
       const rec = parsed as Record<string, unknown>;
       if (rec["op"] === "atlas" && typeof rec["timestamp"] === "string") {
@@ -231,7 +241,10 @@ function _matchPage(
  * `app/<topic>/`, `services/<topic>/`, or just `<topic>/...` at the repo root)
  * otherwise `null`.
  */
-function _matchTopic(filePath: string, topics: readonly string[]): string | null {
+function _matchTopic(
+  filePath: string,
+  topics: readonly string[],
+): string | null {
   const parts = filePath.split("/");
   for (const topic of topics) {
     if (parts.includes(topic)) return topic;
@@ -279,7 +292,11 @@ export function classifyChanges(
   for (const [page, sources] of [...staleByPage.entries()].sort()) {
     stale_pages.push({ page, sources: [...sources].sort() });
   }
-  return { stale_pages, uncovered_files: uncovered, unrelated_files: unrelated };
+  return {
+    stale_pages,
+    uncovered_files: uncovered,
+    unrelated_files: unrelated,
+  };
 }
 
 // ── CLI ────────────────────────────────────────────────────────────
@@ -333,12 +350,16 @@ export function main(argv: readonly string[] = process.argv.slice(2)): number {
     return 2;
   }
   const repoRoot =
-    typeof parsed.values["repoRoot"] === "string" && parsed.values["repoRoot"].length > 0
+    typeof parsed.values["repoRoot"] === "string" &&
+    parsed.values["repoRoot"].length > 0
       ? parsed.values["repoRoot"]
       : process.cwd();
 
   let since: string | null = null;
-  if (typeof parsed.values["since"] === "string" && parsed.values["since"].length > 0) {
+  if (
+    typeof parsed.values["since"] === "string" &&
+    parsed.values["since"].length > 0
+  ) {
     since = parsed.values["since"];
   } else {
     const last = getLastAtlasTimestamp(wikiRoot);

--- a/skills/doc-wiki/scripts/atlas_orchestrator.js
+++ b/skills/doc-wiki/scripts/atlas_orchestrator.js
@@ -124,15 +124,17 @@ export function getLastAtlasRunId(wikiRoot) {
     const eventsPath = path.join(wikiRoot, "log", "events.jsonl");
     if (!fs.existsSync(eventsPath))
         return null;
-    let lines;
+    let raw;
     try {
-        lines = fs.readFileSync(eventsPath, "utf-8").split("\n");
+        raw = fs.readFileSync(eventsPath, "utf-8");
     }
     catch {
         return null;
     }
-    for (let i = lines.length - 1; i >= 0; i--) {
-        const line = lines[i];
+    // Performance optimization: Iterating backwards using lastIndexOf avoids materializing a massive array
+    // via .split('\n'). This is significantly faster and uses far less memory.
+    for (let pos = raw.length, nextPos = pos === 0 ? -1 : raw.lastIndexOf("\n", pos - 1); pos > 0; pos = nextPos, nextPos = pos === 0 ? -1 : raw.lastIndexOf("\n", pos - 1)) {
+        const line = nextPos === -1 ? raw.substring(0, pos) : raw.substring(nextPos + 1, pos);
         if (!line)
             continue;
         // Fast-path: skip JSON parse overhead if this line cannot be an atlas event
@@ -189,7 +191,7 @@ export function detectState(wikiRoot, atlasPageThreshold = 3) {
     return "fresh";
 }
 // ── Per-ingest cost average ────────────────────────────────────────
-const DEFAULT_PER_INGEST_AVG_USD = 0.20;
+const DEFAULT_PER_INGEST_AVG_USD = 0.2;
 /**
  * Read recent `op: ingest` events from `log/events.jsonl` and return a
  * rolling-average `cost_usd` over up to `sampleSize` entries. Falls back
@@ -202,16 +204,16 @@ export function getRollingPerIngestAvg(wikiRoot, sampleSize = 50) {
     const eventsPath = path.join(wikiRoot, "log", "events.jsonl");
     if (!fs.existsSync(eventsPath))
         return DEFAULT_PER_INGEST_AVG_USD;
-    let lines;
+    let raw;
     try {
-        lines = fs.readFileSync(eventsPath, "utf-8").split("\n");
+        raw = fs.readFileSync(eventsPath, "utf-8");
     }
     catch {
         return DEFAULT_PER_INGEST_AVG_USD;
     }
     const samples = [];
-    for (let i = lines.length - 1; i >= 0 && samples.length < sampleSize; i--) {
-        const line = lines[i];
+    for (let pos = raw.length, nextPos = pos === 0 ? -1 : raw.lastIndexOf("\n", pos - 1); pos > 0 && samples.length < sampleSize; pos = nextPos, nextPos = pos === 0 ? -1 : raw.lastIndexOf("\n", pos - 1)) {
+        const line = nextPos === -1 ? raw.substring(0, pos) : raw.substring(nextPos + 1, pos);
         if (!line)
             continue;
         // Fast-path: skip JSON parse overhead if this line cannot be an ingest event
@@ -280,7 +282,7 @@ export const CROSS_SERVICE_GLOBAL_PAGES = [
     "database-traces",
     "shared-libraries",
 ];
-const GLOBAL_PAGE_AVG_USD = 0.20; // synthesis-only, smaller than ingest
+const GLOBAL_PAGE_AVG_USD = 0.2; // synthesis-only, smaller than ingest
 /**
  * Count of global synthesis pages that will be regenerated in Phase 7.
  * The `facets` argument is reserved for future per-facet-driven globals.
@@ -289,7 +291,8 @@ const GLOBAL_PAGE_AVG_USD = 0.20; // synthesis-only, smaller than ingest
  */
 export function expectedGlobalCount(facets, crossServiceEnabled = false) {
     void facets;
-    return STATIC_GLOBAL_PAGES.length + (crossServiceEnabled ? CROSS_SERVICE_GLOBAL_PAGES.length : 0);
+    return (STATIC_GLOBAL_PAGES.length +
+        (crossServiceEnabled ? CROSS_SERVICE_GLOBAL_PAGES.length : 0));
 }
 /**
  * Estimate the cost of running a plan on a wiki. For each `(topic, facet)`
@@ -309,11 +312,21 @@ export function estimateCost(wikiRoot, plan, perIngestAvgUsd, crossServiceEnable
         const cached = _isPlanEntryCached(wikiRoot, entry);
         if (cached) {
             cacheHits++;
-            breakdown.push({ topic: entry.topic, facet: entry.facet, expected: false, cached: true });
+            breakdown.push({
+                topic: entry.topic,
+                facet: entry.facet,
+                expected: false,
+                cached: true,
+            });
         }
         else {
             expectedIngests++;
-            breakdown.push({ topic: entry.topic, facet: entry.facet, expected: true, cached: false });
+            breakdown.push({
+                topic: entry.topic,
+                facet: entry.facet,
+                expected: true,
+                cached: false,
+            });
         }
     }
     const topicCost = expectedIngests * avg;
@@ -515,7 +528,9 @@ export function assembleGapReport(wikiRoot, plan, gitlog, inventory) {
     }
     const sourceFilesWithNoPage = [...missingSources].sort();
     // 4. Gitlog uncovered_files — pass through if provided.
-    const uncoveredFiles = gitlog?.uncovered_files ? [...gitlog.uncovered_files] : [];
+    const uncoveredFiles = gitlog?.uncovered_files
+        ? [...gitlog.uncovered_files]
+        : [];
     // 5. Connectors mentioned in atlas pages but missing from integrations.md.
     // Single wiki walk also collects every page's `sources:` frontmatter so
     // step 6 (manifest-driven) doesn't re-walk.
@@ -524,7 +539,9 @@ export function assembleGapReport(wikiRoot, plan, gitlog, inventory) {
     let integrationsBody = "";
     if (fs.existsSync(integrationsPath)) {
         try {
-            integrationsBody = fs.readFileSync(integrationsPath, "utf-8").toLowerCase();
+            integrationsBody = fs
+                .readFileSync(integrationsPath, "utf-8")
+                .toLowerCase();
         }
         catch {
             integrationsBody = "";

--- a/skills/doc-wiki/scripts/atlas_orchestrator.ts
+++ b/skills/doc-wiki/scripts/atlas_orchestrator.ts
@@ -170,14 +170,23 @@ export function countAllPages(wikiRoot: string): number {
 export function getLastAtlasRunId(wikiRoot: string): string | null {
   const eventsPath = path.join(wikiRoot, "log", "events.jsonl");
   if (!fs.existsSync(eventsPath)) return null;
-  let lines: string[];
+  let raw: string;
   try {
-    lines = fs.readFileSync(eventsPath, "utf-8").split("\n");
+    raw = fs.readFileSync(eventsPath, "utf-8");
   } catch {
     return null;
   }
-  for (let i = lines.length - 1; i >= 0; i--) {
-    const line = lines[i];
+  // Performance optimization: Iterating backwards using lastIndexOf avoids materializing a massive array
+  // via .split('\n'). This is significantly faster and uses far less memory.
+  for (
+    let pos = raw.length,
+      nextPos = pos === 0 ? -1 : raw.lastIndexOf("\n", pos - 1);
+    pos > 0;
+    pos = nextPos, nextPos = pos === 0 ? -1 : raw.lastIndexOf("\n", pos - 1)
+  ) {
+    const line =
+      nextPos === -1 ? raw.substring(0, pos) : raw.substring(nextPos + 1, pos);
+
     if (!line) continue;
 
     // Fast-path: skip JSON parse overhead if this line cannot be an atlas event
@@ -237,7 +246,7 @@ export function detectState(
 
 // ── Per-ingest cost average ────────────────────────────────────────
 
-const DEFAULT_PER_INGEST_AVG_USD = 0.20;
+const DEFAULT_PER_INGEST_AVG_USD = 0.2;
 
 /**
  * Read recent `op: ingest` events from `log/events.jsonl` and return a
@@ -253,15 +262,22 @@ export function getRollingPerIngestAvg(
 ): number {
   const eventsPath = path.join(wikiRoot, "log", "events.jsonl");
   if (!fs.existsSync(eventsPath)) return DEFAULT_PER_INGEST_AVG_USD;
-  let lines: string[];
+  let raw: string;
   try {
-    lines = fs.readFileSync(eventsPath, "utf-8").split("\n");
+    raw = fs.readFileSync(eventsPath, "utf-8");
   } catch {
     return DEFAULT_PER_INGEST_AVG_USD;
   }
   const samples: number[] = [];
-  for (let i = lines.length - 1; i >= 0 && samples.length < sampleSize; i--) {
-    const line = lines[i];
+  for (
+    let pos = raw.length,
+      nextPos = pos === 0 ? -1 : raw.lastIndexOf("\n", pos - 1);
+    pos > 0 && samples.length < sampleSize;
+    pos = nextPos, nextPos = pos === 0 ? -1 : raw.lastIndexOf("\n", pos - 1)
+  ) {
+    const line =
+      nextPos === -1 ? raw.substring(0, pos) : raw.substring(nextPos + 1, pos);
+
     if (!line) continue;
 
     // Fast-path: skip JSON parse overhead if this line cannot be an ingest event
@@ -273,9 +289,11 @@ export function getRollingPerIngestAvg(
     } catch {
       continue;
     }
-    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) continue;
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed))
+      continue;
     const rec = parsed as Record<string, unknown>;
     if (rec["op"] !== "ingest") continue;
+
     // Cost may live at top level or in details.total_cost_usd.
     let cost: number | null = null;
     if (typeof rec["cost_usd"] === "number") cost = rec["cost_usd"];
@@ -326,7 +344,7 @@ export const CROSS_SERVICE_GLOBAL_PAGES: readonly string[] = [
   "shared-libraries",
 ];
 
-const GLOBAL_PAGE_AVG_USD = 0.20; // synthesis-only, smaller than ingest
+const GLOBAL_PAGE_AVG_USD = 0.2; // synthesis-only, smaller than ingest
 
 /**
  * Count of global synthesis pages that will be regenerated in Phase 7.
@@ -334,9 +352,15 @@ const GLOBAL_PAGE_AVG_USD = 0.20; // synthesis-only, smaller than ingest
  * Pass `crossServiceEnabled = true` when `ecosystem.cross_service.enabled`
  * is set so that the 6 cross-service pages are included in the count.
  */
-export function expectedGlobalCount(facets?: readonly string[], crossServiceEnabled = false): number {
+export function expectedGlobalCount(
+  facets?: readonly string[],
+  crossServiceEnabled = false,
+): number {
   void facets;
-  return STATIC_GLOBAL_PAGES.length + (crossServiceEnabled ? CROSS_SERVICE_GLOBAL_PAGES.length : 0);
+  return (
+    STATIC_GLOBAL_PAGES.length +
+    (crossServiceEnabled ? CROSS_SERVICE_GLOBAL_PAGES.length : 0)
+  );
 }
 
 /**
@@ -363,15 +387,26 @@ export function estimateCost(
     const cached = _isPlanEntryCached(wikiRoot, entry);
     if (cached) {
       cacheHits++;
-      breakdown.push({ topic: entry.topic, facet: entry.facet, expected: false, cached: true });
+      breakdown.push({
+        topic: entry.topic,
+        facet: entry.facet,
+        expected: false,
+        cached: true,
+      });
     } else {
       expectedIngests++;
-      breakdown.push({ topic: entry.topic, facet: entry.facet, expected: true, cached: false });
+      breakdown.push({
+        topic: entry.topic,
+        facet: entry.facet,
+        expected: true,
+        cached: false,
+      });
     }
   }
 
   const topicCost = expectedIngests * avg;
-  const globalCost = expectedGlobalCount(plan.facets, crossServiceEnabled) * GLOBAL_PAGE_AVG_USD;
+  const globalCost =
+    expectedGlobalCount(plan.facets, crossServiceEnabled) * GLOBAL_PAGE_AVG_USD;
   return {
     expected_ingests: expectedIngests,
     cache_hits: cacheHits,
@@ -465,10 +500,7 @@ export function savePlanSnapshot(
  * old version with no `created_at`) are tolerated; the orchestrator can
  * decide whether to keep going.
  */
-export function loadPlanSnapshot(
-  wikiRoot: string,
-  runId: string,
-): Plan | null {
+export function loadPlanSnapshot(wikiRoot: string, runId: string): Plan | null {
   const target = _planSnapshotPath(wikiRoot, runId);
   if (!fs.existsSync(target)) return null;
   let raw: string;
@@ -483,7 +515,8 @@ export function loadPlanSnapshot(
   } catch {
     return null;
   }
-  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return null;
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed))
+    return null;
   const rec = parsed as Record<string, unknown>;
   if (
     !Array.isArray(rec["topics"]) ||
@@ -496,8 +529,9 @@ export function loadPlanSnapshot(
     topics: rec["topics"].filter((x): x is string => typeof x === "string"),
     facets: rec["facets"].filter((x): x is string => typeof x === "string"),
     entries: (rec["entries"] as unknown[])
-      .filter((e): e is Record<string, unknown> =>
-        Boolean(e) && typeof e === "object" && !Array.isArray(e),
+      .filter(
+        (e): e is Record<string, unknown> =>
+          Boolean(e) && typeof e === "object" && !Array.isArray(e),
       )
       .map((e) => ({
         topic: typeof e["topic"] === "string" ? e["topic"] : "",
@@ -507,8 +541,7 @@ export function loadPlanSnapshot(
           : [],
         output: typeof e["output"] === "string" ? e["output"] : "",
       })),
-    created_at:
-      typeof rec["created_at"] === "string" ? rec["created_at"] : "",
+    created_at: typeof rec["created_at"] === "string" ? rec["created_at"] : "",
   };
 }
 
@@ -641,7 +674,9 @@ export function assembleGapReport(
   const sourceFilesWithNoPage = [...missingSources].sort();
 
   // 4. Gitlog uncovered_files — pass through if provided.
-  const uncoveredFiles = gitlog?.uncovered_files ? [...gitlog.uncovered_files] : [];
+  const uncoveredFiles = gitlog?.uncovered_files
+    ? [...gitlog.uncovered_files]
+    : [];
 
   // 5. Connectors mentioned in atlas pages but missing from integrations.md.
   // Single wiki walk also collects every page's `sources:` frontmatter so
@@ -651,7 +686,9 @@ export function assembleGapReport(
   let integrationsBody = "";
   if (fs.existsSync(integrationsPath)) {
     try {
-      integrationsBody = fs.readFileSync(integrationsPath, "utf-8").toLowerCase();
+      integrationsBody = fs
+        .readFileSync(integrationsPath, "utf-8")
+        .toLowerCase();
     } catch {
       integrationsBody = "";
     }
@@ -698,7 +735,8 @@ export function assembleGapReport(
     walk(wikiContent);
   }
   for (const k of archMentions) {
-    if (!integrationsBody.includes(k)) externalServicesWithoutDocumentation.push(k);
+    if (!integrationsBody.includes(k))
+      externalServicesWithoutDocumentation.push(k);
   }
   externalServicesWithoutDocumentation.sort();
 
@@ -758,7 +796,10 @@ export function assembleGapReport(
 }
 
 /** Render a {@link GapReport} as a Markdown document for `gap-report.md`. */
-export function renderGapReportMarkdown(report: GapReport, runId: string): string {
+export function renderGapReportMarkdown(
+  report: GapReport,
+  runId: string,
+): string {
   const lines: string[] = [];
   lines.push(`# Atlas gap report — ${runId}`);
   lines.push("");
@@ -819,7 +860,8 @@ export function renderGapReportMarkdown(report: GapReport, runId: string): strin
     lines.push("_(none)_");
   } else {
     lines.push("");
-    for (const s of report.externalServicesWithoutDocumentation) lines.push(`- ${s}`);
+    for (const s of report.externalServicesWithoutDocumentation)
+      lines.push(`- ${s}`);
   }
   lines.push("");
 
@@ -952,7 +994,9 @@ export function main(argv: readonly string[] = process.argv.slice(2)): number {
     try {
       plan = JSON.parse(planRaw) as Plan;
     } catch (e) {
-      process.stderr.write(`--plan is not valid JSON: ${(e as Error).message}\n`);
+      process.stderr.write(
+        `--plan is not valid JSON: ${(e as Error).message}\n`,
+      );
       return 2;
     }
     const avgRaw = parsed.values["perIngestAvgUsd"];
@@ -1001,7 +1045,9 @@ export function main(argv: readonly string[] = process.argv.slice(2)): number {
     try {
       plan = JSON.parse(planRaw) as Plan;
     } catch (e) {
-      process.stderr.write(`--plan is not valid JSON: ${(e as Error).message}\n`);
+      process.stderr.write(
+        `--plan is not valid JSON: ${(e as Error).message}\n`,
+      );
       return 2;
     }
     savePlanSnapshot(wikiRoot, runId, plan);
@@ -1042,7 +1088,9 @@ export function main(argv: readonly string[] = process.argv.slice(2)): number {
     try {
       plan = JSON.parse(planRaw) as Plan;
     } catch (e) {
-      process.stderr.write(`--plan is not valid JSON: ${(e as Error).message}\n`);
+      process.stderr.write(
+        `--plan is not valid JSON: ${(e as Error).message}\n`,
+      );
       return 2;
     }
     let gitlog: GitlogClassification | undefined;
@@ -1051,7 +1099,9 @@ export function main(argv: readonly string[] = process.argv.slice(2)): number {
       try {
         gitlog = JSON.parse(gitlogRaw) as GitlogClassification;
       } catch (e) {
-        process.stderr.write(`--gitlog is not valid JSON: ${(e as Error).message}\n`);
+        process.stderr.write(
+          `--gitlog is not valid JSON: ${(e as Error).message}\n`,
+        );
         return 2;
       }
     }
@@ -1075,7 +1125,9 @@ export function main(argv: readonly string[] = process.argv.slice(2)): number {
       );
       fs.mkdirSync(path.dirname(target), { recursive: true });
       fs.writeFileSync(target, md);
-      process.stdout.write(JSON.stringify({ ...report, written: target }) + "\n");
+      process.stdout.write(
+        JSON.stringify({ ...report, written: target }) + "\n",
+      );
     } else {
       process.stdout.write(JSON.stringify(report) + "\n");
     }


### PR DESCRIPTION
### 💡 What
Replaced `fs.readFileSync(eventsPath, "utf-8").split("\n")` with manual string traversal using `indexOf` for forward iteration and `lastIndexOf` for backward iteration across `atlas_archive.ts`, `atlas_gitlog.ts`, and `atlas_orchestrator.ts`. Also added inline comments documenting the optimization.

### 🎯 Why
Parsing large append-only JSONL log files using `.split('\n')` creates a massive intermediate array in memory, causing severe memory spikes and heavy garbage collection overhead. Furthermore, when reading backwards for recent events (e.g., in `getRollingPerIngestAvg`), `.split('\n')` still incurs the O(N) cost of parsing the entire file before we can extract the O(k) recent lines. The manual traversal approach completely bypasses the array allocation and allows backward traversal to short-circuit effectively.

### 📊 Impact
* **Memory:** Drastically reduces memory consumption during log parsing by eliminating the massive array allocation.
* **Speed:** Faster execution due to reduced garbage collection overhead and short-circuited backward iteration in `getRollingPerIngestAvg` (O(k) instead of O(N)).

### 🔬 Measurement
Verify the memory footprint when parsing a >10MB `events.jsonl` file. The memory overhead should remain small instead of spiking proportionally to the file size.

---
*PR created automatically by Jules for task [17374331616363576447](https://jules.google.com/task/17374331616363576447) started by @rfv-code*